### PR TITLE
Update README with correct Chocolatey installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ For Windows (`*.nupkg`), install with `choco.exe`:
 
 ```shell
 # Install
-choco.exe install zsv --pre -source .
+choco.exe install zsv --pre -source <directory containing .nupkg file>
 
 # Uninstall
 choco.exe uninstall zsv

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ For Windows (`*.nupkg`), install with `choco.exe`:
 
 ```shell
 # Install
-choco.exe install zsv --pre -source .\zsv-amd64-windows-mingw.nupkg
+choco.exe install zsv --pre -source .
 
 # Uninstall
 choco.exe uninstall zsv


### PR DESCRIPTION
Previous installation in README.md for Windows using choco.exe changed so it points at directory .nupkg file is in, not at the .nupkg file itself