### PR TITLE
Enable tests on macosx/gcc with GCC 11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         PREFIX: ${{ env.AMD64_MACOSX_GCC }}
         CC: gcc-11
         MAKE: make
-        RUN_TESTS: false
+        RUN_TESTS: true
       shell: bash
       run: |
         ./scripts/ci-build.sh


### PR DESCRIPTION
Enable tests on `macosx/gcc` with GCC 11.