### PR TITLE
fix tiny mem leak when `select` cmd run with trailing blank header rows

### DIFF
--- a/app/utils/arg.c
+++ b/app/utils/arg.c
@@ -35,7 +35,6 @@
  * to use thread-local storage with static initializer
  */
 static struct zsv_opts *zsv_with_default_opts(char mode) {
-
   ZSVTLS static char zsv_default_opts_initd = 0;
   ZSVTLS static struct zsv_opts zsv_default_opts = { 0 };
 
@@ -49,6 +48,9 @@ static struct zsv_opts *zsv_with_default_opts(char mode) {
       zsv_default_opts_initd = 1;
       zsv_default_opts.max_row_size = ZSV_ROW_MAX_SIZE_DEFAULT;
       zsv_default_opts.max_columns = ZSV_MAX_COLS_DEFAULT;
+    } else {
+      zsv_default_opts.max_row_size = zsv_default_opts.max_row_size ? zsv_default_opts.max_row_size : ZSV_ROW_MAX_SIZE_DEFAULT;
+      zsv_default_opts.max_columns = zsv_default_opts.max_columns ? zsv_default_opts.max_columns : ZSV_MAX_COLS_DEFAULT;
     }
     break;
   }

--- a/app/utils/writer.c
+++ b/app/utils/writer.c
@@ -180,6 +180,7 @@ zsv_csv_writer zsv_writer_new(struct zsv_csv_writer_options *opts) {
 
 enum zsv_writer_status zsv_writer_flush(zsv_csv_writer w) {
   if(!w) return zsv_writer_status_missing_handle;
+
   zsv_output_buff_flush(&w->out);
   return zsv_writer_status_ok;
 }


### PR DESCRIPTION
change zsv_with_default_opts() to ensure max_row_size and max_columns are always 0 to fix bug that may show up up in consecutive runs when instance is left open e.g. in emcc