### PR TITLE
fix typo in examples/js/README.md

### DIFF
--- a/app/desc.c
+++ b/app/desc.c
@@ -329,6 +329,8 @@ static void zsv_desc_cell(void *ctx, unsigned char *restrict utf8_value, size_t 
   if(!data || data->err || data->done)
     return;
 
+  // trim the cell values, so we don't count e.g. " abc" as different from "abc"
+  utf8_value = (unsigned char *)zsv_strtrim(utf8_value, &len);
   if(data->row_count == 0) {
     if(data->current_column_ix < data->max_cols) {
       struct zsv_desc_column_name *e = calloc(1, sizeof(*e));

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -319,3 +319,5 @@ test-desc: test-%: ${BUILD_DIR}/bin/zsv_%${EXE}
 	${CMP} ${TMP_DIR}/$@.out2 expected/$@.out2 && ${TEST_PASS} || ${TEST_FAIL})
 	@(${PREFIX} $< -H < ${TEST_DATA_DIR}/test/$*.csv ${REDIRECT2} ${TMP_DIR}/$@.out3 && \
 	${CMP} ${TMP_DIR}/$@.out3 expected/$@.out3 && ${TEST_PASS} || ${TEST_FAIL})
+	@(${PREFIX} $< < ${TEST_DATA_DIR}/test/$*-trim.csv ${REDIRECT2} ${TMP_DIR}/$@.trim && \
+	${CMP} ${TMP_DIR}/$@.trim expected/$@.trim && ${TEST_PASS} || ${TEST_FAIL})

--- a/app/test/expected/test-desc.trim
+++ b/app/test/expected/test-desc.trim
@@ -1,0 +1,4 @@
+#,Column name,Min Length,Max Length,Count,Blank %,Example 1,Example 2,Example 3,Example 4,Example 5
+1,abc,1,1,3,0.00,x (3)
+2,def,1,1,3,0.00,A (2),B
+3,ghi,1,1,3,0.00,1 (3)

--- a/data/test/desc-trim.csv
+++ b/data/test/desc-trim.csv
@@ -1,0 +1,4 @@
+abc,def,ghi
+x,A,1
+x,B,1
+x, A,1

--- a/examples/js/README.md
+++ b/examples/js/README.md
@@ -45,7 +45,7 @@ this example does not require that libzsv is already installed
 ## Performance
 
 Running ZSV lib from Javascript is still experimental and is not yet fully optimized.
-Some performance challenges rae particular to web assembly + Javascript, e.g. where a lot of string data
+Some performance challenges are particular to web assembly + Javascript, e.g. where a lot of string data
 is being passed between Javascript and the library (see e.g. https://hacks.mozilla.org/2019/08/webassembly-interface-types/).
 
 However, initial results are promising:


### PR DESCRIPTION
desc: trim input data