### PR TITLE
add zsv_row_length_raw_bytes

### DIFF
--- a/include/zsv/api.h
+++ b/include/zsv/api.h
@@ -259,6 +259,11 @@ ZSV_EXPORT size_t zsv_scanned_length(zsv_parser);
 ZSV_EXPORT size_t zsv_cum_scanned_length(zsv_parser parser);
 
 /**
+ * @return number of raw bytes scanned from the beginning to the end of this row
+ */
+ZSV_EXPORT size_t zsv_row_length_raw_bytes(zsv_parser parser);
+
+/**
  * Check the quoted status of the last cell that was read. This function is only
  * applicable when called from within a cell_handler() callback. Furthermore, this
  * function is generally only useful when the cell value will subsequent be

--- a/src/zsv.c
+++ b/src/zsv.c
@@ -446,7 +446,14 @@ size_t zsv_scanned_length(zsv_parser parser) {
 
 ZSV_EXPORT
 size_t zsv_cum_scanned_length(zsv_parser parser) {
-  return parser->cum_scanned_length + parser->scanned_length + (parser->had_bom ? strlen(ZSV_BOM) : 0);
+  return parser->cum_scanned_length +
+    (parser->finished ? 0 : parser->scanned_length) +
+    (parser->had_bom ? strlen(ZSV_BOM) : 0);
+}
+
+ZSV_EXPORT
+size_t zsv_row_length_raw_bytes(zsv_parser parser) {
+  return parser->scanned_length - parser->row_start;
 }
 
 /**


### PR DESCRIPTION
and fix zsv_cum_scanned_length if called during final() with input that has no final trailing row end