### PR TITLE
Use GCC 11 instead of clang for macosx build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       if: runner.os == 'macOS'
       env:
         PREFIX: ${{ env.AMD64_MACOSX_GCC }}
-        CC: gcc
+        CC: gcc-11
         MAKE: make
         RUN_TESTS: false
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       AMD64_LINUX_GCC: amd64-linux-gcc
       AMD64_LINUX_CLANG: amd64-linux-clang
       AMD64_WINDOWS_MINGW: amd64-windows-mingw
-      AMD64_MACOSX_CLANG: amd64-macosx-clang
+      AMD64_MACOSX_GCC: amd64-macosx-gcc
       AMD64_FREEBSD_GCC: amd64-freebsd-gcc
       ARTIFACT_DIR: .artifacts
       ARTIFACT_RETENTION_DAYS: 5
@@ -103,11 +103,11 @@ jobs:
         ./scripts/ci-build.sh
         ./scripts/ci-create-nuget-package.sh
 
-    - name: Build on macOS (${{ env.AMD64_MACOSX_CLANG }})
+    - name: Build on macOS (${{ env.AMD64_MACOSX_GCC }})
       if: runner.os == 'macOS'
       env:
-        PREFIX: ${{ env.AMD64_MACOSX_CLANG }}
-        CC: clang
+        PREFIX: ${{ env.AMD64_MACOSX_GCC }}
+        CC: gcc-11
         MAKE: make
         RUN_TESTS: false
       shell: bash
@@ -223,11 +223,11 @@ jobs:
         retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
         if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_CLANG }}.zip)
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip)
       if: runner.os == 'macOS'
       uses: actions/upload-artifact@v3
       env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_CLANG }}.zip
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
@@ -278,11 +278,11 @@ jobs:
         retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
         if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_CLANG }}.tar.gz)
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz)
       if: runner.os == 'macOS'
       uses: actions/upload-artifact@v3
       env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_CLANG }}.tar.gz
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       if: runner.os == 'macOS'
       env:
         PREFIX: ${{ env.AMD64_MACOSX_GCC }}
-        CC: gcc-11
+        CC: gcc
         MAKE: make
         RUN_TESTS: false
       shell: bash

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,15 +1,11 @@
-# Binaries
-
-Pre-built binaries for OSX, Windows, Linux and BSD are available at
-[Releases](https://github.com/liquidaty/zsv/releases).
-
 # Building and installing the library and/or CLI
 
 ## From source
 
 GCC is the recommended compiler, but clang is also supported.
 
-To build from source, you'll need a basic unix toolchain with `sh` and `make`/`gmake`:
+To build from source, you'll need a basic unix toolchain with `sh` and
+`make`/`gmake`:
 
 ```shell
 ./configure && sudo ./install.sh
@@ -48,5 +44,3 @@ zsv will soon be available from a number of package managers:
 - OSX: `brew install zsv`
 - Windows: `nuget install zsv`
 - Linux: `yum install zsv`
-
-

--- a/README.md
+++ b/README.md
@@ -103,10 +103,13 @@ sudo yum remove zsv
 For Windows (`*.nupkg`), install with `nuget.exe`:
 
 ```shell
-# Install via nuget custom feed
+# Install via nuget custom feed (requires absolutes paths)
 md nuget-feed
-nuget.exe add zsv .\zsv-amd64-windows-mingw.nupkg -source <path>/nuget-feed
+nuget.exe add zsv .\<path>\zsv-amd64-windows-mingw.nupkg -source <path>/nuget-feed
 nuget.exe install zsv -source <path>/nuget-feed
+
+# Uninstall
+nuget.exe delete zsv <version> -source <path>/nuget-feed
 ```
 
 For Windows (`*.nupkg`), install with `choco.exe`:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ that implements the expected
 * Fast (maybe the fastest ever, at least on all platforms we've benchmarked where
   256 SIMD operations are available). See
   [app/benchmark/README.md](app/benchmark/README.md)
-* Low memory usage (regardless of how big your data is) and size footprint for both lib (~20k) and CLI executable (< 1MB)
+* Low memory usage (regardless of how big your data is) and size footprint for
+  both lib (~20k) and CLI executable (< 1MB)
 * Easy to use as a library in a few lines of code
 * Includes `zsv` CLI with built-in commands:
   * `select`, `count`, `sql` query, `describe`, `flatten`, `serialize`, `2json`,
@@ -103,7 +104,7 @@ For Windows (`*.nupkg`), install with `nuget.exe`:
 # Install via nuget custom feed (requires absolutes paths)
 md nuget-feed
 nuget.exe add zsv .\<path>\zsv-amd64-windows-mingw.nupkg -source <path>/nuget-feed
-nuget.exe install zsv -source <path>/nuget-feed
+nuget.exe install zsv -version <version> -source <path>/nuget-feed
 
 # Uninstall
 nuget.exe delete zsv <version> -source <path>/nuget-feed
@@ -127,7 +128,7 @@ according to your Windows version and place it with `zsv` executable.
 
 See [BUILD.md](BUILD.md) for more details.
 
-## Why another CSV parser / utility?
+## Why another CSV parser/utility?
 
 Our objectives, which we were unable to find in a pre-existing project, are:
 
@@ -148,16 +149,16 @@ Our objectives, which we were unable to find in a pre-existing project, are:
 There are several excellent tools that achieve high performance. Among those we
 considered were xsv and tsv-utils. While they met our performance objective,
 both were designed primarily as a utility and not a library, and were not easy
-enough, for our needs, to customize and/or to support
-modular customizations that could be maintained (or licensed) independently of
-the related project (in addition to the fact that they were written in Rust and
-D, respectively, which happen to be languages with which we lacked deep
-experience, especially for web assembly targeting).
+enough, for our needs, to customize and/or to support modular customizations
+that could be maintained (or licensed) independently of the related project (in
+addition to the fact that they were written in Rust and D, respectively, which
+happen to be languages with which we lacked deep experience, especially for web
+assembly targeting).
 
-Others we considered were Miller (mlr), csvkit and Go (csv module),
-which did not meet our performance objective. We also considered various
-other libraries using SIMD for CSV parsing, but none that we tried met the
-"real-world CSV" objective.
+Others we considered were Miller (mlr), csvkit and Go (csv module), which did
+not meet our performance objective. We also considered various other libraries
+using SIMD for CSV parsing, but none that we tried met the "real-world CSV"
+objective.
 
 Hence zsv was created as a library and a versatile application, both optimized
 for speed and ease of development for extending and/or customizing to your needs

--- a/app/Makefile
+++ b/app/Makefile
@@ -265,6 +265,7 @@ ${BUILD_DIR}/objs/zsv_%.o: %.c
 	${CC} ${CFLAGS} -I${INCLUDE_DIR} -I${UTF8PROC_INCLUDE} -c $< -o $@
 
 ${UTF8PROC_OBJECT}: ${UTF8PROC_SRC}/utf8proc.c
+	@echo ">> Compiling ${UTF8PROC_OBJECT}"
 	@mkdir -p `dirname "$@"`
 	${CC} ${CFLAGS} -I${UTF8PROC_INCLUDE} -c $< -o $@
 
@@ -357,5 +358,6 @@ clean-lib:
 	${MAKE} -C ../src clean CONFIGFILE=${CONFIGFILEPATH} DEBUG=${DEBUG}
 
 external/utf8proc-2.6.1/utf8proc.c: external/utf8proc-2.6.1.tar.gz
+	@echo ">> Extracting utf8proc-2.6.1.tar.gz"
 	@cd external && tar xf ../$<
 	@touch $@

--- a/app/Makefile
+++ b/app/Makefile
@@ -264,7 +264,7 @@ ${BUILD_DIR}/objs/zsv_%.o: %.c
 	@mkdir -p `dirname "$@"`
 	${CC} ${CFLAGS} -I${INCLUDE_DIR} -I${UTF8PROC_INCLUDE} -c $< -o $@
 
-${UTF8PROC_OBJECT}: ${UTF8PROC_SRC}/utf8proc.h
+${UTF8PROC_OBJECT}: ${UTF8PROC_SRC}/utf8proc.c
 	@mkdir -p `dirname "$@"`
 	${CC} ${CFLAGS} -I${UTF8PROC_INCLUDE} -c $< -o $@
 
@@ -273,7 +273,7 @@ ${INIH_OBJECT}: ${INIH_SRC}/ini.c
 	${CC} ${CFLAGS} -I${INIH_INCLUDE} -DINI_HANDLER_LINENO=1 -DINI_CALL_HANDLER_ON_NEW_SECTION=1 -c $< -o $@
 
 ${CLI_APP_OBJECT} : cli_ini.c builtin/*.c
-${CLI_APP_OBJECT} ${CLI_OBJECTS}: ${CLI_OBJ_PFX}%.o: %.c ${UTF8PROC_SRC}/utf8proc.h # ${MORE_OBJECTS}
+${CLI_APP_OBJECT} ${CLI_OBJECTS}: ${CLI_OBJ_PFX}%.o: %.c ${UTF8PROC_SRC}/utf8proc.c # ${MORE_OBJECTS}
 	@mkdir -p `dirname "$@"`
 	${CC} ${CFLAGS} -DVERSION=\"${VERSION}\" -DZSV_CLI -DMAIN=main_$* ${CLI_INCLUDE} -Iexternal/sglib -I${INCLUDE_DIR} -c $< -o $@ ${MORE_SOURCE}
 
@@ -356,6 +356,6 @@ clean-obj:
 clean-lib:
 	${MAKE} -C ../src clean CONFIGFILE=${CONFIGFILEPATH} DEBUG=${DEBUG}
 
-external/utf8proc-2.6.1/utf8proc.h: external/utf8proc-2.6.1.tar.gz
+external/utf8proc-2.6.1/utf8proc.c: external/utf8proc-2.6.1.tar.gz
 	@cd external && tar xf ../$<
 	@touch $@

--- a/app/Makefile
+++ b/app/Makefile
@@ -265,7 +265,6 @@ ${BUILD_DIR}/objs/zsv_%.o: %.c
 	${CC} ${CFLAGS} -I${INCLUDE_DIR} -I${UTF8PROC_INCLUDE} -c $< -o $@
 
 ${UTF8PROC_OBJECT}: ${UTF8PROC_SRC}/utf8proc.c
-	@echo ">> Compiling ${UTF8PROC_OBJECT}"
 	@mkdir -p `dirname "$@"`
 	${CC} ${CFLAGS} -I${UTF8PROC_INCLUDE} -c $< -o $@
 
@@ -358,6 +357,5 @@ clean-lib:
 	${MAKE} -C ../src clean CONFIGFILE=${CONFIGFILEPATH} DEBUG=${DEBUG}
 
 external/utf8proc-2.6.1/utf8proc.c: external/utf8proc-2.6.1.tar.gz
-	@echo ">> Extracting utf8proc-2.6.1.tar.gz"
 	@cd external && tar xf ../$<
 	@touch $@

--- a/app/utils/os.c
+++ b/app/utils/os.c
@@ -50,12 +50,13 @@ void to_unicode(const void *path, wchar_t *wbuf, size_t wbuf_len) {
 
 #include <stdio.h>
 #include <wchar.h>
+
 int zsv_replace_file(const void *src, const void *dest) {
   wchar_t wdest[PATH_MAX], wsrc[PATH_MAX];
   to_unicode(dest, wdest, ARRAY_SIZE(wdest));
   to_unicode(src, wsrc, ARRAY_SIZE(wsrc));
 
-  if(ReplaceFileW(wdest, wsrc, NULL, REPLACEFILE_IGNORE_MERGE_ERRORS | REPLACEFILE_IGNORE_ACL_ERRORS, 0, 0)) // success
+  if(ReplaceFileW(wdest, wsrc, NULL, REPLACEFILE_IGNORE_MERGE_ERRORS, 0, 0)) // success
     return 0;
   else if(GetLastError() == 2) // file not found, could be target. use simple rename
     return _wrename(wsrc, wdest); // returns 0 on success

--- a/docs/csv_json_sqlite.md
+++ b/docs/csv_json_sqlite.md
@@ -1,40 +1,50 @@
-## CSV, JSON and SQLITE3
+# CSV, JSON and SQLITE3
 
 Summary:
-- Yes, CSV sucks. But it, and its xxx-delimited brethren, are still around a lot, and let's face it, delimited format does have certain advantages (such as being at least somewhat readable directly by human eyes), which is probably why they've been around so long
+
+- Yes, CSV sucks. But it, and its xxx-delimited brethren, are still around a
+  lot, and let's face it, delimited format does have certain advantages (such as
+  being at least somewhat readable directly by human eyes), which is probably
+  why they've been around so long
 - sqlite3 is the most widely deployed database engine in the world
-- JSON is useful as an intermediate format between CSV and sqlite3 because it is more API-friendly than CSV, is more git- and diff-friendly than the binary sqlite3 format, can be used to hold both metadata as well as data, and can be devised for performant stream-based consumption
-- the same could be said of other binary table formats (parquet etc), though that is out of scope for the discussion here
+- JSON is useful as an intermediate format between CSV and sqlite3 because it is
+  more API-friendly than CSV, is more git- and diff-friendly than the binary
+  sqlite3 format, can be used to hold both metadata as well as data, and can be
+  devised for performant stream-based consumption
+- the same could be said of other binary table formats (parquet etc), though
+  that is out of scope for the discussion here
 
-### Background
+## Background
 
-Each of these formats, commonly used for tabular data, has different strengths and weaknesses:
+Each of these formats, commonly used for tabular data, has different strengths
+and weaknesses:
 
-- CSV is easy to use in any text editor or common apps such as Excel
-  or Google Sheets, but lacks schema, data types or indexing
+- CSV is easy to use in any text editor or common apps such as Excel or Google
+  Sheets, but lacks schema, data types or indexing
 
-- JSON is easy to use for API inter-communication and REST APIs,
-  editable with any text editor, supports primitive data types;
-  but, lacks native indexing or schema
-  (though JSON Schema can be overlaid for validation and documentation) and
-  is difficult for non-technical users to use or analyze
+- JSON is easy to use for API inter-communication and REST APIs, editable with
+  any text editor, supports primitive data types; but, lacks native indexing or
+  schema (though JSON Schema can be overlaid for validation and documentation)
+  and is difficult for non-technical users to use or analyze
 
-- sqlite3 supports schema, indexes and other SQL operations, but
-  requires sqlite3 and knowledge of SQL to use, and file format is binary which is not human-readable
-  and is difficult to version-track either metadata or data
+- sqlite3 supports schema, indexes and other SQL operations, but requires
+  sqlite3 and knowledge of SQL to use, and file format is binary which is not
+  human-readable and is difficult to version-track either metadata or data
 
-### Benefits of converting between formats
+## Benefits of converting between formats
 
 - easily stream CSV or DB data through APIs and back to CSV / DB
 
-- use standard version control on sqlite3 files, covering metadata and data,
-  by converting to JSON and tracking that instead of the binary DB file
+- use standard version control on sqlite3 files, covering metadata and data, by
+  converting to JSON and tracking that instead of the binary DB file
 
-- Using DB over CSV offers specific benefits not available in other formats such as function-based indexes and much more
+- Using DB over CSV offers specific benefits not available in other formats such
+  as function-based indexes and much more
 
 ## Using `zsv` to work with data in your format of choice
 
-`zsv` provides high-performance conversion to and from various formats including:
+`zsv` provides high-performance conversion to and from various formats
+including:
 
 - CSV (or TSV or pipe- or other- delimited)
 - JSON (as arrays, objects, or [database-friendly table schema](db.schema.json))
@@ -42,11 +52,11 @@ Each of these formats, commonly used for tabular data, has different strengths a
 
 To install `zsv`, see https://github.com/liquidaty/zsv/blob/main/BUILD.md
 
-`zsv`'s `2json`, `2db` and `jq` commands provide conversion between delimited, json and sqlite3
-formats. A streamlined JSON schema is used to retain metadata when converting between JSON
-and sqlite3 formats, using the [zsv](https://github.com/liquidaty/zsv),
-[jq](https://github.com/stedolan/jq) and [sqlite3](https://www.sqlite.org) libraries.
-
+`zsv`'s `2json`, `2db` and `jq` commands provide conversion between delimited,
+json and sqlite3 formats. A streamlined JSON schema is used to retain metadata
+when converting between JSON and sqlite3 formats, using the
+[zsv](https://github.com/liquidaty/zsv), [jq](https://github.com/stedolan/jq)
+and [sqlite3](https://www.sqlite.org) libraries.
 
 ### CSV to JSON
 
@@ -54,7 +64,8 @@ and sqlite3 formats, using the [zsv](https://github.com/liquidaty/zsv),
 
 The most common CSV to JSON conversion approaches, referred to herein as the
 "plain-array" and "plain-objects" approaches, have limited utility:
-```
+
+```shell
 zsv 2json data.csv --no-header < data.csv # output as arrays
 zsv 2json data.csv --object < data.csv    # output as objects
 ```
@@ -62,23 +73,23 @@ zsv 2json data.csv --object < data.csv    # output as objects
 The problem with the first format is that it treats the header row as a data row
 and lacks support for additional metadata such as data type.
 
-The second format has the same weakness and furthermore
-takes up significantly more space, though it has the advantage
-of each row being independently human-readable without
-without having to look at the header information to know which data corresponds
-to which column. That said, this advantage has limited benefit
-only useful, in the best case, for debugging purposes. To quantify the difference in
-data volume, using the first 10k rows of worldcitiespop.csv, the `plain-object` format
-is 78% larger or 117% larger for pretty-printed or compact JSON, respectively.
+The second format has the same weakness and furthermore takes up significantly
+more space, though it has the advantage of each row being independently
+human-readable without without having to look at the header information to know
+which data corresponds to which column. That said, this advantage has limited
+benefit only useful, in the best case, for debugging purposes. To quantify the
+difference in data volume, using the first 10k rows of worldcitiespop.csv, the
+`plain-object` format is 78% larger or 117% larger for pretty-printed or compact
+JSON, respectively.
 
 #### Adding column metadata
 
-A better approach is to replace each header name with an object,
-to provide a means to store metadata separately from data.
-One approach is to simply allow the first row to use an object
-in lieu of a scalar galue, in what we refer to herein as a [row-based schema](csv.schema.json):
+A better approach is to replace each header name with an object, to provide a
+means to store metadata separately from data. One approach is to simply allow
+the first row to use an object in lieu of a scalar galue, in what we refer to
+herein as a [row-based schema](csv.schema.json):
 
-```
+```shell
 # output as an array of rows, where the first row is a list of column header objects
 zsv 2json < data.csv > data.json
 
@@ -89,30 +100,30 @@ zsv jq '[.[0]|[.[]|.name]] + .[1:]|.[]' --csv < data.json
 zsv jq '.[]|[.[]|(if (.|type) == "object" then .name else . end)]' --csv < data.json
 ```
 
-Note that the above `zsv jq` filter is essentially the same as what you would use with
-`jq` in conjunction with `@csv` and `-r`, but the csv output from `zsv jq ... --csv`
-is a bit more compact due to the omission of unnecessary surrounding quotes
+Note that the above `zsv jq` filter is essentially the same as what you would
+use with `jq` in conjunction with `@csv` and `-r`, but the csv output from `zsv
+jq ... --csv` is a bit more compact due to the omission of unnecessary
+surrounding quotes
 
-This approach has the same overall structure as the `plain-array` method,
-but extends each cell's schema to allow for an object that can hold metadata.
-This provides significantly more flexibility, but still has a
-significant drawback: it does not allow for table-level metadata.
+This approach has the same overall structure as the `plain-array` method, but
+extends each cell's schema to allow for an object that can hold metadata. This
+provides significantly more flexibility, but still has a significant drawback:
+it does not allow for table-level metadata.
 
 #### Adding table metadata
 
-To support both table and column metadata, `zsv` uses a schema comprised of
-a tuple with two elements: metadata and data.
+To support both table and column metadata, `zsv` uses a schema comprised of a
+tuple with two elements: metadata and data.
 
 This [database-friendly approach](db.schema.json) supports table metadata such
 as table name and indexes.
 
-Future enhancements could support table-level
-validations/constraints and other features, and this approach could
-be merged with the aforementioned [row-based schema](csv.schema.json)
-to support row-level or cell-level metadata,
-to represent spreadsheet data such as cell-level formatting.
+Future enhancements could support table-level validations/constraints and other
+features, and this approach could be merged with the aforementioned [row-based
+schema](csv.schema.json) to support row-level or cell-level metadata, to
+represent spreadsheet data such as cell-level formatting.
 
-```
+```shell
 # Convert CSV to JSON
 # Additionally, specify a non-unique index on Population and a unique index on the combination of City, Country and Region
 zsv 2json --database --index "ix1 on state" --unique-index "ix2 on City, Country, Region" < data.csv > database.json
@@ -125,100 +136,106 @@ zsv jq '[.[0]|.columns|[.[]|.name]] + .[1]|.[]' --csv < database.json
 
 ## or
 zsv jq '.[]|if (.|type) == "object" then (.columns|[.[]|.name]) else . end|.[]' --csv < database.json
-
 ```
 
 ## Questions
 
 ### Why the bundled / "swiss army knife" approach?
 
-An alternative approach, which is more consistent with the unix philosophy whereby
-"each utility does one and only one thing", would be leave anything related to
-sqlite3 and JSON to `sqlite3`, `jq`, respectively, or similar standalone utilities.
+An alternative approach, which is more consistent with the unix philosophy
+whereby "each utility does one and only one thing", would be leave anything
+related to sqlite3 and JSON to `sqlite3`, `jq`, respectively, or similar
+standalone utilities.
 
 However, the unix philosophy also assumed that a full toolset would always be
 available, whereas we cannot assume that anyone already has `jq` or `sqlite3`
-installed. It is true that we could have distributed them with this package
-but then we introduce potential conflict where they were already installed.
+installed. It is true that we could have distributed them with this package but
+then we introduce potential conflict where they were already installed.
 Furthermore, there are other benefits to bundling:
 
-* tasks that involve multiple utilities can be further simplified and modularized
-  For example, CSV->DB conversion can be further broken down into CSV->JSON->DB,
-  and the middle JSON form can be independently manipulated. This additional
-  modularization / granularity provides greater optionality with regard to
-  flexibility and control of how data is processed
+- tasks that involve multiple utilities can be further simplified and
+  modularized For example, CSV->DB conversion can be further broken down into
+  CSV->JSON->DB, and the middle JSON form can be independently manipulated. This
+  additional modularization / granularity provides greater optionality with
+  regard to flexibility and control of how data is processed
 
-* deployment is simplified (there is only one executable), and the total
-  executable code size is compact even when fully statically compiled.
-  this is convenient in environments where dynamically-linked code can be
-  challenging, such as WebAssembly
+- deployment is simplified (there is only one executable), and the total
+  executable code size is compact even when fully statically compiled. this is
+  convenient in environments where dynamically-linked code can be challenging,
+  such as WebAssembly
 
-The main drawback of the bundled approach is that if a single command needs to be
-updated, the entire executable must be updated. In most cases, our experience
+The main drawback of the bundled approach is that if a single command needs to
+be updated, the entire executable must be updated. In most cases, our experience
 is that the above benefits are worth this cost. However, one need not choose one
 over the other: the `zsv` source also supports unbundled binary builds (though
 the unbundled binaries are not part of the officially supported packages).
 
-Note that `zsv` does not attempt to replace `jq` or `sqlite3` and only integrates a
-portion of their features that is necessary for basic conversion, testing and other
-common pipeline operations.
+Note that `zsv` does not attempt to replace `jq` or `sqlite3` and only
+integrates a portion of their features that is necessary for basic conversion,
+testing and other common pipeline operations.
 
 ### For each of these JSON schemas, why is top-level construct is an array and not an object
 
-At some point while reading this, you may have wondered: why is the JSON
-schema an array instead of an object? Why not something like:
+At some point while reading this, you may have wondered: why is the JSON schema
+an array instead of an object? Why not something like:
 
-```
+```json
 {
   metadata: ... # columns, indexes, whatever
   data: ...
 }
 ```
 
-Indeed, to programmers familiar with data structures, this would seem like a logical approach.
+Indeed, to programmers familiar with data structures, this would seem like a
+logical approach.
 
-One of the central design principles that `zsv` follows is to support stream-based processing
-whenever possible, in order to maximize performance efficiency. To do that, serialized data
-must always locate metadata before data.
+One of the central design principles that `zsv` follows is to support
+stream-based processing whenever possible, in order to maximize performance
+efficiency. To do that, serialized data must always locate metadata before data.
 
-Unfortunately, JSON does not support ordered properties within an object. As a result,
-if the top-level container was an object, there would be no guarantee that when serialized,
-metadata would always be written (or read, in the case of the recipient) before data. The
-only way to enforce order in JSON is to use a list.
+Unfortunately, JSON does not support ordered properties within an object. As a
+result, if the top-level container was an object, there would be no guarantee
+that when serialized, metadata would always be written (or read, in the case of
+the recipient) before data. The only way to enforce order in JSON is to use a
+list.
 
 #### For the database-compatible JSON schema, why use a 2-element tuple?
 
-An alternative to the 2-element tuple would be to simply use a list such as is used in
-the [row-based schema](csv.schema.json). The primary reason to prefer the tuple approach
-is *optionality*. Using the tuple approach still offers the option to support everything
-the row-based schema offers, while furthermore offering the benefit of a container
-that is unambiguously and solely dedicated to metadata.
-
+An alternative to the 2-element tuple would be to simply use a list such as is
+used in the [row-based schema](csv.schema.json). The primary reason to prefer
+the tuple approach is *optionality*. Using the tuple approach still offers the
+option to support everything the row-based schema offers, while furthermore
+offering the benefit of a container that is unambiguously and solely dedicated
+to metadata.
 
 ### How can this approach be extended to databases or database services (vs a single table at a time)?
 
-To extend this approach to an entire database, there are several objectives to consider:
+To extend this approach to an entire database, there are several objectives to
+consider:
+
 1. coverage: all metadata (and data) must be covered
-2. modularity: metadata must be separable not from data, but also within its own categories (e.g. tables vs indexes)
+2. modularity: metadata must be separable not from data, but also within its own
+   categories (e.g. tables vs indexes)
 3. performance: metadata and data must be serializable in a form that can be
    efficiently unserialized
 
-The [database-friendly table schema](db.schema.json) is compatible with all of these
-objectives.
+The [database-friendly table schema](db.schema.json) is compatible with all of
+these objectives.
 
-Table and column metadata is already covered, so the only remaining levels of metadata
-to address are database and database-service. These could be handled through a top-level
-object with properties such as "tables", "views" etc.
+Table and column metadata is already covered, so the only remaining levels of
+metadata to address are database and database-service. These could be handled
+through a top-level object with properties such as "tables", "views" etc.
 
-However, for serialization, it may be advantageous to output all metadata for all tables (and other objects)
-before any data. In addition, there may be reasons to want to specify the order in which
-metadata objects or table data is populated. As discussed above for table objects, this requires ordering which
-in turn requires a list rather than an object.
+However, for serialization, it may be advantageous to output all metadata for
+all tables (and other objects) before any data. In addition, there may be
+reasons to want to specify the order in which metadata objects or table data is
+populated. As discussed above for table objects, this requires ordering which in
+turn requires a list rather than an object.
 
-So putting them all together, a database-wide schema could be structured as a (metadata, data) tuple
-as follows:
+So putting them all together, a database-wide schema could be structured as a
+(metadata, data) tuple as follows:
 
-```
+```text
 # first, define a metadata object with a discriminator
 {
   type: table|view|...
@@ -241,14 +258,16 @@ as follows:
     ...
   ]
 ]
-
 ```
 
-A similar approach could be used for a collection of databases. The above is not meant to be
-a comprehensive final design, but hopefully conveys the basic idea that the
-[database-friendly table schema](db.schema.json) will not require breaking change in order
-to leverage for extended purposes
+A similar approach could be used for a collection of databases. The above is not
+meant to be a comprehensive final design, but hopefully conveys the basic idea
+that the [database-friendly table schema](db.schema.json) will not require
+breaking change in order to leverage for extended purposes
 
 ### Can you extend the `zsv 2db` command and/or related JSON schema to support the sqlite3 feature XYZ
 
-For standard sqlite3 features, the answer is generally yes! Please open an issue with your request
+For standard sqlite3 features, the answer is generally yes!
+
+Please [open an issue](https://github.com/liquidaty/zsv/issues/new/choose) with
+your request.


### PR DESCRIPTION
- Use GCC 11 instead of clang for macosx build.
- Resolves #30.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>