### PR TITLE
[CI] Use macos-12 instead of macos-10.15.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: ci
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15, macos-12]
+        os: [ubuntu-20.04, macos-12]
 
     runs-on: ${{ matrix.os }}
 
@@ -72,16 +72,13 @@ jobs:
         CC: gcc
         MAKE: gmake
         RUN_TESTS: false
-      # uses: vmactions/freebsd-vm@v0.2.8
-      uses: vmactions/freebsd-vm@v0
+      uses: vmactions/freebsd-vm@v0   # https://github.com/vmactions/freebsd-vm
       with:
         mem: 2048
         release: 12.3
         envs: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
         usesh: true
         prepare: pkg install -y tree zip git autotools gmake lang/gcc
-        # copyback: false
-        # sync: sshfs
         run: |
           ./scripts/ci-build.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         echo "TAG=$TAG" >> $GITHUB_ENV
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Linux
       if: runner.os == 'Linux'


### PR DESCRIPTION
- `macos-10.15` is deprecated.
- FreeBSD action (https://github.com/vmactions/freebsd-vm) v0 is available for `macos-12` only.
- Use `macos-12` for all macOS workflow.
- Use `actions/checkout@v3`. Its `v2` is deprecated.
- Updates #83.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>