### PR TITLE
ARM NEON movemask update v0

### DIFF
--- a/app/utils/arg.c
+++ b/app/utils/arg.c
@@ -12,19 +12,8 @@
 #include <zsv.h>
 #include <zsv/utils/string.h>
 #include <zsv/utils/arg.h>
+#include <zst/utils/thread.h>
 
-/*
- * for now we don't really need thread support because this is only being used
- * by the CLI. However, it's here anyway in case future enhancements or
- * user customizations need multithreading support
- */
-#ifndef ZSVTLS
-# ifndef NO_THREADING
-#  define ZSVTLS _Thread_local
-# else
-#  define ZSVTLS
-# endif
-#endif
 /*
  * global zsv_default_opts for convenience funcs zsv_get_default_opts() and zsv_set_default_opts()
  *  for the cli to pass global opts to the standalone modules

--- a/app/utils/arg.c
+++ b/app/utils/arg.c
@@ -12,7 +12,7 @@
 #include <zsv.h>
 #include <zsv/utils/string.h>
 #include <zsv/utils/arg.h>
-#include <zst/utils/thread.h>
+#include <zsv/utils/thread.h>
 
 /*
  * global zsv_default_opts for convenience funcs zsv_get_default_opts() and zsv_set_default_opts()

--- a/include/zsv/utils/thread.h
+++ b/include/zsv/utils/thread.h
@@ -1,0 +1,16 @@
+#ifndef ZSV_THREAD_H
+#define ZSV_THREAD_H
+/*
+ * for now we don't really need thread support because this is only being used
+ * by the CLI. However, it's here anyway in case future enhancements or
+ * user customizations need multithreading support
+ */
+#ifndef ZSVTLS
+# ifndef NO_THREADING
+#  define ZSVTLS _Thread_local
+# else
+#  define ZSVTLS
+# endif
+#endif
+
+#endif

--- a/src/zsv.c
+++ b/src/zsv.c
@@ -269,6 +269,10 @@ zsv_parser zsv_new(struct zsv_opts *opts) {
       scanner = NULL;
     }
   }
+
+#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+  movemask_pseudo_ARM_NEON_init();
+#endif
   return scanner;
 }
 


### PR DESCRIPTION
remove one-time initialization from movemask_pseudo into zsv_new() via movemask_pseudo_ARM_NEON_init()