### PR TITLE
Automate source code formatting with `clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Microsoft
+BreakBeforeBraces: Attach
+ContinuationIndentWidth: 2
+IndentWidth: 2
+SortIncludes: false
+TabWidth: 2
+UseTab: Never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       if: matrix.os == 'macos-14'
       env:
         PREFIX: ${{ env.ARM64_MACOSX_GCC }}
-        CC: gcc-12
+        CC: clang
         MAKE: make
         RUN_TESTS: false
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
   tag:
     name: tag
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
 
     outputs:
-      TAG: ${{ steps.tag.outputs.TAG }}
+      TAG: ${{ steps.tag.outputs.TAG || '0.3.6' }}
 
     steps:
     - name: Set TAG on release
+      if: startsWith(github.ref, 'refs/tags/v')
       id: tag
       shell: bash
       run: |
@@ -57,7 +57,7 @@ jobs:
       contents: write
 
     env:
-      TAG: ${{ needs.tag.outputs.TAG || '0.3.6' }}
+      TAG: ${{ needs.tag.outputs.TAG }}
       AMD64_LINUX_GCC: amd64-linux-gcc
       AMD64_LINUX_CLANG: amd64-linux-clang
       AMD64_WINDOWS_MINGW: amd64-windows-mingw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,21 @@ on:
     types: [published]
 
 jobs:
+  format:
+    name: format
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Run clang-format
+      run: ./scripts/ci-run-clang-format.sh
+
   ci:
     name: ci
+    needs: [format]
+
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-13, macos-14]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       if: matrix.os == 'macos-13'
       env:
         PREFIX: ${{ env.AMD64_MACOSX_GCC }}
-        CC: gcc-12
+        CC: gcc-13
         MAKE: make
         RUN_TESTS: false
       shell: bash
@@ -164,7 +164,7 @@ jobs:
       if: matrix.os == 'macos-14'
       env:
         PREFIX: ${{ env.ARM64_MACOSX_GCC }}
-        CC: clang
+        CC: gcc-13
         MAKE: make
         RUN_TESTS: false
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Set up macOS (AMD64 and ARM64)
       if: runner.os == 'macOS'
       run: |
-        brew install --quiet coreutils tree autoconf automake libtool gcc@11
+        brew install --quiet coreutils tree autoconf automake libtool
         brew uninstall jq
 
     # --- Build ---
@@ -152,7 +152,7 @@ jobs:
       if: matrix.os == 'macos-13'
       env:
         PREFIX: ${{ env.AMD64_MACOSX_GCC }}
-        CC: gcc-11
+        CC: gcc-12
         MAKE: make
         RUN_TESTS: false
       shell: bash
@@ -164,7 +164,7 @@ jobs:
       if: matrix.os == 'macos-14'
       env:
         PREFIX: ${{ env.ARM64_MACOSX_GCC }}
-        CC: gcc-11
+        CC: gcc-12
         MAKE: make
         RUN_TESTS: false
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,27 @@ on:
     types: [published]
 
 jobs:
+  tag:
+    name: tag
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    outputs:
+      TAG: ${{ steps.tag.outputs.TAG }}
+
+    steps:
+    - name: Set TAG on release
+      id: tag
+      shell: bash
+      run: |
+        TAG="$GITHUB_REF_NAME"
+        echo "TAG: $TAG"
+        if [[ $TAG == "v"* ]]; then
+          TAG="${TAG:1}"
+        fi
+        echo "TAG: $TAG"
+        echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+
   format:
     name: format
     runs-on: ubuntu-latest
@@ -24,7 +45,7 @@ jobs:
 
   ci:
     name: ci
-    needs: [format]
+    needs: [format, tag]
 
     strategy:
       matrix:
@@ -36,7 +57,7 @@ jobs:
       contents: write
 
     env:
-      TAG: "0.3.6"
+      TAG: ${{ needs.tag.outputs.TAG || '0.3.6' }}
       AMD64_LINUX_GCC: amd64-linux-gcc
       AMD64_LINUX_CLANG: amd64-linux-clang
       AMD64_WINDOWS_MINGW: amd64-windows-mingw
@@ -47,18 +68,6 @@ jobs:
       ARTIFACT_RETENTION_DAYS: 5
 
     steps:
-    - name: Get tag if tagged/released and set TAG env var
-      if: startsWith(github.ref, 'refs/tags/v')
-      shell: bash
-      run: |
-        TAG="$GITHUB_REF_NAME"
-        echo "TAG: $TAG"
-        if [[ $TAG == "v"* ]]; then
-          TAG="${TAG:1}"
-        fi
-        echo "TAG: $TAG"
-        echo "TAG=$TAG" >> "$GITHUB_ENV"
-
     - name: Checkout
       uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Set up macOS (AMD64 and ARM64)
       if: runner.os == 'macOS'
       run: |
-        brew install coreutils tree autoconf automake libtool gcc@11
+        brew install --quiet coreutils tree autoconf automake libtool gcc@11
         brew uninstall jq
 
     # --- Build ---

--- a/README.md
+++ b/README.md
@@ -73,32 +73,32 @@ that implements the expected
 
 ## Key highlights
 
-* Available as BOTH a library and an application (coming soon: standalone
+- Available as BOTH a library and an application (coming soon: standalone
   zsvutil library for common helper functions such as csv writer)
-* Open-source, permissively licensed
-* Handles real-world CSV the same way that spreadsheet programs do (*including
+- Open-source, permissively licensed
+- Handles real-world CSV the same way that spreadsheet programs do (*including
   edge cases*). Gracefully handles (and can "clean") real-world data that may be
   "dirty".
-* Runs on macOS (tested on clang/gcc), Linux (gcc), Windows (mingw), BSD
+- Runs on macOS (tested on clang/gcc), Linux (gcc), Windows (mingw), BSD
   (gcc-only) and in-browser (emscripten/wasm)
-* Fastest (at least, vs all alternatives and on all platforms we've benchmarked
+- Fastest (at least, vs all alternatives and on all platforms we've benchmarked
   where 256-bit SIMD operations are available). See
   [app/benchmark/README.md](app/benchmark/README.md)
-* Low memory usage (regardless of how big your data is) and size footprint for
+- Low memory usage (regardless of how big your data is) and size footprint for
   both lib (~20k) and CLI executable (< 1MB)
-* Handles general delimited data (e.g. pipe-delimited) and fixed-with input
+- Handles general delimited data (e.g. pipe-delimited) and fixed-with input
   (with specified widths or auto-detected widths)
-* Handles multi-row headers
-* Handles input from any stream, including caller-defined streams accessed via a
+- Handles multi-row headers
+- Handles input from any stream, including caller-defined streams accessed via a
   single caller-defined `fread`-like function
-* Easy to use as a library in a few lines of code, via either pull or push
+- Easy to use as a library in a few lines of code, via either pull or push
   parsing
-* Includes the `zsv` CLI with the following built-in commands:
-  * `select`, `count`, `sql` query, `desc`ribe, `flatten`, `serialize`, `2json`,
+- Includes the `zsv` CLI with the following built-in commands:
+  - `select`, `count`, `sql` query, `desc`ribe, `flatten`, `serialize`, `2json`,
     `2db`, `stack`, `pretty`, `2tsv`, `paste`, `compare`, `jq`, `prop`, `rm`
-  * easily [convert between CSV/JSON/sqlite3](docs/csv_json_sqlite.md)
-  * [compare multiple files](docs/compare.md)
-* CLI is easy to extend/customize with a few lines of code via modular plug-in
+  - easily [convert between CSV/JSON/sqlite3](docs/csv_json_sqlite.md)
+  - [compare multiple files](docs/compare.md)
+- CLI is easy to extend/customize with a few lines of code via modular plug-in
   framework. Just write a few custom functions and compile into a distributable
   DLL that any existing zsv installation can use.
 
@@ -184,10 +184,10 @@ npm install zsv-lib
 
 Please note:
 
-* This package is still in alpha and currently only exposes a small subset of
+- This package is still in alpha and currently only exposes a small subset of
   the zsv library capabilities. More to come!
-* The CLI is not yet available as a Node package
-* If you'd like to use additional parser features, or use the CLI as a Node
+- The CLI is not yet available as a Node package
+- If you'd like to use additional parser features, or use the CLI as a Node
   package, please feel free to post a request in an issue here.
 
 ### From source
@@ -198,19 +198,19 @@ See [BUILD.md](BUILD.md) for more details.
 
 Our objectives, which we were unable to find in a pre-existing project, are:
 
-* Reasonably high performance
-* Runs on any platform, including web assembly
-* Available as both a library and a standalone executable / command-line
+- Reasonably high performance
+- Runs on any platform, including web assembly
+- Available as both a library and a standalone executable / command-line
   interface utility (CLI)
-* Memory-efficient, configurable resource limits
-* Handles real-world CSV cases the same way that Excel does, including all edge
+- Memory-efficient, configurable resource limits
+- Handles real-world CSV cases the same way that Excel does, including all edge
   cases (quote handling, newline handling (either `\n` or `\r`), embedded
   newlines, abnormal quoting (e.g. aaa"aaa,bbb...)
-* Handles other "dirty" data issues:
-  * Assumes valid UTF8, but does not misbehave if input contains bad UTF8
-  * Option to specify multi-row headers
-  * Does not assume or stop working in case of inconsistent numbers of columns
-* Easy to use library or extend/customize CLI
+- Handles other "dirty" data issues:
+  - Assumes valid UTF8, but does not misbehave if input contains bad UTF8
+  - Option to specify multi-row headers
+  - Does not assume or stop working in case of inconsistent numbers of columns
+- Easy to use library or extend/customize CLI
 
 There are several excellent tools that achieve high performance. Among those we
 considered were xsv and tsv-utils. While they met our performance objective,
@@ -234,34 +234,34 @@ needs.
 
 `zsv` comes with several built-in commands:
 
-* `echo`: read CSV from stdin and write it back out to stdout. This is mostly
+- `echo`: read CSV from stdin and write it back out to stdout. This is mostly
   useful for demonstrating how to use the API and also how to create a plug-in,
   and has several uses beyond that including adding/removing BOM, cleaning up
   bad UTF8, whitespace or blank column trimming, limiting output to a contiguous
   data block, skipping leading garbage, and even proving substitution values
   without modifying the underlying source
-* `select`: re-shape CSV by skipping leading garbage, combining header rows into
+- `select`: re-shape CSV by skipping leading garbage, combining header rows into
   a single header, selecting or excluding specified columns, removing duplicate
   columns, sampling, converting from fixed-width input, searching and more
-* `sql`: treat one or more CSV files like database tables and query with SQL
-* `desc`: provide a quick description of your table data
-* `pretty`: format for console (fixed-width) display, or convert to markdown
+- `sql`: treat one or more CSV files like database tables and query with SQL
+- `desc`: provide a quick description of your table data
+- `pretty`: format for console (fixed-width) display, or convert to markdown
   format
-* `2json`: convert CSV to JSON. Optionally, output in
+- `2json`: convert CSV to JSON. Optionally, output in
   [database schema](docs/db.schema.json)
-* `2tsv`: convert to TSV (tab-delimited) format
-* `compare`: compare two or more tables of data and output the differences
-* `paste` (alpha): horizontally paste two tables together (given inputs X and Y,
+- `2tsv`: convert to TSV (tab-delimited) format
+- `compare`: compare two or more tables of data and output the differences
+- `paste` (alpha): horizontally paste two tables together (given inputs X and Y,
    output 1...N rows where each row all columns of X in row N, followed by all
    columns of Y in row N)
-* `serialize` (inverse of flatten): convert an NxM table to a single 3x (Nx(M-1))
+- `serialize` (inverse of flatten): convert an NxM table to a single 3x (Nx(M-1))
   table with columns: Row, Column Name, Column Value
-* `flatten` (inverse of serialize): flatten a table by combining rows that share
+- `flatten` (inverse of serialize): flatten a table by combining rows that share
   a common value in a specified identifier column
-* `stack`: merge CSV files vertically
-* `jq`: run a `jq` filter
-* `2db`: [convert from JSON to sqlite3 db](docs/csv_json_sqlite.md)
-* `prop`: view or save parsing options associated with a file, such as initial
+- `stack`: merge CSV files vertically
+- `jq`: run a `jq` filter
+- `2db`: [convert from JSON to sqlite3 db](docs/csv_json_sqlite.md)
+- `prop`: view or save parsing options associated with a file, such as initial
   rows to ignore, or header row span. Saved options are be applied by default
   when processing that file.
 
@@ -332,10 +332,10 @@ You can extend `zsv` by providing a pre-compiled shared or static library that
 defines the functions specified in `extension_template.h` and which `zsv` loads
 in one of three ways:
 
-* as a static library that is statically linked at compile time
-* as a dynamic library that is linked at compile time and located in any library
+- as a static library that is statically linked at compile time
+- as a dynamic library that is linked at compile time and located in any library
   search path
-* as a dynamic library that is located in the same folder as the `zsv`
+- as a dynamic library that is located in the same folder as the `zsv`
   executable and loaded at runtime if/as/when the custom mode is invoked
 
 #### Example and template
@@ -354,24 +354,26 @@ helping, please post an issue.
 
 ### Possible enhancements and related developments
 
-* online "playground" (soon to be released)
-* optimize search; add search with hyperscan or re2 regex matching, possibly
+- online "playground" (soon to be released)
+- optimize search; add search with hyperscan or re2 regex matching, possibly
   parallelize?
-* optional OpenMP or other multi-threading for row processing
-* auto-generated documentation, and better documentation in general
-* Additional benchmarking. Would be great to use
+- optional OpenMP or other multi-threading for row processing
+- auto-generated documentation, and better documentation in general
+- Additional benchmarking. Would be great to use
   <https://bitbucket.org/ewanhiggs/csv-game/src/master/> as a springboard to
   benchmarking a number of various tasks
-* encoding conversion e.g. UTF16 to UTF8
+- encoding conversion e.g. UTF16 to UTF8
 
 ## Contribute
 
-* [Fork](https://github.com/liquidaty/zsv/fork) the project.
-* Check out the latest [`main`](https://github.com/liquidaty/zsv/tree/main)
+- [Fork](https://github.com/liquidaty/zsv/fork) the project.
+- Check out the latest [`main`](https://github.com/liquidaty/zsv/tree/main)
   branch.
-* Create a feature or bugfix branch from `main`.
-* Commit and push your changes.
-* Submit the PR.
+- Create a feature or bugfix branch from `main`.
+- Update your required changes.
+- Make sure to run `clang-format` (version 14 or later) for C source updates.
+- Commit and push your changes.
+- Submit the PR.
 
 ## License
 

--- a/app/2db.c
+++ b/app/2db.c
@@ -24,13 +24,15 @@
 
 #define ZSV_2DB_DEFAULT_TABLE_NAME "mytable"
 
-enum zsv_2db_action {
+enum zsv_2db_action
+{
   zsv_2db_action_create = 1,
   zsv_2db_action_append,
   zsv_2db_action_index
 };
 
-enum zsv_2db_state {
+enum zsv_2db_state
+{
   zsv_2db_state_header = 1,
   zsv_2db_state_data,
   zsv_2db_state_done

--- a/app/2db.c
+++ b/app/2db.c
@@ -107,9 +107,9 @@ static void zsv_2db_ix_free(struct zsv_2db_ix *e) {
 }
 
 static void zsv_2db_ixes_delete(struct zsv_2db_ix **p) {
-  if(p && *p) {
+  if (p && *p) {
     struct zsv_2db_ix *next;
-    for(struct zsv_2db_ix *e = *p; e; e = next) {
+    for (struct zsv_2db_ix *e = *p; e; e = next) {
       next = e->next;
       zsv_2db_ix_free(e);
       free(e);
@@ -126,8 +126,8 @@ static void zsv_2db_column_free(struct zsv_2db_column *e) {
 
 static void zsv_2db_columns_delete(struct zsv_2db_column **p) {
   struct zsv_2db_column *next;
-  if(p && *p) {
-    for(struct zsv_2db_column *e = *p; e; e = next) {
+  if (p && *p) {
+    for (struct zsv_2db_column *e = *p; e; e = next) {
       next = e->next;
       zsv_2db_column_free(e);
       free(e);
@@ -137,11 +137,12 @@ static void zsv_2db_columns_delete(struct zsv_2db_column **p) {
 }
 
 static void zsv_2db_delete(zsv_2db_handle data) {
-  if(!data) return;
+  if (!data)
+    return;
 
   free(data->opts.table_name);
   free(data->db_fn_tmp);
-  if(data->db)
+  if (data->db)
     sqlite3_close(data->db);
 
   zsv_2db_columns_delete(&data->json_parser.columns);
@@ -162,26 +163,22 @@ static void zsv_2db_delete(zsv_2db_handle data) {
 static int zsv_2db_sqlite3_exec_2db(sqlite3 *db, const char *sql) {
   char *err_msg = NULL;
   int rc = sqlite3_exec(db, sql, NULL, NULL, &err_msg);
-  if(err_msg) {
+  if (err_msg) {
     fprintf(stderr, "Error executing '%s': %s\n", sql, err_msg);
     sqlite3_free(err_msg);
-  } else if(rc == SQLITE_DONE || rc == SQLITE_OK)
+  } else if (rc == SQLITE_DONE || rc == SQLITE_OK)
     return 0;
   return 1;
 }
 // add_db_indexes: return 0 on success, else error code
 static int zsv_2db_add_indexes(struct zsv_2db_data *data) {
   int err = 0;
-  for(struct zsv_2db_ix *ix = data->json_parser.indexes; !err && ix; ix = ix->next) {
+  for (struct zsv_2db_ix *ix = data->json_parser.indexes; !err && ix; ix = ix->next) {
     sqlite3_str *pStr = sqlite3_str_new(data->db);
-    sqlite3_str_appendf(pStr, "create%s index \"%w_%w\" on \"%w\"(%s)",
-                        ix->unique ? " unique" : "",
-                        data->opts.table_name,
-                        ix->name,
-                        data->opts.table_name,
-                        ix->on);
+    sqlite3_str_appendf(pStr, "create%s index \"%w_%w\" on \"%w\"(%s)", ix->unique ? " unique" : "",
+                        data->opts.table_name, ix->name, data->opts.table_name, ix->on);
     err = zsv_2db_sqlite3_exec_2db(data->db, sqlite3_str_value(pStr));
-    if(!err)
+    if (!err)
       data->json_parser.index_sequence_num_max++;
     sqlite3_free(sqlite3_str_finish(pStr));
   }
@@ -189,42 +186,40 @@ static int zsv_2db_add_indexes(struct zsv_2db_data *data) {
 }
 
 static void zsv_2db_start_transaction(struct zsv_2db_data *data) {
-  if(!data->transaction_started)
+  if (!data->transaction_started)
     sqlite3_exec(data->db, "BEGIN TRANSACTION", NULL, NULL, NULL);
   data->transaction_started = 1;
 }
 
 static void zsv_2db_end_transaction(struct zsv_2db_data *data) {
-  if(data->transaction_started)
+  if (data->transaction_started)
     sqlite3_exec(data->db, "COMMIT", NULL, NULL, NULL);
   data->transaction_started = 0;
 }
 
-static sqlite3_str *build_create_table_statement(sqlite3 *db, const char *tname,
-                                                 const char * const *colnames,
-                                                 const char * const *datatypes,
-                                                 const char * const *collates,
-                                                 unsigned int col_count
-                                                 ) {
+static sqlite3_str *build_create_table_statement(sqlite3 *db, const char *tname, const char *const *colnames,
+                                                 const char *const *datatypes, const char *const *collates,
+                                                 unsigned int col_count) {
   int err = 0;
   sqlite3_str *pStr = sqlite3_str_new(db);
   sqlite3_str_appendf(pStr, "CREATE TABLE \"%w\" (\n  ", tname ? tname : ZSV_2DB_DEFAULT_TABLE_NAME);
-  for(unsigned int i = 0; i < col_count; i++) {
-    if(i > 0)
+  for (unsigned int i = 0; i < col_count; i++) {
+    if (i > 0)
       sqlite3_str_appendf(pStr, ",\n  ");
     sqlite3_str_appendf(pStr, "\"%w\"", colnames[i]);
 
     const char *datatype = datatypes ? datatypes[i] : NULL;
-    if(!datatype || !(!strcmp("int", datatype) || !strcmp("integer", datatype) || !strcmp("real", datatype) || !strcmp("text", datatype))) {
-      if(datatype)
+    if (!datatype || !(!strcmp("int", datatype) || !strcmp("integer", datatype) || !strcmp("real", datatype) ||
+                       !strcmp("text", datatype))) {
+      if (datatype)
         fprintf(stderr, "Unrecognized datatype %s", datatype), err = 1;
       else
         datatype = "text";
     }
-    if(!err) {
+    if (!err) {
       const char *collate = collates ? collates[i] : NULL;
-      if(collate && *collate) {
-        if(collate && !(!strcmp("binary", collate) || !strcmp("rtrim", collate) || !strcmp("nocase", collate))) {
+      if (collate && *collate) {
+        if (collate && !(!strcmp("binary", collate) || !strcmp("rtrim", collate) || !strcmp("nocase", collate))) {
           fprintf(stderr, "Unrecognized collate: expected binary, rtrim or nocase, got %s", collate);
           err = 1;
         } else
@@ -232,8 +227,8 @@ static sqlite3_str *build_create_table_statement(sqlite3 *db, const char *tname,
       }
     }
   }
-  if(err) {
-    if(pStr)
+  if (err) {
+    if (pStr)
       sqlite3_free(sqlite3_str_finish(pStr));
     pStr = NULL;
   } else
@@ -243,39 +238,34 @@ static sqlite3_str *build_create_table_statement(sqlite3 *db, const char *tname,
 
 // zsv_2db_finish_header: return 0 on error, 1 on success
 static int zsv_2db_finish_header(struct zsv_2db_data *data) {
-  if(data->err)
+  if (data->err)
     return 0;
-  if(!data->json_parser.col_count) {
+  if (!data->json_parser.col_count) {
     fprintf(stderr, "No columns found!\n");
     return 0;
   }
 
   data->json_parser.state = zsv_2db_state_data;
-  if((data->json_parser.row_values = calloc(data->json_parser.col_count,
-                                            sizeof(*data->json_parser.row_values))))
+  if ((data->json_parser.row_values = calloc(data->json_parser.col_count, sizeof(*data->json_parser.row_values))))
     return 1;
 
   data->err = 1;
   return 0;
 }
 
-
 /* json parser functions */
 
-static sqlite3_stmt *create_insert_statement(sqlite3 *db, const char *tname,
-                                             unsigned int col_count) {
+static sqlite3_stmt *create_insert_statement(sqlite3 *db, const char *tname, unsigned int col_count) {
   sqlite3_stmt *insert_stmt = NULL;
   sqlite3_str *insert_sql = sqlite3_str_new(db);
-  if(insert_sql) {
+  if (insert_sql) {
     sqlite3_str_appendf(insert_sql, "insert into \"%w\" values(?", tname);
-    for(unsigned int i = 1; i < col_count; i++)
+    for (unsigned int i = 1; i < col_count; i++)
       sqlite3_str_appendf(insert_sql, ", ?");
     sqlite3_str_appendf(insert_sql, ")");
-    int status = sqlite3_prepare_v2(db, sqlite3_str_value(insert_sql),
-                                    -1, &insert_stmt, NULL);
-    if(status != SQLITE_OK) {
-      fprintf(stderr, "Unable to prep (%s): %s\n", sqlite3_str_value(insert_sql),
-              sqlite3_errmsg(db));
+    int status = sqlite3_prepare_v2(db, sqlite3_str_value(insert_sql), -1, &insert_stmt, NULL);
+    if (status != SQLITE_OK) {
+      fprintf(stderr, "Unable to prep (%s): %s\n", sqlite3_str_value(insert_sql), sqlite3_errmsg(db));
     }
     sqlite3_free(sqlite3_str_finish(insert_sql));
   }
@@ -285,7 +275,7 @@ static sqlite3_stmt *create_insert_statement(sqlite3 *db, const char *tname,
 // return error
 static int zsv_2db_set_insert_stmt(struct zsv_2db_data *data) {
   int err = 0;
-  if(!data->json_parser.col_count) {
+  if (!data->json_parser.col_count) {
     fprintf(stderr, "insert statement called with no columns to insert");
     err = 1;
   } else {
@@ -293,24 +283,20 @@ static int zsv_2db_set_insert_stmt(struct zsv_2db_data *data) {
     const char **datatypes = calloc(data->json_parser.col_count, sizeof(*datatypes));
     const char **collates = calloc(data->json_parser.col_count, sizeof(*collates));
     unsigned int i = 0;
-    for(struct zsv_2db_column *e = data->json_parser.columns; e; e = e->next, i++) {
+    for (struct zsv_2db_column *e = data->json_parser.columns; e; e = e->next, i++) {
       colnames[i] = e->name;
       datatypes[i] = e->datatype;
       collates[i] = e->collate;
     }
 
-    sqlite3_str *create_sql =
-      build_create_table_statement(data->db, data->opts.table_name,
-                                   colnames, datatypes, collates,
-                                   data->json_parser.col_count
-                                   );
-    if(!create_sql)
+    sqlite3_str *create_sql = build_create_table_statement(data->db, data->opts.table_name, colnames, datatypes,
+                                                           collates, data->json_parser.col_count);
+    if (!create_sql)
       err = 1;
     else {
-      if(!(err = zsv_2db_sqlite3_exec_2db(data->db, sqlite3_str_value(create_sql)))
-            && !(data->json_parser.insert_stmt =
-                 create_insert_statement(data->db, data->opts.table_name,
-                                         data->json_parser.col_count))) {
+      if (!(err = zsv_2db_sqlite3_exec_2db(data->db, sqlite3_str_value(create_sql))) &&
+          !(data->json_parser.insert_stmt =
+              create_insert_statement(data->db, data->opts.table_name, data->json_parser.col_count))) {
         err = 1;
         zsv_2db_start_transaction(data);
       } else
@@ -325,41 +311,38 @@ static int zsv_2db_set_insert_stmt(struct zsv_2db_data *data) {
   return err;
 }
 
-
 /*
   add_local_db_row(): return sqlite3 error, or 0 on ok
 */
-static int zsv_2db_insert_row_values(sqlite3_stmt *stmt, unsigned stmt_colcount,
-                                     char const *const *const values,
-                                     unsigned int values_count
-                                     ) {
-  if(!stmt)
+static int zsv_2db_insert_row_values(sqlite3_stmt *stmt, unsigned stmt_colcount, char const *const *const values,
+                                     unsigned int values_count) {
+  if (!stmt)
     return -1;
 
   int status = 0;
   unsigned int errors_printed = 0;
-  if(values_count > stmt_colcount)
+  if (values_count > stmt_colcount)
     values_count = stmt_colcount;
 
-  for(unsigned int i = 0; i < values_count; i++) {
+  for (unsigned int i = 0; i < values_count; i++) {
     const char *val = values[i];
-    if(val && *val)
-      sqlite3_bind_text(stmt, (int)i+1, val, (int)strlen(val), SQLITE_STATIC);
+    if (val && *val)
+      sqlite3_bind_text(stmt, (int)i + 1, val, (int)strlen(val), SQLITE_STATIC);
     else
       // don't use sqlite3_bind_null, else x = ? will fail if value is ""/null
-      sqlite3_bind_text(stmt, (int)i+1, "", 0, SQLITE_STATIC);
+      sqlite3_bind_text(stmt, (int)i + 1, "", 0, SQLITE_STATIC);
   }
 
-  for(unsigned int i = values_count; i < stmt_colcount; i++)
-    sqlite3_bind_null(stmt, (int)i+1);
+  for (unsigned int i = values_count; i < stmt_colcount; i++)
+    sqlite3_bind_null(stmt, (int)i + 1);
 
   status = sqlite3_step(stmt);
-  if(status == SQLITE_DONE)
+  if (status == SQLITE_DONE)
     status = 0;
-  else if(errors_printed < 10) {
+  else if (errors_printed < 10) {
     errors_printed++;
     fprintf(stderr, "Unable to insert: %s\n", sqlite3_errstr(status));
-  } else if(errors_printed != 100) {
+  } else if (errors_printed != 100) {
     errors_printed = 100;
     fprintf(stderr, "Too many insert errors to print\n");
   }
@@ -370,27 +353,25 @@ static int zsv_2db_insert_row_values(sqlite3_stmt *stmt, unsigned stmt_colcount,
 }
 
 static int zsv_2db_insert_row(struct zsv_2db_data *data) {
-  if(!data->err) {
+  if (!data->err) {
     data->rows_processed++;
-    if(data->json_parser.have_row_data) {
-      if(!data->json_parser.insert_stmt)
+    if (data->json_parser.have_row_data) {
+      if (!data->json_parser.insert_stmt)
         data->err = zsv_2db_set_insert_stmt(data);
 
-      if(!data->db)
+      if (!data->db)
         return 0;
       int rc =
-        zsv_2db_insert_row_values(data->json_parser.insert_stmt,
-                                  data->json_parser.stmt_colcount,
-                                  (char const *const *const) data->json_parser.row_values,
-                                  data->json_parser.col_count);
+        zsv_2db_insert_row_values(data->json_parser.insert_stmt, data->json_parser.stmt_colcount,
+                                  (char const *const *const)data->json_parser.row_values, data->json_parser.col_count);
       data->row_insert_attempts++;
-      if(!rc) {
+      if (!rc) {
         data->rows_inserted++;
-        if(data->opts.verbose && (data->rows_inserted % ZSV_2DB_MSG_BATCH_SIZE == 0))
+        if (data->opts.verbose && (data->rows_inserted % ZSV_2DB_MSG_BATCH_SIZE == 0))
           fprintf(stderr, "%zu rows inserted\n", data->rows_inserted);
-        if(data->opts.batch_size && (data->rows_inserted % data->opts.batch_size == 0)) {
+        if (data->opts.batch_size && (data->rows_inserted % data->opts.batch_size == 0)) {
           zsv_2db_end_transaction(data);
-          if(data->opts.verbose)
+          if (data->opts.verbose)
             fprintf(stderr, "%zu rows committed\n", data->rows_inserted);
           zsv_2db_start_transaction(data);
         }
@@ -408,13 +389,14 @@ static int json_start_map(yajl_helper_t yh) {
 
 static int json_end_map(yajl_helper_t yh) {
   struct zsv_2db_data *data = yajl_helper_ctx(yh);
-  if(data->json_parser.state == zsv_2db_state_header && yajl_helper_got_path(yh, 3, "[{columns[")) { // exiting a column header
-    if(!data->json_parser.current_column.name) {
+  if (data->json_parser.state == zsv_2db_state_header &&
+      yajl_helper_got_path(yh, 3, "[{columns[")) { // exiting a column header
+    if (!data->json_parser.current_column.name) {
       fprintf(stderr, "Name missing from column spec!\n");
       return 0;
     } else {
       struct zsv_2db_column *e = calloc(1, sizeof(*e));
-      if(!e) {
+      if (!e) {
         fprintf(stderr, "Out of memory!");
         return 0;
       }
@@ -424,17 +406,17 @@ static int json_end_map(yajl_helper_t yh) {
       data->json_parser.col_count++;
       memset(&data->json_parser.current_column, 0, sizeof(data->json_parser.current_column));
     }
-  } else if(data->json_parser.state == zsv_2db_state_header &&
-            yajl_helper_got_path(yh, 3, "[{indexes{")) { // exiting an index
-    if(!data->json_parser.current_index.name) {
+  } else if (data->json_parser.state == zsv_2db_state_header &&
+             yajl_helper_got_path(yh, 3, "[{indexes{")) { // exiting an index
+    if (!data->json_parser.current_index.name) {
       fprintf(stderr, "Name missing from index spec\n");
       return 0;
-    } else if(!(data->json_parser.current_index.on || data->json_parser.current_index.delete)) {
+    } else if (!(data->json_parser.current_index.on || data->json_parser.current_index.delete)) {
       fprintf(stderr, "'on' or 'delete' missing from index spec\n");
       return 0;
     } else {
       struct zsv_2db_ix *e = calloc(1, sizeof(*e));
-      if(!e) {
+      if (!e) {
         fprintf(stderr, "Out of memory!");
         return 0;
       }
@@ -447,13 +429,11 @@ static int json_end_map(yajl_helper_t yh) {
   return 1;
 }
 
-static int json_map_key(yajl_helper_t yh,
-                        const unsigned char *s, size_t len) {
+static int json_map_key(yajl_helper_t yh, const unsigned char *s, size_t len) {
   struct zsv_2db_data *data = yajl_helper_ctx(yh);
-  if(data->json_parser.state == zsv_2db_state_header &&
-     yajl_helper_got_path(yh, 3, "[{indexes{")) {
+  if (data->json_parser.state == zsv_2db_state_header && yajl_helper_got_path(yh, 3, "[{indexes{")) {
     free(data->json_parser.current_index.name);
-    if(len)
+    if (len)
       data->json_parser.current_index.name = zsv_memdup(s, len);
     else
       data->json_parser.current_index.name = NULL;
@@ -462,19 +442,18 @@ static int json_map_key(yajl_helper_t yh,
 }
 
 static int json_start_array(yajl_helper_t yh) {
-  if(yajl_helper_level(yh) == 2) {
+  if (yajl_helper_level(yh) == 2) {
     struct zsv_2db_data *data = yajl_helper_ctx(yh);
-    if(data->json_parser.state == zsv_2db_state_header &&
-       yajl_helper_got_path(yh, 2, "[[")
-       && yajl_helper_array_index_plus_1(yh, 1) == 2)
+    if (data->json_parser.state == zsv_2db_state_header && yajl_helper_got_path(yh, 2, "[[") &&
+        yajl_helper_array_index_plus_1(yh, 1) == 2)
       return zsv_2db_finish_header(data);
   }
   return 1;
 }
 
 static void reset_row_values(struct zsv_2db_data *data) {
-  if(data->json_parser.row_values) {
-    for(unsigned int i = 0; i < data->json_parser.col_count; i++) {
+  if (data->json_parser.row_values) {
+    for (unsigned int i = 0; i < data->json_parser.col_count; i++) {
       free(data->json_parser.row_values[i]);
       data->json_parser.row_values[i] = NULL;
     }
@@ -483,10 +462,9 @@ static void reset_row_values(struct zsv_2db_data *data) {
 }
 
 static int json_end_array(yajl_helper_t yh) {
-  if(yajl_helper_level(yh) == 2) {
+  if (yajl_helper_level(yh) == 2) {
     struct zsv_2db_data *data = yajl_helper_ctx(yh);
-    if(data->json_parser.state == zsv_2db_state_data &&
-       yajl_helper_got_path(yh, 2, "[[")) { // finished a row of data
+    if (data->json_parser.state == zsv_2db_state_data && yajl_helper_got_path(yh, 2, "[[")) { // finished a row of data
       zsv_2db_insert_row(data);
       reset_row_values(data);
     }
@@ -494,58 +472,56 @@ static int json_end_array(yajl_helper_t yh) {
   return 1;
 }
 
-static int json_process_value(yajl_helper_t yh,
-                              struct json_value *value) {
+static int json_process_value(yajl_helper_t yh, struct json_value *value) {
   const unsigned char *jsstr;
   size_t len;
   struct zsv_2db_data *data = yajl_helper_ctx(yh);
-  if(data->json_parser.state == zsv_2db_state_data) {
-    if(yajl_helper_got_path(yh, 3, "[[[")) {
+  if (data->json_parser.state == zsv_2db_state_data) {
+    if (yajl_helper_got_path(yh, 3, "[[[")) {
       json_value_default_string(value, &jsstr, &len);
-      if(jsstr && len) {
+      if (jsstr && len) {
         unsigned int j = yajl_helper_array_index_plus_1(yh, 0);
-        if(j && j-1 < data->json_parser.col_count) {
-          data->json_parser.row_values[j-1] = zsv_memdup(jsstr, len);
+        if (j && j - 1 < data->json_parser.col_count) {
+          data->json_parser.row_values[j - 1] = zsv_memdup(jsstr, len);
           data->json_parser.have_row_data = 1;
         }
       }
     }
-  } else if(yajl_helper_got_path(yh, 2, "[{name")) {
+  } else if (yajl_helper_got_path(yh, 2, "[{name")) {
     json_value_default_string(value, &jsstr, &len);
-    if(len) {
-      if(data->opts.table_name)
-        fprintf(stderr, "Table name specified twice; keeping %s, ignoring %.*s\n",
-                data->opts.table_name, (int)len, jsstr);
+    if (len) {
+      if (data->opts.table_name)
+        fprintf(stderr, "Table name specified twice; keeping %s, ignoring %.*s\n", data->opts.table_name, (int)len,
+                jsstr);
       else
         data->opts.table_name = zsv_memdup(jsstr, len);
     }
-  } else if(yajl_helper_got_path(yh, 4, "[{columns[{name")) {
+  } else if (yajl_helper_got_path(yh, 4, "[{columns[{name")) {
     free(data->json_parser.current_column.name);
     data->json_parser.current_column.name = NULL;
     json_value_default_string(value, &jsstr, &len);
-    if(jsstr && len)
+    if (jsstr && len)
       data->json_parser.current_column.name = zsv_memdup(jsstr, len);
-  } else if(yajl_helper_got_path(yh, 4, "[{columns[{datatype")) {
+  } else if (yajl_helper_got_path(yh, 4, "[{columns[{datatype")) {
     free(data->json_parser.current_column.datatype);
     data->json_parser.current_column.datatype = NULL;
     json_value_default_string(value, &jsstr, &len);
-    if(jsstr && len)
+    if (jsstr && len)
       data->json_parser.current_column.datatype = zsv_memdup(jsstr, len);
-  } else if(yajl_helper_got_path(yh, 4, "[{columns[{collate")) {
+  } else if (yajl_helper_got_path(yh, 4, "[{columns[{collate")) {
     free(data->json_parser.current_column.collate);
     data->json_parser.current_column.collate = NULL;
     json_value_default_string(value, &jsstr, &len);
-    if(jsstr && len)
+    if (jsstr && len)
       data->json_parser.current_column.collate = zsv_memdup(jsstr, len);
-  } else if(yajl_helper_got_path(yh, 4, "[{indexes{*{delete")) {
+  } else if (yajl_helper_got_path(yh, 4, "[{indexes{*{delete")) {
     data->json_parser.current_index.delete = json_value_truthy(value);
-  } else if(yajl_helper_got_path(yh, 4, "[{indexes{*{unique")) {
+  } else if (yajl_helper_got_path(yh, 4, "[{indexes{*{unique")) {
     data->json_parser.current_index.unique = json_value_truthy(value);
-  } else if(yajl_helper_got_path(yh, 4, "[{indexes{*{on")
-            || yajl_helper_got_path(yh, 5, "[{indexes{*{on[")) {
+  } else if (yajl_helper_got_path(yh, 4, "[{indexes{*{on") || yajl_helper_got_path(yh, 5, "[{indexes{*{on[")) {
     json_value_default_string(value, &jsstr, &len);
-    if(len) {
-      if(yajl_helper_level(yh) == 4 || !data->json_parser.current_index.on) {
+    if (len) {
+      if (yajl_helper_level(yh) == 4 || !data->json_parser.current_index.on) {
         free(data->json_parser.current_index.on);
         data->json_parser.current_index.on = zsv_memdup(jsstr, len);
       } else {
@@ -564,29 +540,29 @@ static int json_process_value(yajl_helper_t yh,
 // exportable
 static zsv_2db_handle zsv_2db_new(struct zsv_2db_options *opts) {
   int err = 0;
-  if(!opts->db_fn)
+  if (!opts->db_fn)
     fprintf(stderr, "Please specify an output file\n"), err = 1;
 
-  struct stat stt = { 0 };
-  if(!err && !opts->overwrite && (!stat(opts->db_fn, &stt) || errno != ENOENT))
+  struct stat stt = {0};
+  if (!err && !opts->overwrite && (!stat(opts->db_fn, &stt) || errno != ENOENT))
     fprintf(stderr, "File %s already exists\n", opts->db_fn), err = 1;
 
-  if(err)
+  if (err)
     return NULL;
 
   struct zsv_2db_data *data = calloc(1, sizeof(*data));
   data->opts = *opts;
 
-  if(!(data->opts.batch_size))
+  if (!(data->opts.batch_size))
     data->opts.batch_size = ZSV_2DB_DEFAULT_BATCH_SIZE;
 
   data->json_parser.last_column = &data->json_parser.columns;
   data->json_parser.last_index = &data->json_parser.indexes;
   data->json_parser.state = zsv_2db_state_header;
-  if(opts->table_name)
+  if (opts->table_name)
     data->opts.table_name = strdup(opts->table_name);
   asprintf(&data->db_fn_tmp, "%s.tmp", data->opts.db_fn);
-  if(!data->db_fn_tmp)
+  if (!data->db_fn_tmp)
     err = 1;
   else {
     int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX;
@@ -596,11 +572,10 @@ static zsv_2db_handle zsv_2db_new(struct zsv_2db_options *opts) {
     unlink(data->db_fn_tmp);
     int rc = sqlite3_open_v2(data->db_fn_tmp, &data->db, flags, NULL);
     err = 1;
-    if(!data->db)
+    if (!data->db)
       fprintf(stderr, "Unable to open db at %s\n", data->db_fn_tmp);
-    else if(rc != SQLITE_OK )
-      fprintf(stderr, "Unable to open db at %s: %s\n", data->db_fn_tmp,
-              sqlite3_errmsg(data->db));
+    else if (rc != SQLITE_OK)
+      fprintf(stderr, "Unable to open db at %s: %s\n", data->db_fn_tmp, sqlite3_errmsg(data->db));
     else {
       err = 0;
 
@@ -609,19 +584,15 @@ static zsv_2db_handle zsv_2db_new(struct zsv_2db_options *opts) {
       sqlite3_exec(data->db, "PRAGMA journal_mode = OFF", NULL, NULL, NULL);
 
       // parse the input and create & populate the database table
-      if(!(data->json_parser.yh =
-           yajl_helper_new(32,
-                           json_start_map, json_end_map, json_map_key,
-                           json_start_array, json_end_array,
-                           json_process_value,
-                           data))) {
+      if (!(data->json_parser.yh = yajl_helper_new(32, json_start_map, json_end_map, json_map_key, json_start_array,
+                                                   json_end_array, json_process_value, data))) {
         fprintf(stderr, "Unable to get yajl parser\n");
         err = 1;
       }
     }
   }
 
-  if(err) {
+  if (err) {
     zsv_2db_delete(data);
     data = NULL;
   }
@@ -638,20 +609,19 @@ static int zsv_2db_err(zsv_2db_handle h) {
 static int zsv_2db_finish(zsv_2db_handle data) {
   // add indexes
   int err = zsv_2db_add_indexes(data);
-  if(!err) {
-    if(data->db) {
+  if (!err) {
+    if (data->db) {
       zsv_2db_end_transaction(data);
-      if(data->json_parser.insert_stmt)
+      if (data->json_parser.insert_stmt)
         sqlite3_finalize(data->json_parser.insert_stmt);
 
       sqlite3_close(data->db);
       data->db = NULL;
 
-       // rename tmp to target
+      // rename tmp to target
       unlink(data->opts.db_fn);
-      if(zsv_replace_file(data->db_fn_tmp, data->opts.db_fn)) {
-        fprintf(stderr, "Unable to rename %s to %s\n",
-                data->db_fn_tmp, data->opts.db_fn);
+      if (zsv_replace_file(data->db_fn_tmp, data->opts.db_fn)) {
+        fprintf(stderr, "Unable to rename %s to %s\n", data->db_fn_tmp, data->opts.db_fn);
         zsv_perror(NULL);
         err = 1;
       } else
@@ -666,83 +636,77 @@ static yajl_handle zsv_2db_yajl_handle(zsv_2db_handle data) {
   return yajl_helper_yajl(data->json_parser.yh);
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zsv_opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zsv_opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
   (void)(zsv_opts);
   (void)(opts_used);
   FILE *f_in = NULL;
   int err = 0;
-  struct zsv_2db_options opts = { 0 };
+  struct zsv_2db_options opts = {0};
   opts.verbose = zsv_get_default_opts().verbose;
 
-  const char *usage[] =
-    {
-     APPNAME ": convert JSON to sqlite3",
-     "",
-     "Usage: " APPNAME " -o <output path> [-t <table name>] [input.json]\n",
-     "",
-     "Alternatively, --output may be used in lieu of -o",
-     "",
-     "Options:",
-     "  -h,--help",
-     "  --table <table_name> : save as specified table name",
-     "  --overwrite          : overwrite existing database",
-     // to do:
-     // --sql to output sql statements
-     // --append: append to existing db
-     "",
-     "Converts a json representation of a database table to an sqlite3 file.",
-     "",
+  const char *usage[] = {
+    APPNAME ": convert JSON to SQLite3 DB",
+    "",
+    "Usage: " APPNAME " -o <output path> [-t <table name>] [input.json]\n",
+    "",
+    "Options:",
+    "  -h,--help            : show usage",
+    "  --table <table_name> : save as specified table name",
+    "  --overwrite          : overwrite existing database",
+    // TO DO:
+    // --sql to output sql statements
+    // --append: append to existing db
+    "",
+    // TO DO: add output examples and schema descriptions
+    "The input should conform to the schema defined at:",
+    "  https://github.com/liquidaty/zsv/blob/main/app/schema/database-table.json",
+    "",
+    "Example:",
+    "  [",
+    "    {",
+    "      \"columns\":[{\"name\":\"column 1\"}],",
+    "      \"indexes\":{\"ix1\":{\"on\":\"[column 1]\",\"unique\":true}}",
+    "    },",
+    "    [",
+    "      [\"row 1 cell 1\"],",
+    "      [\"row 2 cell 1\"]",
+    "    ]",
+    "  ]",
+    NULL,
+  };
 
-     // TO DO: add output examples and schema descriptions
-     "The input should conform to the schema defined at:",
-     "  https://github.com/liquidaty/zsv/blob/main/app/schema/database-table.json",
-     "",
-     "For example:",
-     "  [",
-     "    {",
-     "      \"columns\":[{\"name\":\"column 1\"}],",
-     "      \"indexes\":{\"ix1\":{\"on\":\"[column 1]\",\"unique\":true}}",
-     "    },",
-     "    [",
-     "      [\"row 1 cell 1\"],",
-     "      [\"row 2 cell 1\"]",
-     "    ]",
-     "  ]",
-     NULL
-    };
-
-  for(int i = 1; !err && i < argc; i++) {
-    if(!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
-      for(int j = 0; usage[j]; j++)
+  for (int i = 1; !err && i < argc; i++) {
+    if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
+      for (int j = 0; usage[j]; j++)
         fprintf(stdout, "%s\n", usage[j]);
       goto exit_2db;
-    } else if(!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
-      if(++i >= argc)
-        fprintf(stderr, "%s option requires a filename value\n", argv[i-1]), err = 1;
-      else if(opts.db_fn)
-        fprintf(stderr, "Output file specified more than once (%s and %s)\n",
-                opts.db_fn, argv[i]), err = 1;
+    } else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
+      if (++i >= argc)
+        fprintf(stderr, "%s option requires a filename value\n", argv[i - 1]), err = 1;
+      else if (opts.db_fn)
+        fprintf(stderr, "Output file specified more than once (%s and %s)\n", opts.db_fn, argv[i]), err = 1;
       else
         opts.db_fn = (char *)argv[i]; // we won't free this
-    } else if(!strcmp(argv[i], "--overwrite")) {
+    } else if (!strcmp(argv[i], "--overwrite")) {
       opts.overwrite = 1;
-    } else if(!strcmp(argv[i], "--table")) {
-      if(++i >= argc)
-        fprintf(stderr, "%s option requires a filename value\n", argv[i-1]), err = 1;
-      else if(opts.table_name)
-        fprintf(stderr, "Table name specified more than once (%s and %s)\n",
-                opts.table_name, argv[i]), err = 1;
+    } else if (!strcmp(argv[i], "--table")) {
+      if (++i >= argc)
+        fprintf(stderr, "%s option requires a filename value\n", argv[i - 1]), err = 1;
+      else if (opts.table_name)
+        fprintf(stderr, "Table name specified more than once (%s and %s)\n", opts.table_name, argv[i]), err = 1;
       else
         opts.table_name = (char *)argv[i]; // we won't free this
-    } else if(f_in)
+    } else if (f_in)
       fprintf(stderr, "Input file specified more than once\n"), err = 1;
-    else if(!(f_in = fopen(argv[i], "rb")))
+    else if (!(f_in = fopen(argv[i], "rb")))
       fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = 1;
-    else if(!(strlen(argv[i]) > 5 && !zsv_stricmp((const unsigned char *)argv[i] + strlen(argv[i]) - 5, (const unsigned char *)".json")))
+    else if (!(strlen(argv[i]) > 5 &&
+               !zsv_stricmp((const unsigned char *)argv[i] + strlen(argv[i]) - 5, (const unsigned char *)".json")))
       fprintf(stderr, "Warning: input filename does not end with .json (%s)\n", argv[i]);
   }
 
-  if(!f_in) {
+  if (!f_in) {
 #ifdef NO_STDIN
     fprintf(stderr, "Please specify an input file\n");
     err = 1;
@@ -751,31 +715,31 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
 #endif
   }
 
-  if(!err) {
+  if (!err) {
     zsv_2db_handle data = zsv_2db_new(&opts);
-    if(!data)
+    if (!data)
       err = 1;
     else {
-      size_t chunk_size = 4096*16;
+      size_t chunk_size = 4096 * 16;
       unsigned char *buff = malloc(chunk_size);
-      if(!buff)
+      if (!buff)
         err = 1;
       else {
         size_t bytes_read = 0;
         yajl_handle y = zsv_2db_yajl_handle(data);
-        while(!err && !zsv_2db_err(data)) {
+        while (!err && !zsv_2db_err(data)) {
           bytes_read = fread(buff, 1, chunk_size, f_in);
-          if(bytes_read == 0)
+          if (bytes_read == 0)
             break;
           yajl_status stat = yajl_parse(y, buff, bytes_read);
-          if(stat != yajl_status_ok)
+          if (stat != yajl_status_ok)
             err = yajl_helper_print_err(y, buff, bytes_read);
         }
 
-        if(!err) {
-          if(yajl_complete_parse(y) != yajl_status_ok)
+        if (!err) {
+          if (yajl_complete_parse(y) != yajl_status_ok)
             err = yajl_helper_print_err(y, buff, bytes_read);
-          else if(zsv_2db_err(data) || zsv_2db_finish(data))
+          else if (zsv_2db_err(data) || zsv_2db_finish(data))
             err = 1;
         }
         free(buff);
@@ -784,8 +748,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
     }
   }
 
- exit_2db:
-  if(f_in && f_in != stdin)
+exit_2db:
+  if (f_in && f_in != stdin)
     fclose(f_in);
 
   return err;

--- a/app/2db.c
+++ b/app/2db.c
@@ -24,15 +24,13 @@
 
 #define ZSV_2DB_DEFAULT_TABLE_NAME "mytable"
 
-enum zsv_2db_action
-{
+enum zsv_2db_action {
   zsv_2db_action_create = 1,
   zsv_2db_action_append,
   zsv_2db_action_index
 };
 
-enum zsv_2db_state
-{
+enum zsv_2db_state {
   zsv_2db_state_header = 1,
   zsv_2db_state_data,
   zsv_2db_state_done

--- a/app/2json.c
+++ b/app/2json.c
@@ -43,19 +43,19 @@ struct zsv_2json_data {
 
 #define ZSV_JSON_SCHEMA_OBJECT 1
 #define ZSV_JSON_SCHEMA_DATABASE 2
-  unsigned char schema:2;
-  unsigned char no_header:1;
-  unsigned char no_empty:1;
-  unsigned char err:1;
-  unsigned char from_db:1;
-  unsigned char compact:1;
-  unsigned char _:1;
+  unsigned char schema : 2;
+  unsigned char no_header : 1;
+  unsigned char no_empty : 1;
+  unsigned char err : 1;
+  unsigned char from_db : 1;
+  unsigned char compact : 1;
+  unsigned char _ : 1;
 };
 
 static void zsv_2json_cleanup(struct zsv_2json_data *data) {
-  for(struct zsv_2json_header *next, *h = data->headers; h; h = next) {
+  for (struct zsv_2json_header *next, *h = data->headers; h; h = next) {
     next = h->next;
-    if(h->name)
+    if (h->name)
       free(h->name);
     free(h);
   }
@@ -63,15 +63,15 @@ static void zsv_2json_cleanup(struct zsv_2json_data *data) {
 }
 
 static void write_header_cell(struct zsv_2json_data *data, const unsigned char *utf8_value, size_t len) {
-  if(data->schema == ZSV_JSON_SCHEMA_OBJECT) {
+  if (data->schema == ZSV_JSON_SCHEMA_OBJECT) {
     struct zsv_2json_header *h;
-    if(!(h = calloc(1, sizeof(*h)))) {
+    if (!(h = calloc(1, sizeof(*h)))) {
       fprintf(stderr, "Out of memory!\n");
       data->err = 1;
     } else {
       *data->headers_next = h;
       data->headers_next = &h->next;
-      if((h->name = malloc(len + 1))) {
+      if ((h->name = malloc(len + 1))) {
         memcpy(h->name, utf8_value, len);
         h->name[len] = '\0';
       }
@@ -86,13 +86,13 @@ static void write_header_cell(struct zsv_2json_data *data, const unsigned char *
 }
 
 static void write_data_cell(struct zsv_2json_data *data, const unsigned char *utf8_value, size_t len) {
-  if(data->schema == ZSV_JSON_SCHEMA_OBJECT) {
-    if(!data->current_header)
+  if (data->schema == ZSV_JSON_SCHEMA_OBJECT) {
+    if (!data->current_header)
       return;
     char *current_header_name = data->current_header->name;
     data->current_header = data->current_header->next;
 
-    if(len || !data->no_empty)
+    if (len || !data->no_empty)
       jsonwriter_object_key(data->jsw, current_header_name);
     else
       return;
@@ -104,16 +104,16 @@ static char *zsv_2json_db_first_tname(sqlite3 *db) {
   char *tname = NULL;
   sqlite3_stmt *stmt = NULL;
   const char *sql = "select name from sqlite_master where type = 'table'";
-  if(sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+  if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
     fprintf(stderr, "Unable to prepare %s: %s\n", sql, sqlite3_errmsg(db));
-  else if(sqlite3_step(stmt) == SQLITE_ROW) {
+  else if (sqlite3_step(stmt) == SQLITE_ROW) {
     const unsigned char *text = sqlite3_column_text(stmt, 0);
-    if(text) {
+    if (text) {
       int len = sqlite3_column_bytes(stmt, 0);
       tname = zsv_memdup(text, len);
     }
   }
-  if(stmt)
+  if (stmt)
     sqlite3_finalize(stmt);
   return tname;
 }
@@ -121,38 +121,38 @@ static char *zsv_2json_db_first_tname(sqlite3 *db) {
 static void zsv_2json_row(void *ctx) {
   struct zsv_2json_data *data = ctx;
   unsigned int cols = zsv_cell_count(data->parser);
-  if(cols) {
+  if (cols) {
     char obj = 0;
     char arr = 0;
-    if(!data->rows_processed) { // header row
+    if (!data->rows_processed) {         // header row
       jsonwriter_start_array(data->jsw); // start array of rows
-      if(data->schema == ZSV_JSON_SCHEMA_DATABASE) {
+      if (data->schema == ZSV_JSON_SCHEMA_DATABASE) {
         jsonwriter_start_object(data->jsw); // start this row
         obj = 1;
 
-        if(data->db_tablename)
+        if (data->db_tablename)
           jsonwriter_object_cstr(data->jsw, "name", data->db_tablename);
 
         // to do: check index syntax (as of now, we just take argument value
         // as-is and assume it will translate into a valid SQLITE3 command)
         char have_index = 0;
-        for(unsigned i = 0; i < data->indexes.count; i++) {
+        for (unsigned i = 0; i < data->indexes.count; i++) {
           const char *name_start = data->indexes.clauses[i];
           const char *on = strstr(name_start, " on ");
-          if(on) {
+          if (on) {
             on += 4;
-            while(*on == ' ')
+            while (*on == ' ')
               on++;
           }
-          if(!on || !*on)
+          if (!on || !*on)
             continue;
 
           const char *name_end = name_start;
-          while(name_end && *name_end && *name_end != ' ')
+          while (name_end && *name_end && *name_end != ' ')
             name_end++;
 
-          if(name_end > name_start) {
-            if(!have_index) {
+          if (name_end > name_start) {
+            if (!have_index) {
               have_index = 1;
               jsonwriter_object_object(data->jsw, "indexes");
             }
@@ -160,45 +160,45 @@ static void zsv_2json_row(void *ctx) {
             jsonwriter_object_object(data->jsw, tmp); // this index
             free(tmp);
             jsonwriter_object_cstr(data->jsw, "on", on);
-            if(data->indexes.unique[i])
+            if (data->indexes.unique[i])
               jsonwriter_object_bool(data->jsw, "unique", 1);
             jsonwriter_end_object(data->jsw); // end this index
           }
         }
-        if(have_index)
+        if (have_index)
           jsonwriter_end_object(data->jsw); // indexes
 
         jsonwriter_object_array(data->jsw, "columns");
         arr = 1;
-      } else if(data->schema != ZSV_JSON_SCHEMA_OBJECT) {
+      } else if (data->schema != ZSV_JSON_SCHEMA_OBJECT) {
         jsonwriter_start_array(data->jsw); // start this row
         arr = 1;
       }
     } else { // processing a data row, not header row
-      if(data->schema == ZSV_JSON_SCHEMA_OBJECT) {
+      if (data->schema == ZSV_JSON_SCHEMA_OBJECT) {
         jsonwriter_start_object(data->jsw); // start this row
         obj = 1;
       } else {
-        if(data->rows_processed == 1 && data->schema == ZSV_JSON_SCHEMA_DATABASE)
+        if (data->rows_processed == 1 && data->schema == ZSV_JSON_SCHEMA_DATABASE)
           jsonwriter_start_array(data->jsw); // start the table-data element
-        jsonwriter_start_array(data->jsw); // start this row
+        jsonwriter_start_array(data->jsw);   // start this row
         arr = 1;
       }
     }
 
-    for(unsigned int i = 0; i < cols; i++) {
+    for (unsigned int i = 0; i < cols; i++) {
       struct zsv_cell cell = zsv_get_cell(data->parser, i);
       // output this cell
-      if(!data->rows_processed && !data->no_header) // this is header row
+      if (!data->rows_processed && !data->no_header) // this is header row
         write_header_cell(data, cell.str, cell.len);
       else
         write_data_cell(data, cell.str, cell.len);
     }
 
     // end this row
-    if(arr)
+    if (arr)
       jsonwriter_end_array(data->jsw);
-    if(obj)
+    if (obj)
       jsonwriter_end_object(data->jsw);
     data->rows_processed++;
   }
@@ -207,129 +207,128 @@ static void zsv_2json_row(void *ctx) {
 
 static int zsv_db2json(const char *input_filename, char **tname, jsonwriter_handle jsw) {
   sqlite3 *db;
-  int rc = sqlite3_open_v2(input_filename, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_SHAREDCACHE, NULL);
+  int rc =
+    sqlite3_open_v2(input_filename, &db, SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX | SQLITE_OPEN_SHAREDCACHE, NULL);
   int err = 0;
-  if(!db)
+  if (!db)
     fprintf(stderr, "Unable to open db at %s\n", input_filename), err = 1;
-  else if(rc != SQLITE_OK )
-    fprintf(stderr, "Unable to open db at %s: %s\n", input_filename,
-            sqlite3_errmsg(db)), err = 1;
-  else if(!*tname)
+  else if (rc != SQLITE_OK)
+    fprintf(stderr, "Unable to open db at %s: %s\n", input_filename, sqlite3_errmsg(db)), err = 1;
+  else if (!*tname)
     *tname = zsv_2json_db_first_tname(db);
 
-  if(!*tname)
+  if (!*tname)
     fprintf(stderr, "No table name provided, and none found in %s\n", input_filename), err = 1;
   else
     err = zsv_dbtable2json(db, *tname, jsw, 0);
   return err;
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  struct zsv_2json_data data = { 0 };
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  struct zsv_2json_data data = {0};
   data.headers_next = &data.headers;
 
-  const char *usage[] =
-    {
-      APPNAME ": streaming CSV to json converter, or sqlite3 db to JSON converter",
-      "",
-      "Usage: ",
-      "   " APPNAME " [input.csv] [options]",
-      "   " APPNAME " --from-db <sqlite3_filename> [options]",
-      "",
-      "Options:",
-      "  -h, --help",
-      "  -o, --output <filename>       : output to specified filename",
-      "  --compact                     : output compact JSON",
-      "  --from-db                     : input is sqlite3 database",
-      "  --db-table <table_name>       : name of table in input database to convert",
-      "  --object                      : output as array of objects",
-      "  --no-empty                    : omit empty properties (only with --object)",
-      "  --database                    : output in database schema",
-      "  --no-header                   : treat the header row as a data row",
-      "  --index <name on expr>        : add index to database schema",
-      "  --unique-index <name on expr> : add unique index to database schema",
-      NULL
-    };
+  const char *usage[] = {
+    APPNAME ": streaming CSV to JSON converter, or SQLite3 DB to JSON converter",
+    "",
+    "Usage: " APPNAME " [options] [file.csv]",
+    "",
+    "Options:",
+    "  -h,--help                     : show usage",
+    "  -o,--output <filename>        : filename to write output to",
+    "  --compact                     : output compact JSON",
+    "  --from-db                     : input is sqlite3 database",
+    "  --db-table <table_name>       : name of table in input database to convert",
+    "  --object                      : output as array of objects",
+    "  --no-empty                    : omit empty properties (only with --object)",
+    "  --database                    : output in database schema",
+    "  --no-header                   : treat the header row as a data row",
+    "  --index <name_on_expr>        : add index to database schema",
+    "  --unique-index <name_on_expr> : add unique index to database schema",
+    NULL,
+  };
 
   FILE *out = NULL;
   const char *input_path = NULL;
   enum zsv_status err = zsv_status_ok;
   int done = 0;
-  
-  for(int i = 1; !err && !done && i < argc; i++) {
-    if(!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
-      for(int j = 0; usage[j]; j++)
+
+  for (int i = 1; !err && !done && i < argc; i++) {
+    if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
+      for (int j = 0; usage[j]; j++)
         fprintf(stdout, "%s\n", usage[j]);
       done = 1;
-    } else if(!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
-      if(++i >= argc)
-        fprintf(stderr, "%s option requires a filename value\n", argv[i-1]), err = zsv_status_error;
-      else if(out && out != stdout)
+    } else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
+      if (++i >= argc)
+        fprintf(stderr, "%s option requires a filename value\n", argv[i - 1]), err = zsv_status_error;
+      else if (out && out != stdout)
         fprintf(stderr, "Output file specified more than once\n"), err = zsv_status_error;
-      else if(!(out = fopen(argv[i], "wb")))
+      else if (!(out = fopen(argv[i], "wb")))
         fprintf(stderr, "Unable to open for writing: %s\n", argv[i]), err = zsv_status_error;
-    } else if(!strcmp(argv[i], "--index") || !strcmp(argv[i], "--unique-index")) {
-      if(++i >= argc)
-        fprintf(stderr, "%s option requires a filename value\n", argv[i-1]), err = zsv_status_error;
-      else if(data.indexes.count > LQ_2JSON_MAX_INDEXES)
+    } else if (!strcmp(argv[i], "--index") || !strcmp(argv[i], "--unique-index")) {
+      if (++i >= argc)
+        fprintf(stderr, "%s option requires a filename value\n", argv[i - 1]), err = zsv_status_error;
+      else if (data.indexes.count > LQ_2JSON_MAX_INDEXES)
         fprintf(stderr, "Max index count exceeded; ignoring %s\n", argv[i]), err = zsv_status_error;
-      else if(!strstr(argv[i], " on "))
-        fprintf(stderr, "Index value should be in the form of 'index_name on expr'; got %s\n", argv[i]), err = zsv_status_error;
+      else if (!strstr(argv[i], " on "))
+        fprintf(stderr, "Index value should be in the form of 'index_name on expr'; got %s\n", argv[i]),
+          err = zsv_status_error;
       else {
-        if(!strcmp(argv[i-1], "--unique-index"))
+        if (!strcmp(argv[i - 1], "--unique-index"))
           data.indexes.unique[data.indexes.count] = 1;
         data.indexes.clauses[data.indexes.count++] = argv[i];
       }
-    } else if(!strcmp(argv[i], "--no-empty")) {
+    } else if (!strcmp(argv[i], "--no-empty")) {
       data.no_empty = 1;
-    } else if(!strcmp(argv[i], "--db-table")) {
-      if(++i >= argc)
-        fprintf(stderr, "%s option requires a table name value\n", argv[i-1]), err = zsv_status_error;
-      else if(data.db_tablename)
-        fprintf(stderr, "%s option specified more than once\n", argv[i-1]), err = zsv_status_error;
+    } else if (!strcmp(argv[i], "--db-table")) {
+      if (++i >= argc)
+        fprintf(stderr, "%s option requires a table name value\n", argv[i - 1]), err = zsv_status_error;
+      else if (data.db_tablename)
+        fprintf(stderr, "%s option specified more than once\n", argv[i - 1]), err = zsv_status_error;
       else
         data.db_tablename = strdup(argv[i]);
-    } else if(!strcmp(argv[i], "--from-db")) {
-      if(++i >= argc)
-        fprintf(stderr, "%s option requires a filename value\n", argv[i-1]), err = zsv_status_error;
-      else if(opts->stream)
+    } else if (!strcmp(argv[i], "--from-db")) {
+      if (++i >= argc)
+        fprintf(stderr, "%s option requires a filename value\n", argv[i - 1]), err = zsv_status_error;
+      else if (opts->stream)
         fprintf(stderr, "Input file specified more than once\n"), err = zsv_status_error;
-      else if(!(opts->stream = fopen(argv[i], "rb")))
+      else if (!(opts->stream = fopen(argv[i], "rb")))
         fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = zsv_status_error;
       else {
         input_path = argv[i];
         data.from_db = 1;
       }
-    } else if(!strcmp(argv[i], "--database") || !strcmp(argv[i], "--object")) {
-      if(data.schema)
+    } else if (!strcmp(argv[i], "--database") || !strcmp(argv[i], "--object")) {
+      if (data.schema)
         fprintf(stderr, "Output schema specified more than once\n"), err = zsv_status_error;
-      else if(!strcmp(argv[i], "--database"))
+      else if (!strcmp(argv[i], "--database"))
         data.schema = ZSV_JSON_SCHEMA_DATABASE;
       else
         data.schema = ZSV_JSON_SCHEMA_OBJECT;
-    } else if(!strcmp(argv[i], "--no-header"))
+    } else if (!strcmp(argv[i], "--no-header"))
       data.no_header = 1;
-    else if(!strcmp(argv[i], "--compact"))
+    else if (!strcmp(argv[i], "--compact"))
       data.compact = 1;
     else {
-      if(opts->stream)
+      if (opts->stream)
         fprintf(stderr, "Input file specified more than once\n"), err = zsv_status_error;
-      else if(!(opts->stream = fopen(argv[i], "rb")))
+      else if (!(opts->stream = fopen(argv[i], "rb")))
         fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = zsv_status_error;
       else
         input_path = argv[i];
     }
   }
 
-  if(!(err || done)) {
-    if(data.indexes.count && data.schema != ZSV_JSON_SCHEMA_DATABASE)
+  if (!(err || done)) {
+    if (data.indexes.count && data.schema != ZSV_JSON_SCHEMA_DATABASE)
       fprintf(stderr, "--index/--unique-index can only be used with --database\n"), err = zsv_status_error;
-    else if(data.no_header && data.schema)
+    else if (data.no_header && data.schema)
       fprintf(stderr, "--no-header cannot be used together with --object or --database\n"), err = zsv_status_error;
-    else if(data.no_empty && data.schema != ZSV_JSON_SCHEMA_OBJECT)
+    else if (data.no_empty && data.schema != ZSV_JSON_SCHEMA_OBJECT)
       fprintf(stderr, "--no-empty can only be used with --object\n"), err = zsv_status_error;
-    else if(!opts->stream) {
-      if(data.from_db)
+    else if (!opts->stream) {
+      if (data.from_db)
         fprintf(stderr, "Database input specified, but no input file provided\n"), err = zsv_status_error;
       else {
 #ifdef NO_STDIN
@@ -341,16 +340,16 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     }
   }
 
-  if(!(err || done)) {
-    if(!out)
+  if (!(err || done)) {
+    if (!out)
       out = stdout;
-    if(!(data.jsw = jsonwriter_new(out)))
+    if (!(data.jsw = jsonwriter_new(out)))
       err = zsv_status_error;
     else {
-      if(data.compact)
+      if (data.compact)
         jsonwriter_set_option(data.jsw, jsonwriter_option_compact);
-      if(data.from_db) {
-        if(opts->stream != stdin) {
+      if (data.from_db) {
+        if (opts->stream != stdin) {
           fclose(opts->stream);
           opts->stream = NULL;
         }
@@ -358,11 +357,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       } else {
         opts->row_handler = zsv_2json_row;
         opts->ctx = &data;
-        if(zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &data.parser) == zsv_status_ok) {
+        if (zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &data.parser) == zsv_status_ok) {
           zsv_handle_ctrl_c_signal();
-          while(!data.err
-                && !zsv_signal_interrupted
-                && zsv_parse_more(data.parser) == zsv_status_ok)
+          while (!data.err && !zsv_signal_interrupted && zsv_parse_more(data.parser) == zsv_status_ok)
             ;
           zsv_finish(data.parser);
           zsv_delete(data.parser);
@@ -375,9 +372,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   }
 
   zsv_2json_cleanup(&data);
-  if(opts->stream && opts->stream != stdin)
+  if (opts->stream && opts->stream != stdin)
     fclose(opts->stream);
-  if(out && out != stdout)
+  if (out && out != stdout)
     fclose(out);
   return err;
 }

--- a/app/2tsv.c
+++ b/app/2tsv.c
@@ -38,10 +38,10 @@ __attribute__((always_inline)) static inline void zsv_2tsv_flush(struct static_b
 }
 
 static inline void zsv_2tsv_write(struct static_buff *b, const unsigned char *s, size_t n) {
-  if(n) {
-    if(VERY_UNLIKELY(n + b->used > ZSV_2TSV_BUFF_SIZE)) {
+  if (n) {
+    if (VERY_UNLIKELY(n + b->used > ZSV_2TSV_BUFF_SIZE)) {
       zsv_2tsv_flush(b);
-      if(VERY_UNLIKELY(n > ZSV_2TSV_BUFF_SIZE)) { // n too big, so write directly
+      if (VERY_UNLIKELY(n > ZSV_2TSV_BUFF_SIZE)) { // n too big, so write directly
         fwrite(s, n, 1, b->stream);
         return;
       }
@@ -56,24 +56,24 @@ static inline void zsv_2tsv_write(struct static_buff *b, const unsigned char *s,
 // - return NULL if nothing to convert
 // - else, return allocated char * of converted tsv (caller must free), and update *lenp
 // - on error, set *err
-__attribute__((always_inline)) static inline
-unsigned char *zsv_to_tsv(const unsigned char *utf8, size_t *len, enum zsv_2tsv_status *err) {
+__attribute__((always_inline)) static inline unsigned char *zsv_to_tsv(const unsigned char *utf8, size_t *len,
+                                                                       enum zsv_2tsv_status *err) {
   // replace tab, newline and lf with \t, \n or \r or backslash
   size_t do_convert = 0;
-  for(size_t i = 0; i < *len; i++) {
-    if(UNLIKELY(utf8[i] == '\t' || utf8[i] == '\n' || utf8[i] == '\r' || utf8[i] == '\\'))
+  for (size_t i = 0; i < *len; i++) {
+    if (UNLIKELY(utf8[i] == '\t' || utf8[i] == '\n' || utf8[i] == '\r' || utf8[i] == '\\'))
       do_convert++;
   }
-  if(LIKELY(do_convert == 0))
+  if (LIKELY(do_convert == 0))
     return NULL;
 
   unsigned char *converted = malloc(*len + do_convert + 1);
-  if(!converted)
+  if (!converted)
     *err = zsv_2tsv_status_out_of_memory;
   else {
     size_t j = 0;
-    for(size_t i = 0; i < *len; i++) {
-      if(UNLIKELY(utf8[i] == '\t' || utf8[i] == '\n' || utf8[i] == '\r' || utf8[i] == '\\')) {
+    for (size_t i = 0; i < *len; i++) {
+      if (UNLIKELY(utf8[i] == '\t' || utf8[i] == '\n' || utf8[i] == '\r' || utf8[i] == '\\')) {
         converted[j++] = '\\';
         converted[j++] = utf8[i] == '\t' ? 't' : utf8[i] == '\n' ? 'n' : utf8[i] == '\r' ? 'r' : '\\';
       } else
@@ -85,23 +85,22 @@ unsigned char *zsv_to_tsv(const unsigned char *utf8, size_t *len, enum zsv_2tsv_
   return converted;
 }
 
-__attribute__((always_inline)) static inline
-void zsv_2tsv_cell(struct zsv_2tsv_data *data, unsigned char *utf8_value, size_t len,
-                   char no_newline_or_slash) {
+__attribute__((always_inline)) static inline void zsv_2tsv_cell(struct zsv_2tsv_data *data, unsigned char *utf8_value,
+                                                                size_t len, char no_newline_or_slash) {
   // output cell contents (converted if necessary)
-  if(len) {
+  if (len) {
     enum zsv_2tsv_status err = zsv_2tsv_status_ok;
-    if(VERY_LIKELY(no_newline_or_slash && !memchr(utf8_value, '\t', len))) {
+    if (VERY_LIKELY(no_newline_or_slash && !memchr(utf8_value, '\t', len))) {
       zsv_2tsv_write(&data->out, utf8_value, len);
       return;
     }
 
     // if we're here, there either definitely an embedded tab, or maybe an embedded \n or \r
     unsigned char *converted = zsv_to_tsv(utf8_value, &len, &err);
-    if(converted != NULL) {
+    if (converted != NULL) {
       zsv_2tsv_write(&data->out, converted, len);
       free(converted);
-    } else if(UNLIKELY(err))
+    } else if (UNLIKELY(err))
       fprintf(stderr, "Out of memory!\n");
     else
       zsv_2tsv_write(&data->out, utf8_value, len);
@@ -111,75 +110,72 @@ void zsv_2tsv_cell(struct zsv_2tsv_data *data, unsigned char *utf8_value, size_t
 static void zsv_2tsv_row(void *ctx) {
   struct zsv_2tsv_data *data = ctx;
   unsigned int cols = zsv_cell_count(data->parser);
-  if(cols) {
+  if (cols) {
     struct zsv_cell cell = zsv_get_cell(data->parser, 0);
-    struct zsv_cell end = zsv_get_cell(data->parser, cols-1);
+    struct zsv_cell end = zsv_get_cell(data->parser, cols - 1);
     unsigned char *start = cell.str;
     size_t row_len = end.str + end.len - start;
     char no_newline_or_slash = 0;
-    if(LIKELY(!(
-                memchr(start, '\n', row_len) ||
-                memchr(start, '\r', row_len) ||
-                memchr(start, '\\', row_len)
-                )))
+    if (LIKELY(!(memchr(start, '\n', row_len) || memchr(start, '\r', row_len) || memchr(start, '\\', row_len))))
       no_newline_or_slash = 1;
 
     zsv_2tsv_cell(ctx, cell.str, cell.len, no_newline_or_slash);
-    for(unsigned int i = 1; i < cols; i++) {
+    for (unsigned int i = 1; i < cols; i++) {
       zsv_2tsv_write(&data->out, (const unsigned char *)"\t", 1);
       cell = zsv_get_cell(data->parser, i);
       zsv_2tsv_cell(ctx, cell.str, cell.len, no_newline_or_slash);
     }
   }
-  zsv_2tsv_write(&data->out, (const unsigned char *) "\n", 1);
+  zsv_2tsv_write(&data->out, (const unsigned char *)"\n", 1);
 }
 
 int zsv_2tsv_usage(int rc) {
-  static const char *zsv_2tsv_usage_msg[] =
-    {
-      APPNAME ": convert CSV to TSV (tab-delimited text) suitable for simple-delimiter",
-      "       text processing. By default, embedded tabs or multilines will be escaped",
-      "       to \\t, \\n or \\r, respectively",
-      "",
-      "Usage: " APPNAME " [filename] [-o <output_filename>]",
-      "  e.g. " APPNAME " < myfile.csv > myfile.tsv",
-      NULL
-    };
-  for(int i = 0; zsv_2tsv_usage_msg[i]; i++)
+  static const char *zsv_2tsv_usage_msg[] = {
+    APPNAME ": convert CSV to TSV (tab-delimited text) suitable for simple-delimiter",
+    "          text processing. By default, embedded tabs or multilines will be escaped",
+    "          to \\t, \\n or \\r, respectively",
+    "",
+    "Usage: " APPNAME " [filename] [-o <output_filename>]",
+    "  e.g. " APPNAME " < file.csv > file.tsv",
+    NULL,
+  };
+
+  for (size_t i = 0; zsv_2tsv_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_2tsv_usage_msg[i]);
 
   return rc;
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  struct zsv_2tsv_data data = { 0 };
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  struct zsv_2tsv_data data = {0};
   const char *input_path = NULL;
   int err = 0;
-  for(int i = 1; !err && i < argc; i++) {
-    if(!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
+  for (int i = 1; !err && i < argc; i++) {
+    if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
       return zsv_2tsv_usage(0);
-    } else if(!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
-      if(++i >= argc)
-        fprintf(stderr, "%s option requires a filename value\n", argv[i-1]), err = 1;
-      else if(data.out.stream && data.out.stream != stdout)
+    } else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
+      if (++i >= argc)
+        fprintf(stderr, "%s option requires a filename value\n", argv[i - 1]), err = 1;
+      else if (data.out.stream && data.out.stream != stdout)
         fprintf(stderr, "Output file specified more than once\n"), err = 1;
-      else if(!(data.out.stream = fopen(argv[i], "wb")))
+      else if (!(data.out.stream = fopen(argv[i], "wb")))
         fprintf(stderr, "Unable to open for writing: %s\n", argv[i]), err = 1;
     } else {
-      if(opts->stream)
+      if (opts->stream)
         fprintf(stderr, "Input file specified more than once\n"), err = 1;
-      else if(!(opts->stream = fopen(argv[i], "rb")))
+      else if (!(opts->stream = fopen(argv[i], "rb")))
         fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = 1;
       else
-       input_path = argv[i];
+        input_path = argv[i];
     }
   }
 
-  if(err) {
+  if (err) {
     goto exit_2tsv;
   }
 
-  if(!opts->stream) {
+  if (!opts->stream) {
 #ifdef NO_STDIN
     fprintf(stderr, "Please specify an input file\n");
     err = 1;
@@ -189,29 +185,28 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #endif
   }
 
-  if(!data.out.stream)
+  if (!data.out.stream)
     data.out.stream = stdout;
 
   opts->row_handler = zsv_2tsv_row;
   opts->ctx = &data;
-  if(zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &data.parser) == zsv_status_ok) {
+  if (zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &data.parser) == zsv_status_ok) {
     char output[ZSV_2TSV_BUFF_SIZE];
     data.out.buff = output;
 
     zsv_handle_ctrl_c_signal();
     enum zsv_status status;
-    while(!zsv_signal_interrupted
-          && (status = zsv_parse_more(data.parser)) == zsv_status_ok)
+    while (!zsv_signal_interrupted && (status = zsv_parse_more(data.parser)) == zsv_status_ok)
       ;
     zsv_finish(data.parser);
     zsv_delete(data.parser);
     zsv_2tsv_flush(&data.out);
   }
 
- exit_2tsv:
-  if(opts->stream && opts->stream != stdin)
+exit_2tsv:
+  if (opts->stream && opts->stream != stdin)
     fclose(opts->stream);
-  if(data.out.stream && data.out.stream != stdout)
+  if (data.out.stream && data.out.stream != stdout)
     fclose(data.out.stream);
   return err;
 }

--- a/app/2tsv.c
+++ b/app/2tsv.c
@@ -14,7 +14,8 @@
 
 #include <zsv/utils/utf8.h>
 
-enum zsv_2tsv_status {
+enum zsv_2tsv_status
+{
   zsv_2tsv_status_ok = 0,
   zsv_2tsv_status_out_of_memory
 };

--- a/app/2tsv.c
+++ b/app/2tsv.c
@@ -14,8 +14,7 @@
 
 #include <zsv/utils/utf8.h>
 
-enum zsv_2tsv_status
-{
+enum zsv_2tsv_status {
   zsv_2tsv_status_ok = 0,
   zsv_2tsv_status_out_of_memory
 };

--- a/app/benchmark/README.md
+++ b/app/benchmark/README.md
@@ -1,107 +1,121 @@
-## ZSV Benchmarks
+# zsv benchmarks
 
-### Summary
-* zsv/lib is still in alpha development. Everything here is preliminary
-* These benchmarks are enough to be suggestive but not enough to be conclusive. They were run on a limited variety of hardware, OS platforms and build options. YMMV depending on OS, processor and compilation flags/options
-* zsv performed faster than all other utilities tested; on our test system (OSX) by ~1.5x-27x, by similar or smaller margins
-  (in each case we tested, by at least 20%) on other operating systems
-* Four utilities were tested: zsv, xsv, tsv-utils and mlr
-* The below figured were based on results from runs on OSX (Intel). Similar results were observed on other operating systems, but in some cases the difference was significantly smaller (for example, zsv
-* On most platforms, zsv performed about 2x as fast as xsv, 1.5-2x as fast as tsv-utils, and 25x+ faster than mlr or the python csv-utils family
+## Summary
+
+- zsv/lib is still in alpha development. Everything here is preliminary.
+- These benchmarks are enough to be suggestive but not enough to be conclusive.
+  They were run on a limited variety of hardware, OS platforms and build
+  options. YMMV depending on OS, processor and compilation flags/options
+- zsv performed faster than all other utilities tested; on our test system (OSX)
+  by ~1.5x-27x, by similar or smaller margins (in each case we tested, by at
+  least 20%) on other operating systems
+- Four utilities were tested: zsv, xsv, tsv-utils and mlr
+- The below figured were based on results from runs on OSX (Intel). Similar
+  results were observed on other operating systems, but in some cases the
+  difference was significantly smaller (for example, `zsv`)
+- On most platforms, `zsv` performed about 2x as fast as xsv, 1.5-2x as fast as
+  `tsv-utils`, and 25x+ faster than `mlr` or the python csv-utils family.
 
 ![image](https://user-images.githubusercontent.com/26302468/146497899-48174114-3b18-49b0-97da-35754ab56e48.png)
 ![image](https://user-images.githubusercontent.com/26302468/146498211-afc77ce6-4229-4599-bf33-81bf00c725a8.png)
 
 Apple M1 chip (updated 7/3/2022)
 
-`zsv`'s performance advantage when running on the M1 chip is still noticeable, but is narrower:
-`count` is about 15-20% faster; `select` is about 25-30% faster. Other operations and comparisons were not tested on this platform.
+`zsv`'s performance advantage when running on the M1 chip is still noticeable,
+but is narrower: `count` is about 15-20% faster; `select` is about 25-30%
+faster. Other operations and comparisons were not tested on this platform.
 
-The main difference in the instructions generated for M1 is the smaller 128bit vector size (see e.g. https://lemire.me/blog/2020/12/13/arm-macbook-vs-intel-macbook-a-simd-benchmark/) and the lack of an M1 `movemask` intrinsic.
+The main difference in the instructions generated for M1 is the smaller 128bit
+vector size (see e.g.
+<https://lemire.me/blog/2020/12/13/arm-macbook-vs-intel-macbook-a-simd-benchmark/>)
+and the lack of an M1 `movemask` intrinsic.
 
-### Choice of tests and input data
+## Choice of tests and input data
 
-Two tests, "count" and "select", were chosen to most closely track
-raw CSV parsing performance, and to reduce the impact of other
-processing tasks (for example, "search" was not tested because that would
-primarily measure the performance of the search algorithm rather than
-the CSV parser).
+Two tests, "count" and "select", were chosen to most closely track raw CSV
+parsing performance, and to reduce the impact of other processing tasks (for
+example, "search" was not tested because that would primarily measure the
+performance of the search algorithm rather than the CSV parser).
 
 We used a range of input data for our internal tests, all of which yielded
-results that were consistent with the benchmark tests. For the benchmark
-tests, we used the same dataset that xsv uses for its benchmark tests.
+results that were consistent with the benchmark tests. For the benchmark tests,
+we used the same dataset that xsv uses for its benchmark tests.
 
-Another factor we considered was the impact of I/O overhead. Because the
-"count" and "select" operations are relatively fast (compared to, for example,
-regular expression matching), it is possible that the entire test may be
-I/O bound and that the results might primarily just measuring I/O speed
-which could have enough variability to swamp any performance differences
-attributable to the particular utility being run. This consideration did
-not turn out to be an issue, as the results differed for each utility
-by consistent and statistically significant amounts.
+Another factor we considered was the impact of I/O overhead. Because the "count"
+and "select" operations are relatively fast (compared to, for example, regular
+expression matching), it is possible that the entire test may be I/O bound and
+that the results might primarily just measuring I/O speed which could have
+enough variability to swamp any performance differences attributable to the
+particular utility being run. This consideration did not turn out to be an
+issue, as the results differed for each utility by consistent and statistically
+significant amounts.
 
-### Limitations
+## Limitations
 
 These benchmarks are obviously extremely limited. However, we believe they are
 sufficient to show the relative performance of zsv as compared to other similar
 utilities. While there were statistically significant differences in relative
-performance depending on various factors such as the number of columns extracted,
-the number of columns per row of data, the average size of each data column,
-the frequency of cells that were quoted and/or require quote escaping, and other
-various factors.
+performance depending on various factors such as the number of columns
+extracted, the number of columns per row of data, the average size of each data
+column, the frequency of cells that were quoted and/or require quote escaping,
+and other various factors.
 
-### Test environment
+## Test environment
 
-Below are reported from tests run on OSX (Intel). Similar results were achieved on Windows, Linux and
-FreeBSD. See above note for results on M1.
+Below are reported from tests run on OSX (Intel). Similar results were achieved
+on Windows, Linux and FreeBSD. See above note for results on M1.
 
-In some cases, especially on Windows, compiler settings had a significant impact.
-If you observe results that materially differ, in terms of zsv vs other utility performance,
-from what shown below, please let us know.
+In some cases, especially on Windows, compiler settings had a significant
+impact. If you observe results that materially differ, in terms of zsv vs other
+utility performance, from what shown below, please let us know.
 
-
-### Utilities compared:
+## Utilities compared
 
 The following utilities were compared:
 
-* `xsv`: version 0.13.0, installed via brew
-* `tsv-utils` (v2.2.1): installed via download of pre-built PGO-optimized binaries
-* `mlr` (5.10.2): installed via brew (not shown in graph-- very slow compared to others)
-* `zsv` (alpha): built from source using the default `configure` settings
-* `csvcut` (1.0.6) (not shown in graph-- very slow compared to others)
+- `xsv`: version 0.13.0, installed via brew
+- `tsv-utils` (v2.2.1): installed via download of pre-built PGO-optimized binaries
+- `mlr` (5.10.2): installed via brew (not shown in graph-- very slow compared to others)
+- `zsv` (alpha): built from source using the default `configure` settings
+- `csvcut` (1.0.6) (not shown in graph-- very slow compared to others)
 
-### Further notes:
+## Further notes
 
-* `tsv-util` using a comma delimiter does *not* handle quoted data,
-  unlike xsv (and zsv), and thus its output may be incorrect. For this reason,
-  these tests ran tsv-utils both using a custom delimiter, and also on TSV data
-  that had been converted from the original CSV data. The performance in either case
+- `tsv-util` using a comma delimiter does *not* handle quoted data, unlike `xsv`
+  (and `zsv`), and thus its output may be incorrect. For this reason, these
+  tests ran `tsv-utils` both using a custom delimiter, and also on TSV data that
+  had been converted from the original CSV data. The performance in either case
   was effectively the same
 
-* `mlr` and `csvcut` are not shown in the graph since their performance was well over 10x slower
-  than the others. `mlr` was included in the test was to compare with
-  another solution written in the same language (i.e. C) as zsv, since
-  tsv-utils, xsv and zsv are all written in different languages, and `csvcut` was
-  included since csvcut/csvkit seem to be fairly commonly used for CSV processing
+- `mlr` and `csvcut` are not shown in the graph since their performance was well
+  over 10x slower than the others. `mlr` was included in the test was to compare
+  with another solution written in the same language (i.e. C) as zsv, since
+  `tsv-utils`, `xsv` and `zsv` are all written in different languages, and
+  `csvcut` was included since `csvcut`/`csvkit` seem to be fairly commonly used
+  for CSV processing.
 
-* Our test system shown in the above graph was a pre-M1 OSX MBA.
-  We also tested on Linux, BSD
-  and Windows. In each case, zsv was the fastest, but in some cases the margin
-  was smaller (e.g. 20%+ instead of 50% vs xsv on Win).
+- Our test system shown in the above graph was a pre-M1 OSX MBA. We also tested
+  on Linux, BSD and Windows. In each case, zsv was the fastest, but in some
+  cases the margin was smaller (e.g. 20%+ instead of 50% vs xsv on Win).
 
-### Results in above graph (pre-M1 OSX MBA)
+## Results in above graph (pre-M1 OSX MBA)
 
-#### count (5 runs, excluding first run)
+### count (5 runs, excluding first run)
 
-zsv:  0.076
-xsv:  0.151
-tsv-utils: 0.150
-mlr: not run
-csvcut: n/a
+|    tool     | results |
+| :---------: | :-----: |
+|    `zsv`    |  0.076  |
+|    `xsv`    |  0.151  |
+| `tsv-utils` |  0.150  |
+|    `mlr`    | not run |
+|  `csvcut`   |   n/a   |
 
-#### select (5 runs, excluding first run)
-zsv: 0.162
-xsv: 0.327
-tsv-utils: 0.24
-csvcut: 6.88
-mlr: 4.53
+### select (5 runs, excluding first run)
+
+|    tool     | results |
+| :---------: | :-----: |
+|    `zsv`    |  0.162  |
+|    `xsv`    |  0.327  |
+| `tsv-utils` |  0.24   |
+|    `mlr`    |  4.53   |
+|  `csvcut`   |  6.88   |

--- a/app/benchmark/README.md
+++ b/app/benchmark/README.md
@@ -9,7 +9,7 @@
 - zsv performed faster than all other utilities tested; on our test system (OSX)
   by ~1.5x-27x, by similar or smaller margins (in each case we tested, by at
   least 20%) on other operating systems
-- Four utilities were tested: zsv, xsv, tsv-utils and mlr
+- Four utilities were tested: `zsv`, `xsv`, `tsv-utils` and `mlr`
 - The below figured were based on results from runs on OSX (Intel). Similar
   results were observed on other operating systems, but in some cases the
   difference was significantly smaller (for example, `zsv`)

--- a/app/builtin/help.c
+++ b/app/builtin/help.c
@@ -20,12 +20,12 @@ static int main_help(int argc, const char *argv[]) {
     "  zsv (un)register [<extension_id>]: (un)register an extension",
     "      Registration info is saved in zsv.ini located in a directory determined as:",
     "        ZSV_CONFIG_DIR environment variable value, if set",
-# if defined(_WIN32)
+#if defined(_WIN32)
     "        LOCALAPPDATA environment variable value, if set",
     "        otherwise, C:\\temp",
 #else
     "        otherwise, " PREFIX "/etc",
-# endif
+#endif
 #endif
     "  zsv help [<command>]",
     "  zsv <command> <options> <arguments>: run a command on data (see below for details)",
@@ -45,8 +45,9 @@ static int main_help(int argc, const char *argv[]) {
     "  -q,--no-quote            : turn off quote handling",
     "  -R,--skip-head <n>       : skip specified number of initial rows",
     "  -d,--header-row-span <n> : apply header depth (rowspan) of n",
-    "  -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed UTF8 input",
-    "       (default for \"desc\" commamnd is '?')",
+    "  -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed "
+    "UTF8 input",
+    "       (default for \"desc\" command is '?')",
     "  -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows",
     "  -0,--header-row <header> : insert the provided CSV as the first row (in position 0)",
     "                             e.g. --header-row 'col1,col2,\"my col 3\"'",
@@ -76,31 +77,30 @@ static int main_help(int argc, const char *argv[]) {
 #ifdef USE_JQ
     "  jq       : run a jq filter on json input",
 #endif
-    NULL
-  };
+    NULL};
 
-  for(int i = 0; usage[i]; i++)
+  for (int i = 0; usage[i]; i++)
     fprintf(f, "%s\n", usage[i]);
 
   char printed_init = 0;
   struct cli_config config;
-  if(!config_init(&config, 1, 1, 0)) {
-    for(struct zsv_ext *ext = config.extensions; ext; ext = ext->next) {
-      if(ext->inited == zsv_init_ok) {
-        if(!printed_init) {
+  if (!config_init(&config, 1, 1, 0)) {
+    for (struct zsv_ext *ext = config.extensions; ext; ext = ext->next) {
+      if (ext->inited == zsv_init_ok) {
+        if (!printed_init) {
           printed_init = 1;
           fprintf(f, "\nExtended commands:\n");
         } else
           fprintf(f, "\n");
-        if(ext->help)
+        if (ext->help)
           fprintf(f, "  Extension '%s': %s\n", ext->id, ext->help);
-        for(struct zsv_ext_command *cmd = ext->commands; cmd; cmd = cmd->next)
+        for (struct zsv_ext_command *cmd = ext->commands; cmd; cmd = cmd->next)
           fprintf(f, "    %s-%s%s%s\n", ext->id, cmd->id, cmd->help ? ": " : "", cmd->help ? cmd->help : "");
       }
     }
     config_free(&config);
   }
-  if(!printed_init)
+  if (!printed_init)
     fprintf(f, "\n(No extended commands)\n");
 
   return 0;

--- a/app/builtin/help.c
+++ b/app/builtin/help.c
@@ -17,7 +17,7 @@ static int main_help(int argc, const char *argv[]) {
     "Usage:",
     "  zsv version: display version info (and if applicable, extension info)",
 #ifndef __EMSCRIPTEN__
-    "  zsv (un)register [<extension_id>]: (un)register an extension",
+    "  zsv (un)register [<extension_id>]    : (un)register an extension",
     "      Registration info is saved in zsv.ini located in a directory determined as:",
     "        ZSV_CONFIG_DIR environment variable value, if set",
 #if defined(_WIN32)
@@ -28,9 +28,9 @@ static int main_help(int argc, const char *argv[]) {
 #endif
 #endif
     "  zsv help [<command>]",
-    "  zsv <command> <options> <arguments>: run a command on data (see below for details)",
-    "  zsv <id>-<cmd> <options> <arguments>: invoke command 'cmd' of extension 'id'",
-    "  zsv thirdparty: view third-party licenses & acknowledgements",
+    "  zsv <command> <options> <arguments>  : run a command on data (see below for details)",
+    "  zsv <id>-<cmd> <options> <arguments> : invoke command 'cmd' of extension 'id'",
+    "  zsv thirdparty                       : view third-party licenses & acknowledgements",
     "  zsv license [<extension_id>]",
     "",
     "Options common to all commands except `prop`, `rm` and `jq`:",
@@ -45,13 +45,12 @@ static int main_help(int argc, const char *argv[]) {
     "  -q,--no-quote            : turn off quote handling",
     "  -R,--skip-head <n>       : skip specified number of initial rows",
     "  -d,--header-row-span <n> : apply header depth (rowspan) of n",
-    "  -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed "
-    "UTF8 input",
+    "  -u,--malformed-utf8-replacement <string>: replacement string (can be empty) in case of malformed UTF8 input",
     "       (default for \"desc\" command is '?')",
     "  -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows",
     "  -0,--header-row <header> : insert the provided CSV as the first row (in position 0)",
     "                             e.g. --header-row 'col1,col2,\"my col 3\"'",
-    "  -v,--verbose: verbose output",
+    "  -v,--verbose             : verbose output",
     "",
     "Commands that parse CSV or other tabular data:",
     "  select   : extract rows/columns by name or position and perform other basic and 'cleanup' operations",
@@ -77,9 +76,10 @@ static int main_help(int argc, const char *argv[]) {
 #ifdef USE_JQ
     "  jq       : run a jq filter on json input",
 #endif
-    NULL};
+    NULL,
+  };
 
-  for (int i = 0; usage[i]; i++)
+  for (size_t i = 0; usage[i]; i++)
     fprintf(f, "%s\n", usage[i]);
 
   char printed_init = 0;

--- a/app/builtin/license.c
+++ b/app/builtin/license.c
@@ -19,15 +19,15 @@ static int main_license(int argc, const char *argv[]) {
   fwrite(zsv_license_text_MIT, 1, strlen(zsv_license_text_MIT), stdout);
 
   struct cli_config config;
-  if(!config_init(&config, 0, 1, 0)) {
-    for(struct zsv_ext *ext = config.extensions; ext; ext = ext->next) {
+  if (!config_init(&config, 0, 1, 0)) {
+    for (struct zsv_ext *ext = config.extensions; ext; ext = ext->next) {
       printf("\n====================================================\n");
       printf("License for extension '%s'", ext->id);
       printf("\n====================================================\n");
-      if(ext->license && *ext->license) {
+      if (ext->license && *ext->license) {
         size_t len = strlen(ext->license);
         fwrite(ext->license, 1, len, stdout);
-        if(ext->license[len-1] != '\n')
+        if (ext->license[len - 1] != '\n')
           printf("\n");
       } else
         printf("Unknown\n");

--- a/app/builtin/register.c
+++ b/app/builtin/register.c
@@ -18,24 +18,20 @@ static int check_extension(struct zsv_ext *ext) {
    * check that each extension command supports `zsv my-cmd --help`;
    *   redirect, examine & restore stdin/out/err
    */
-  if(!ext)
+  if (!ext)
     return 1;
 
   ext_init(ext);
-  if(ext->inited != zsv_init_ok)
+  if (ext->inited != zsv_init_ok)
     return 1;
   return 0;
 }
 
 static int register_help(char do_register) {
-  static const char *register_help =
-    "zsv register: register an extension\n\n"
-    "usage: zsv register <extension_id>"
-    ;
-  static const char *unregister_help =
-    "zsv unregister: unregister an extension\n\n"
-    "usage: zsv unregister <extension_id>"
-    ;
+  static const char *register_help = "zsv register: register an extension\n\n"
+                                     "usage: zsv register <extension_id>";
+  static const char *unregister_help = "zsv unregister: unregister an extension\n\n"
+                                       "usage: zsv unregister <extension_id>";
   printf("%s\n", do_register ? register_help : unregister_help);
   return 0;
 }
@@ -46,38 +42,38 @@ static int main_register_aux(int argc, const char *argv[]) {
   char do_register = *argv[0] == 'r';
   const char *extension_id = argc < 2 ? NULL : argv[1];
 
-  if(argc < 2)
+  if (argc < 2)
     fprintf(stderr, "No extension id provided\n"), err = 1;
-  else if(!strcmp(extension_id, "--help") || !strcmp(extension_id, "-h"))
+  else if (!strcmp(extension_id, "--help") || !strcmp(extension_id, "-h"))
     return register_help(do_register);
-  else if(strlen(extension_id) != 2)
+  else if (strlen(extension_id) != 2)
     fprintf(stderr, "Extension id must be exactly two characters\n"), err = 1;
-  else if(config_init(&config, !do_register, 1, 1))
+  else if (config_init(&config, !do_register, 1, 1))
     config_free(&config); // unable to init config
   else {
     struct zsv_ext *found;
-    if((found = find_extension(&config, extension_id))) {
+    if ((found = find_extension(&config, extension_id))) {
       // found this extension registered
-      if(do_register) {
+      if (do_register) {
         fprintf(stderr, "Extension %s already registered\n", extension_id), err = 1;
         check_extension(found);
       }
       // unregister
-      else if(!(err = remove_extension(&config.extensions, found)))
-        if(!(err = config_save(&config)))
+      else if (!(err = remove_extension(&config.extensions, found)))
+        if (!(err = config_save(&config)))
           fprintf(stderr, "Extension %s unregistered\n", extension_id);
     } else {
       // this extension has not been registered
-      if(!do_register)
+      if (!do_register)
         fprintf(stderr, "Extension %s was not already registered\n", extension_id), err = 1;
 
       // register
       else {
         // confirm we can successfully load dll, then register
         // add_extension() adds this extension to the front of the list
-        if(!(err = add_extension(extension_id, &config.extensions, 1, 1))) {
-          if(!check_extension(config.extensions)) {
-            if(!(err = config_save(&config)))
+        if (!(err = add_extension(extension_id, &config.extensions, 1, 1))) {
+          if (!check_extension(config.extensions)) {
+            if (!(err = config_save(&config)))
               fprintf(stderr, "Extension %s registered\n", extension_id);
           }
         }

--- a/app/builtin/thirdparty.c
+++ b/app/builtin/thirdparty.c
@@ -8,9 +8,9 @@
 
 static void print_str_array(const char *name, const char *name2, const char **ss) {
   printf("\n\n==========================\n%s%s\n==========================\n", name, name2 ? name2 : "?");
-  if(!ss)
+  if (!ss)
     printf("No third-party information\n");
-  for(int i = 0; ss && ss[i]; i++) {
+  for (int i = 0; ss && ss[i]; i++) {
     const char *s = ss[i];
     fwrite(s, 1, strlen(s), stdout);
   }
@@ -20,15 +20,15 @@ static int main_thirdparty(int argc, const char *argv[]) {
   (void)(argc);
   (void)(argv);
 
-  printf("Third-party licenses and acknowldgements");
+  printf("Third-party licenses and acknowledgements");
   print_str_array("ZSV/lib third-party dependencies", "", zsv_thirdparty);
 
   struct cli_config config;
   const char *ss[2];
   ss[1] = NULL;
-  if(!config_init(&config, 0, 1, 0)) {
-    for(struct zsv_ext *ext = config.extensions; ext; ext = ext->next) {
-      if(ext->thirdparty) {
+  if (!config_init(&config, 0, 1, 0)) {
+    for (struct zsv_ext *ext = config.extensions; ext; ext = ext->next) {
+      if (ext->thirdparty) {
         ss[0] = ext->thirdparty;
         print_str_array("Extension: ", (const char *)ext->id, ss);
       }

--- a/app/cli.c
+++ b/app/cli.c
@@ -32,8 +32,9 @@ static struct zsv_ext *zsv_ext_new(const char *dl_name, const char *id, char ver
 
 #include "cli_ini.c"
 
-typedef int (cmd_main)(int argc, const char *argv[]);
-typedef int (zsv_cmd)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used);
+typedef int(cmd_main)(int argc, const char *argv[]);
+typedef int(zsv_cmd)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler,
+                     const char *opts_used);
 typedef int (*cmd_reserved)();
 
 struct builtin_cmd {
@@ -44,9 +45,9 @@ struct builtin_cmd {
 
 #include "zsv_main.h"
 
-#define CLI_BUILTIN_DECL(x) int main_ ## x(int argc, const char *argv[])
+#define CLI_BUILTIN_DECL(x) int main_##x(int argc, const char *argv[])
 
-#define CLI_BUILTIN_DECL_STATIC(x) static int main_ ## x(int argc, const char *argv[])
+#define CLI_BUILTIN_DECL_STATIC(x) static int main_##x(int argc, const char *argv[])
 
 CLI_BUILTIN_DECL_STATIC(license);
 CLI_BUILTIN_DECL_STATIC(thirdparty);
@@ -77,9 +78,12 @@ ZSV_MAIN_NO_OPTIONS_DECL(mv);
 ZSV_MAIN_NO_OPTIONS_DECL(jq);
 #endif
 
-#define CLI_BUILTIN_CMD(x) { .name = #x, .main = main_ ## x, .cmd = NULL }
-#define CLI_BUILTIN_COMMAND(x) { .name = #x, .main = NULL, .cmd = ZSV_MAIN_FUNC(x) }
-#define CLI_BUILTIN_NO_OPTIONS_COMMAND(x) { .name = #x, .main = ZSV_MAIN_NO_OPTIONS_FUNC(x), .cmd = NULL }
+#define CLI_BUILTIN_CMD(x) {.name = #x, .main = main_##x, .cmd = NULL}
+#define CLI_BUILTIN_COMMAND(x) {.name = #x, .main = NULL, .cmd = ZSV_MAIN_FUNC(x)}
+#define CLI_BUILTIN_NO_OPTIONS_COMMAND(x) {.name = #x, .main = ZSV_MAIN_NO_OPTIONS_FUNC(x), .cmd = NULL}
+
+// clang-format off
+
 struct builtin_cmd builtin_cmds[] = {
   CLI_BUILTIN_CMD(license),
   CLI_BUILTIN_CMD(thirdparty),
@@ -104,11 +108,13 @@ struct builtin_cmd builtin_cmds[] = {
   CLI_BUILTIN_COMMAND(echo),
   CLI_BUILTIN_NO_OPTIONS_COMMAND(prop),
   CLI_BUILTIN_NO_OPTIONS_COMMAND(rm),
-  CLI_BUILTIN_NO_OPTIONS_COMMAND(mv)
+  CLI_BUILTIN_NO_OPTIONS_COMMAND(mv),
 #ifdef USE_JQ
-  , CLI_BUILTIN_NO_OPTIONS_COMMAND(jq)
+  CLI_BUILTIN_NO_OPTIONS_COMMAND(jq),
 #endif
 };
+
+// clang-format on
 
 struct zsv_execution_data {
   struct zsv_ext *ext;
@@ -137,15 +143,15 @@ static enum zsv_ext_status ext_init(struct zsv_ext *ext);
 static int config_init(struct cli_config *c, char err_if_dl_not_found, char do_init, char verbose) {
   memset(c, 0, sizeof(*c));
   size_t len = get_ini_file(c->filepath, FILENAME_MAX);
-  if(!len) {
+  if (!len) {
     fprintf(stderr, "Unable to get config filepath!\n");
     return 1;
   }
 
   int rc = parse_extensions_ini(c, err_if_dl_not_found, verbose);
-  if(rc == 0 && do_init) {
-    for(struct zsv_ext *ext = c->extensions; ext; ext = ext->next) {
-      if(ext_init(ext) != zsv_ext_status_ok)
+  if (rc == 0 && do_init) {
+    for (struct zsv_ext *ext = c->extensions; ext; ext = ext->next) {
+      if (ext_init(ext) != zsv_ext_status_ok)
         fprintf(stderr, "Error: unable to initialize extension %s\n", ext->id);
     }
   }
@@ -180,8 +186,7 @@ static void execution_context_free(struct zsv_execution_data *d) {
   (void)(d);
 }
 
-static enum zsv_ext_status execution_context_init(struct zsv_execution_data *d,
-                                                  int argc, const char *argv[]) {
+static enum zsv_ext_status execution_context_init(struct zsv_execution_data *d, int argc, const char *argv[]) {
   memset(d, 0, sizeof(*d));
   d->argv = argv;
   d->argc = argc;
@@ -189,13 +194,13 @@ static enum zsv_ext_status execution_context_init(struct zsv_execution_data *d,
 }
 
 static char *zsv_ext_errmsg(enum zsv_ext_status stat, zsv_execution_context ctx) {
-  switch(stat) {
+  switch (stat) {
   case zsv_ext_status_ok:
     return strdup("No error");
   case zsv_ext_status_memory:
     return strdup("Out of memory");
   case zsv_ext_status_unrecognized_cmd:
-    if(!(ctx && ((struct zsv_execution_data *)ctx)->argc > 0))
+    if (!(ctx && ((struct zsv_execution_data *)ctx)->argc > 0))
       return strdup("Unrecognized command");
     else {
       char *s;
@@ -203,30 +208,29 @@ static char *zsv_ext_errmsg(enum zsv_ext_status stat, zsv_execution_context ctx)
       asprintf(&s, "Unrecognized command %s", d->argv[1]);
       return s;
     }
-    /* use zsv_ext_status_other for silent errors. will not attempt to call errcode() or errstr() */
+    // use zsv_ext_status_other for silent errors. will not attempt to call errcode() or errstr()
   case zsv_ext_status_other:
-    /* use zsv_ext_status_err for custom errors. will attempt to call errcode() and errstr()
-       for custom error code and message (if not errcode or errstr not provided, will be silent) */
+    // use zsv_ext_status_err for custom errors. will attempt to call errcode() and errstr()
+    // for custom error code and message (if not errcode or errstr not provided, will be silent)
   case zsv_ext_status_error:
     return NULL;
   }
   return NULL;
 }
 
-/* handle_ext_err(): return 1 if handled via ext callbacks, 0 otherwise */
-static int handle_ext_err(struct zsv_ext *ext, zsv_execution_context ctx,
-                          enum zsv_ext_status stat) {
+// handle_ext_err(): return 1 if handled via ext callbacks, 0 otherwise
+static int handle_ext_err(struct zsv_ext *ext, zsv_execution_context ctx, enum zsv_ext_status stat) {
   int rc = stat;
   char *msg = zsv_ext_errmsg(stat, ctx);
-  if(msg) {
+  if (msg) {
     fprintf(stderr, "Error in extension %s: %s\n", ext->id, msg);
     free(msg);
-  } else if(ext->module.errcode) {
+  } else if (ext->module.errcode) {
     int ext_err = rc = ext->module.errcode(ctx);
     char *errstr = ext->module.errstr ? ext->module.errstr(ctx, ext_err) : NULL;
-    if(errstr) {
+    if (errstr) {
       fprintf(stderr, "Error (%s): %s\n", ext->id, errstr);
-      if(ext->module.errfree)
+      if (ext->module.errfree)
         ext->module.errfree(errstr);
     }
   } else
@@ -236,7 +240,7 @@ static int handle_ext_err(struct zsv_ext *ext, zsv_execution_context ctx,
 
 static void ext_set_help(zsv_execution_context ctx, const char *help) {
   struct zsv_execution_data *data = ctx;
-  if(data && data->ext) {
+  if (data && data->ext) {
     free(data->ext->help);
     data->ext->help = help ? strdup(help) : NULL;
   }
@@ -244,7 +248,7 @@ static void ext_set_help(zsv_execution_context ctx, const char *help) {
 
 static void ext_set_license(zsv_execution_context ctx, const char *license) {
   struct zsv_execution_data *data = ctx;
-  if(data && data->ext) {
+  if (data && data->ext) {
     free(data->ext->license);
     data->ext->license = license ? strdup(license) : NULL;
   }
@@ -252,41 +256,40 @@ static void ext_set_license(zsv_execution_context ctx, const char *license) {
 
 static char *dup_str_array(const char *ss[]) {
   size_t len = 0;
-  for(int i = 0; ss && ss[i]; i++)
+  for (int i = 0; ss && ss[i]; i++)
     len += strlen(ss[i]);
 
-  if(!len) return NULL;
+  if (!len)
+    return NULL;
   char *mem = malloc(len + 2 * sizeof(*mem));
-  if(mem) {
+  if (mem) {
     char *tmp = mem;
-    for(int i = 0; ss && ss[i]; i++) {
+    for (int i = 0; ss && ss[i]; i++) {
       size_t n = strlen(ss[i]);
-      if(n) {
+      if (n) {
         memcpy(tmp, ss[i], n);
         tmp += n;
       }
     }
-    mem[len] = mem[len+1] = '\0';
+    mem[len] = mem[len + 1] = '\0';
   }
   return mem;
 }
 
 static void ext_set_thirdparty(zsv_execution_context ctx, const char *thirdparty[]) {
   struct zsv_execution_data *data = ctx;
-  if(data && data->ext) {
+  if (data && data->ext) {
     free(data->ext->thirdparty);
     data->ext->thirdparty = dup_str_array(thirdparty);
   }
 }
 
-static enum zsv_ext_status ext_add_command(zsv_execution_context ctx,
-                                           const char *id, const char *help,
+static enum zsv_ext_status ext_add_command(zsv_execution_context ctx, const char *id, const char *help,
                                            zsv_ext_main extmain) {
   struct zsv_execution_data *data = ctx;
-  if(data && data->ext && data->ext->commands_next
-     && id && *id && extmain) {
+  if (data && data->ext && data->ext->commands_next && id && *id && extmain) {
     struct zsv_ext_command *cmd = ext_command_new(id, help, extmain);
-    if(cmd) {
+    if (cmd) {
       *data->ext->commands_next = cmd;
       data->ext->commands_next = &cmd->next;
       return zsv_ext_status_ok;
@@ -295,17 +298,14 @@ static enum zsv_ext_status ext_add_command(zsv_execution_context ctx,
   return zsv_ext_status_error;
 }
 
-static enum zsv_ext_status ext_parse_all(zsv_execution_context ctx,
-                                         void *user_context,
-                                         void (*row_handler)(void *ctx),
-                                         struct zsv_opts *const custom
-                                         ) {
+static enum zsv_ext_status ext_parse_all(zsv_execution_context ctx, void *user_context, void (*row_handler)(void *ctx),
+                                         struct zsv_opts *const custom) {
   struct zsv_opts opts = custom ? *custom : ext_parser_opts(ctx);
 
-  if(row_handler)
+  if (row_handler)
     opts.row_handler = row_handler;
   zsv_parser parser = zsv_new(&opts);
-  if(!parser)
+  if (!parser)
     return zsv_ext_status_memory;
 
   ext_set_parser(ctx, parser);
@@ -314,10 +314,9 @@ static enum zsv_ext_status ext_parse_all(zsv_execution_context ctx,
 
   zsv_handle_ctrl_c_signal();
   enum zsv_status stat = zsv_status_ok;
-  while(!zsv_signal_interrupted
-        && (stat = zsv_parse_more(parser)) == zsv_status_ok) ;
-  if(stat == zsv_status_no_more_input
-     || (zsv_signal_interrupted && stat == zsv_status_ok))
+  while (!zsv_signal_interrupted && (stat = zsv_parse_more(parser)) == zsv_status_ok)
+    ;
+  if (stat == zsv_status_no_more_input || (zsv_signal_interrupted && stat == zsv_status_ok))
     stat = zsv_finish(parser);
   zsv_delete(parser);
 
@@ -325,7 +324,7 @@ static enum zsv_ext_status ext_parse_all(zsv_execution_context ctx,
 }
 
 static struct zsv_ext_callbacks *zsv_ext_callbacks_init(struct zsv_ext_callbacks *e) {
-  if(e) {
+  if (e) {
     memset(e, 0, sizeof(*e));
     e->set_row_handler = zsv_set_row_handler;
     e->set_context = zsv_set_context;
@@ -354,8 +353,8 @@ static struct zsv_ext_callbacks *zsv_ext_callbacks_init(struct zsv_ext_callbacks
 
 static enum zsv_ext_status ext_init(struct zsv_ext *ext) {
   enum zsv_ext_status stat = zsv_ext_status_ok;
-  if(!ext->inited) {
-    if(!ext->ok)
+  if (!ext->inited) {
+    if (!ext->ok)
       return zsv_ext_status_error;
 
     ext->inited = zsv_init_started;
@@ -366,7 +365,7 @@ static enum zsv_ext_status ext_init(struct zsv_ext *ext) {
     struct zsv_execution_data d;
     memset(&d, 0, sizeof(d));
     d.ext = ext;
-    if((stat = ext->module.init(&cb, &d)) != zsv_ext_status_ok) {
+    if ((stat = ext->module.init(&cb, &d)) != zsv_ext_status_ok) {
       handle_ext_err(ext, NULL, stat);
       return stat;
     }
@@ -377,37 +376,36 @@ static enum zsv_ext_status ext_init(struct zsv_ext *ext) {
 
 static int zsv_unload_custom_cmds(struct zsv_ext *ext) {
   int err = 0;
-  for(struct zsv_ext *next; ext; ext = next) {
+  for (struct zsv_ext *next; ext; ext = next) {
     next = ext->next;
-    if(zsv_ext_delete(ext))
+    if (zsv_ext_delete(ext))
       err = 1;
   }
   return err;
 }
 
 struct zsv_ext_command *find_ext_cmd(struct zsv_ext *ext, const char *id) {
-  for(struct zsv_ext_command *cmd = ext->commands; cmd; cmd = cmd->next)
-    if(!strcmp(cmd->id, id))
+  for (struct zsv_ext_command *cmd = ext->commands; cmd; cmd = cmd->next)
+    if (!strcmp(cmd->id, id))
       return cmd;
   return NULL;
 }
 
 static enum zsv_ext_status run_extension(int argc, const char *argv[], struct zsv_ext *ext) {
   enum zsv_ext_status stat = zsv_ext_status_error;
-  if(ext) {
-    if((stat = ext_init(ext)) != zsv_ext_status_ok)
+  if (ext) {
+    if ((stat = ext_init(ext)) != zsv_ext_status_ok)
       return stat;
 
     struct zsv_ext_command *cmd = find_ext_cmd(ext, argv[1] + 3);
-    if(!cmd) {
-      fprintf(stderr, "Unrecognized command for extension %s: %s\n",
-              ext->id, argv[1] + 3);
+    if (!cmd) {
+      fprintf(stderr, "Unrecognized command for extension %s: %s\n", ext->id, argv[1] + 3);
       return zsv_ext_status_unrecognized_cmd;
     }
 
-    struct zsv_execution_data ctx = { 0 };
+    struct zsv_execution_data ctx = {0};
 
-    if((stat = execution_context_init(&ctx, argc, argv)) == zsv_ext_status_ok) {
+    if ((stat = execution_context_init(&ctx, argc, argv)) == zsv_ext_status_ok) {
       struct zsv_opts opts;
       zsv_args_to_opts(argc, argv, &argc, argv, &opts, ctx.opts_used);
       zsv_set_default_opts(opts);
@@ -415,43 +413,39 @@ static enum zsv_ext_status run_extension(int argc, const char *argv[], struct zs
       stat = cmd->main(&ctx, ctx.argc - 1, &ctx.argv[1], &opts, ctx.opts_used);
     }
 
-    if(stat != zsv_ext_status_ok)
+    if (stat != zsv_ext_status_ok)
       stat = handle_ext_err(ext, &ctx, stat);
     execution_context_free(&ctx);
   }
   return stat;
 }
 
-/* havearg(): case-insensitive partial arg matching */
-char havearg(const char *arg,
-             const char *form1, size_t min_len1,
-             const char *form2, size_t min_len2) {
+// havearg(): case-insensitive partial arg matching
+char havearg(const char *arg, const char *form1, size_t min_len1, const char *form2, size_t min_len2) {
   size_t len = strlen(arg);
-  if(!min_len1)
+  if (!min_len1)
     min_len1 = strlen(form1);
-  if(len > min_len1)
+  if (len > min_len1)
     min_len1 = len;
 
-  if(!zsv_strincmp_ascii((const unsigned char *)arg, min_len1,
-			 (const unsigned char *)form1, min_len1))
+  if (!zsv_strincmp_ascii((const unsigned char *)arg, min_len1, (const unsigned char *)form1, min_len1))
     return 1;
 
-  if(form2) {
-    if(!min_len2)
+  if (form2) {
+    if (!min_len2)
       min_len2 = strlen(form2);
-    if(len > min_len2)
+    if (len > min_len2)
       min_len2 = len;
-    if(!zsv_strincmp_ascii((const unsigned char *)arg, min_len2,
-			   (const unsigned char *)form2, min_len2))
+    if (!zsv_strincmp_ascii((const unsigned char *)arg, min_len2, (const unsigned char *)form2, min_len2))
       return 1;
   }
   return 0;
 }
 
 static struct builtin_cmd *find_builtin(const char *cmd_name) {
-  int builtin_cmd_count = sizeof(builtin_cmds)/sizeof(*builtin_cmds);
-  for(int i = 0; i < builtin_cmd_count; i++)
-    if(havearg(cmd_name, builtin_cmds[i].name, 0, 0, 0))
+  int builtin_cmd_count = sizeof(builtin_cmds) / sizeof(*builtin_cmds);
+  for (int i = 0; i < builtin_cmd_count; i++)
+    if (havearg(cmd_name, builtin_cmds[i].name, 0, 0, 0))
       return &builtin_cmds[i];
   return NULL;
 }
@@ -463,7 +457,7 @@ static struct builtin_cmd *find_builtin(const char *cmd_name) {
 #include "builtin/register.c"
 
 static const char *extension_cmd_from_arg(const char *arg) {
-  if(strlen(arg) > 3 && arg[2] == '-')
+  if (strlen(arg) > 3 && arg[2] == '-')
     return arg + 3;
   return NULL;
 }
@@ -476,28 +470,24 @@ ZSV_CLI_EXPORT
 int ZSV_CLI_MAIN(int argc, const char *argv[]) {
   const char **alt_argv = NULL;
   struct builtin_cmd *builtin = find_builtin(argc > 1 ? argv[1] : "help");
-  if(builtin) {
-    /* help is different from other commands: zsv help <arg> is treated as
-       if it was zsv <arg> --help
-    */
-    if(builtin->main == main_help && argc > 2) {
+  if (builtin) {
+    // help is different from other commands: zsv help <arg> is treated as
+    //   if it was zsv <arg> --help
+    if (builtin->main == main_help && argc > 2) {
       struct builtin_cmd *help_builtin = find_builtin(argv[2]);
-      if(help_builtin) {
-        const char *argv_tmp[2] = {
-          argv[2],
-          "--help"
-        };
-        if(help_builtin->main)
+      if (help_builtin) {
+        const char *argv_tmp[2] = {argv[2], "--help"};
+        if (help_builtin->main)
           return help_builtin->main(2, argv_tmp);
-        else if(help_builtin->cmd) {
-          char opts_used[ZSV_OPTS_SIZE_MAX] = { 0 };
-          struct zsv_opts opts = { 0 };
+        else if (help_builtin->cmd) {
+          char opts_used[ZSV_OPTS_SIZE_MAX] = {0};
+          struct zsv_opts opts = {0};
           return help_builtin->cmd(2, argv_tmp, &opts, NULL, opts_used);
         } else
           return fprintf(stderr, "Unexpected syntax!\n");
       } else {
         const char *ext_cmd = extension_cmd_from_arg(argv[2]);
-        if(ext_cmd) {
+        if (ext_cmd) {
           alt_argv = calloc(3, sizeof(*alt_argv));
           alt_argv[0] = argv[0];
           alt_argv[1] = argv[2];
@@ -511,25 +501,25 @@ int ZSV_CLI_MAIN(int argc, const char *argv[]) {
         }
       }
     } else {
-      if(builtin->main)
+      if (builtin->main)
         return builtin->main(argc - 1, argc > 1 ? &argv[1] : NULL);
 
       char opts_used[ZSV_OPTS_SIZE_MAX];
       struct zsv_opts opts;
       enum zsv_status stat = zsv_args_to_opts(argc, argv, &argc, argv, &opts, opts_used);
-      if(stat == zsv_status_ok)
+      if (stat == zsv_status_ok)
         return builtin->cmd(argc - 1, argc > 1 ? &argv[1] : NULL, &opts, NULL, opts_used);
       return stat;
     }
   }
 
   int err = 1;
-  if(strlen(argv[1]) > 3 && argv[1][2] == '-') { // this is an extension command
+  if (strlen(argv[1]) > 3 && argv[1][2] == '-') { // this is an extension command
     struct cli_config config;
     memset(&config, 0, sizeof(config));
-    if(!(err = add_extension(argv[1], &config.extensions, 0, 0)))
+    if (!(err = add_extension(argv[1], &config.extensions, 0, 0)))
       err = run_extension(argc, argv, config.extensions);
-    if(config_free(&config) && !err)
+    if (config_free(&config) && !err)
       err = 1;
   } else
     fprintf(stderr, "Unrecognized command %s\n", argv[1]), err = 1;
@@ -541,16 +531,16 @@ int ZSV_CLI_MAIN(int argc, const char *argv[]) {
 // extensions
 static enum zsv_ext_status zsv_ext_delete(struct zsv_ext *ext) {
   enum zsv_ext_status stat = zsv_ext_status_ok;
-  if(ext) {
-    if(ext->dl) {
-      if(ext->module.exit && ext->inited) {
+  if (ext) {
+    if (ext->dl) {
+      if (ext->module.exit && ext->inited) {
         stat = ext->module.exit();
-        if(stat != zsv_ext_status_ok)
+        if (stat != zsv_ext_status_ok)
           handle_ext_err(ext, NULL, stat);
       }
       dlclose(ext->dl);
     }
-    for(struct zsv_ext_command *next, *cmd = ext->commands; cmd; cmd = next) {
+    for (struct zsv_ext_command *next, *cmd = ext->commands; cmd; cmd = next) {
       next = cmd->next;
       ext_command_delete(cmd);
     }
@@ -568,12 +558,12 @@ static enum zsv_ext_status zsv_ext_delete(struct zsv_ext *ext) {
  */
 static int zsv_ext_init(void *dl, const char *dl_name, struct zsv_ext *ext) {
   memset(ext, 0, sizeof(*ext));
-  if(dl) {
+  if (dl) {
 #define zsv_ext_func_assign(sig, x) ext->module.x = sig zsv_dlsym(dl, "zsv_ext_" #x)
 #include "cli_internal.c.in"
 
     /* check if required functions are present */
-    if(ext->module.id)
+    if (ext->module.id)
       return 0;
     fprintf(stderr, "Dynamic library %s missing required function zsv_ext_id()\n", dl_name);
   }
@@ -586,8 +576,8 @@ static int zsv_ext_init(void *dl, const char *dl_name, struct zsv_ext *ext) {
 
 #ifdef _WIN32
 char *get_module_name(HMODULE handle) {
-  wchar_t *pth16 = (wchar_t*)malloc(32768); // max long path length
-  DWORD n16 = GetModuleFileNameW(handle,pth16,32768);
+  wchar_t *pth16 = (wchar_t *)malloc(32768); // max long path length
+  DWORD n16 = GetModuleFileNameW(handle, pth16, 32768);
   if (n16 <= 0) {
     free(pth16);
     return NULL;
@@ -598,7 +588,7 @@ char *get_module_name(HMODULE handle) {
     free(pth16);
     return NULL;
   }
-  char *filepath = (char*)malloc(++n8);
+  char *filepath = (char *)malloc(++n8);
   if (!WideCharToMultiByte(CP_UTF8, 0, pth16, -1, filepath, n8, NULL, NULL)) {
     free(pth16);
     free(filepath);
@@ -612,26 +602,24 @@ char *get_module_name(HMODULE handle) {
 static char *dl_name_from_func(const void *func) {
 #ifdef _WIN32
   HMODULE hModule = NULL;
-  if(GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                       GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                       (LPCTSTR)func, &hModule))
+  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                        (LPCTSTR)func, &hModule))
     return get_module_name(hModule);
 #endif
 
 #ifdef __APPLE__
   Dl_info info;
-  if(dladdr(func, &info))
+  if (dladdr(func, &info))
     return strdup(info.dli_fname);
 #endif
   return NULL;
 }
 
-
 #ifdef __EMSCRIPTEN__
-static void* zsv_dlopen(const char *path, int mode) {
+static void *zsv_dlopen(const char *path, int mode) {
   fprintf(stderr, "Emscripten dlopen() does not work for shared libs > 4kb!"
-          "fix this when it does."
-          "See https://github.com/emscripten-core/emscripten/issues/15795\n");
+                  "fix this when it does."
+                  "See https://github.com/emscripten-core/emscripten/issues/15795\n");
   return dlopen(path, mode);
 }
 #else
@@ -646,54 +634,53 @@ static struct zsv_ext *zsv_ext_new(const char *dl_name, const char *id, char ver
 #else
   void *h = zsv_dlopen(dl_name, RTLD_LAZY);
 #endif
-  if(!h) {
-    /* not in system search path. try again in the same path as our executable (or in /ext if in emcc) */
+  if (!h) {
+    // not in system search path. try again in the same path as our executable (or in /ext if in emcc)
     char exe_path[FILENAME_MAX];
     char have_path = 0;
 #ifdef __EMSCRIPTEN__
     size_t n = snprintf(exe_path, sizeof(exe_path), "/tmp/zsvext%s.so", id);
-    if(n > 0 && n < sizeof(exe_path)) {
+    if (n > 0 && n < sizeof(exe_path)) {
       fprintf(stderr, "Opening %s\n", exe_path);
       h = zsv_dlopen(exe_path, RTLD_LAZY);
     } else
-      fprintf(stderr, "Opening whaa???\n");
+      fprintf(stderr, "Opening what???\n");
 #else
     size_t n = zsv_get_executable_path(exe_path, sizeof(exe_path));
-    if(n > 0 && n < sizeof(exe_path)) {
+    if (n > 0 && n < sizeof(exe_path)) {
       char *end = strrchr(exe_path, FILESLASH);
-      if(end) {
+      if (end) {
         end[1] = '\0';
         n = strlen(exe_path);
         size_t n2 = snprintf(exe_path + n, sizeof(exe_path) - n, "%s", dl_name);
-        if(n2 > 0 && n + n2 < sizeof(exe_path)) {
+        if (n2 > 0 && n + n2 < sizeof(exe_path)) {
           have_path = 1;
           h = zsv_dlopen(exe_path, RTLD_LAZY);
         }
       }
     }
 #endif
-    if(verbose) {
-      if(have_path)
-        fprintf(stderr, "Library %s not found in path; trying exe dir %s\n",
-                dl_name, exe_path);
+    if (verbose) {
+      if (have_path)
+        fprintf(stderr, "Library %s not found in path; trying exe dir %s\n", dl_name, exe_path);
       else
-        fprintf(stderr, "Library %s not found in path; cannot determine exe dir\n",
-                dl_name);
+        fprintf(stderr, "Library %s not found in path; cannot determine exe dir\n", dl_name);
     }
   }
-  if(!h)
+  if (!h)
     fprintf(stderr, "Library %s not found\n", dl_name);
 
-  /* run zsv_ext_init to add to our extension list, even if it's invalid */
+  // run zsv_ext_init to add to our extension list, even if it's invalid
   tmp.ok = !zsv_ext_init(h, dl_name, &tmp);
   const char *m_id = tmp.ok && tmp.module.id ? tmp.module.id() : NULL;
-  if(h && (!m_id || strcmp(m_id, (const char *)id))) {
-    fprintf(stderr, "Library %s: unexpected result from zsv_ext_id()\n"
+  if (h && (!m_id || strcmp(m_id, (const char *)id))) {
+    fprintf(stderr,
+            "Library %s: unexpected result from zsv_ext_id()\n"
             "(got %s, expected %s)\n",
             id, m_id ? m_id : "(null)", id);
     tmp.ok = 0;
-  } else if(h && tmp.ok) {
-    if(verbose) {
+  } else if (h && tmp.ok) {
+    if (verbose) {
       char *image_name = dl_name_from_func((const void *)tmp.module.id);
       fprintf(stderr, "Loaded %s from %s\n", dl_name, image_name ? image_name : "unknown location");
       free(image_name);
@@ -701,7 +688,7 @@ static struct zsv_ext *zsv_ext_new(const char *dl_name, const char *id, char ver
   }
   tmp.dl = h;
   tmp.id = strdup((const char *)id);
-  if(!(dl = calloc(1, sizeof(*dl))))
+  if (!(dl = calloc(1, sizeof(*dl))))
     fprintf(stderr, "Out of memory\n");
   else
     *dl = tmp;

--- a/app/cli.c
+++ b/app/cli.c
@@ -78,9 +78,12 @@ ZSV_MAIN_NO_OPTIONS_DECL(mv);
 ZSV_MAIN_NO_OPTIONS_DECL(jq);
 #endif
 
-#define CLI_BUILTIN_CMD(x) {.name = #x, .main = main_##x, .cmd = NULL}
-#define CLI_BUILTIN_COMMAND(x) {.name = #x, .main = NULL, .cmd = ZSV_MAIN_FUNC(x)}
-#define CLI_BUILTIN_NO_OPTIONS_COMMAND(x) {.name = #x, .main = ZSV_MAIN_NO_OPTIONS_FUNC(x), .cmd = NULL}
+#define CLI_BUILTIN_CMD(x)                                                                                             \
+  { .name = #x, .main = main_##x, .cmd = NULL }
+#define CLI_BUILTIN_COMMAND(x)                                                                                         \
+  { .name = #x, .main = NULL, .cmd = ZSV_MAIN_FUNC(x) }
+#define CLI_BUILTIN_NO_OPTIONS_COMMAND(x)                                                                              \
+  { .name = #x, .main = ZSV_MAIN_NO_OPTIONS_FUNC(x), .cmd = NULL }
 
 // clang-format off
 

--- a/app/cli_const.h
+++ b/app/cli_const.h
@@ -9,6 +9,8 @@
 #ifndef CLI_LICENSE_H
 #define CLI_LICENSE_H
 
+// clang-format off
+
 const char *zsv_license_text_MIT =
   "Permission is hereby granted, free of charge, to any person obtaining a copy of\n"
   "this software and associated documentation files (the \"Software\"), to deal in\n"
@@ -29,9 +31,11 @@ const char *zsv_license_text_MIT =
   "SOFTWARE.\n"
   ;
 
+// clang-format on
+
 const char *zsv_thirdparty[] = {
   "See https://github.com/liquidaty/zsv/blob/main/misc/THIRDPARTY.md",
-  NULL
+  NULL,
 };
 
 #endif

--- a/app/cli_export.h
+++ b/app/cli_export.h
@@ -2,11 +2,11 @@
 #define ZSV_CLI_EXPORT_H
 
 #if defined(__EMSCRIPTEN__)
-# include <emscripten.h>
-# define ZSV_CLI_EXPORT EMSCRIPTEN_KEEPALIVE
-# define ZSV_CLI_MAIN zsv
+#include <emscripten.h>
+#define ZSV_CLI_EXPORT EMSCRIPTEN_KEEPALIVE
+#define ZSV_CLI_MAIN zsv
 #else
-# define ZSV_CLI_EXPORT
+#define ZSV_CLI_EXPORT
 #endif
 
 #endif

--- a/app/cli_ini.c
+++ b/app/cli_ini.c
@@ -19,13 +19,13 @@
  * on Windows, this should be either LOCALAPPDATA or APPDATA
  */
 #ifndef PREFIX
-# if defined(_WIN32)
-#  define PREFIX "LOCALAPPDATA"
-# elif defined(__EMSCRIPTEN__)
-#  define PREFIX "/tmp"
-# else
-#  define PREFIX "/usr/local"
-# endif
+#if defined(_WIN32)
+#define PREFIX "LOCALAPPDATA"
+#elif defined(__EMSCRIPTEN__)
+#define PREFIX "/tmp"
+#else
+#define PREFIX "/usr/local"
+#endif
 #endif
 
 static void write_extension_config(struct zsv_ext *ext, FILE *f) {
@@ -37,17 +37,17 @@ static int config_save(struct cli_config *config) {
   int err = 1;
   char *tmp;
   asprintf(&tmp, "%s.tmp", config->filepath);
-  if(!tmp)
+  if (!tmp)
     fprintf(stderr, "Out of memory!\n");
   else {
     FILE *f = fopen(tmp, "wb");
-    if(!f)
+    if (!f)
       fprintf(stderr, "Unable to open config file temp %s\n", tmp);
     else {
-      for(struct zsv_ext *ext = config->extensions; ext; ext = ext->next)
+      for (struct zsv_ext *ext = config->extensions; ext; ext = ext->next)
         write_extension_config(ext, f);
       fclose(f);
-      if((err = zsv_replace_file(tmp, config->filepath)))
+      if ((err = zsv_replace_file(tmp, config->filepath)))
         perror("Unable to update config file");
     }
     free(tmp);
@@ -59,14 +59,14 @@ static enum zsv_ext_status zsv_ext_delete(struct zsv_ext *ext);
 
 static int remove_extension(struct zsv_ext **list, struct zsv_ext *element) {
   char found = 1;
-  for( ; *list; list = &(*list)->next) {
-    if(*list == element) {
+  for (; *list; list = &(*list)->next) {
+    if (*list == element) {
       *list = element->next;
       found = 1;
       break;
     }
   }
-  if(found) {
+  if (found) {
     element->next = NULL;
     return zsv_ext_delete(element);
   }
@@ -74,19 +74,15 @@ static int remove_extension(struct zsv_ext **list, struct zsv_ext *element) {
 }
 
 static struct zsv_ext *find_extension(struct cli_config *config, const char *id) {
-  for(struct zsv_ext *ext = config ? config->extensions : NULL; ext; ext = ext->next)
-    if(!zsv_stricmp((const unsigned char *)ext->id, (const unsigned char *)id))
+  for (struct zsv_ext *ext = config ? config->extensions : NULL; ext; ext = ext->next)
+    if (!zsv_stricmp((const unsigned char *)ext->id, (const unsigned char *)id))
       return ext;
   return NULL;
 }
 
 static char extension_id_ok(const unsigned char *id) {
-  for(int i = 0; id[i]; i++)
-    if(!(
-         (id[i] >= 'a' && id[i] <= 'z')
-         || (id[i] >= '0' && id[i] <= '9')
-         )
-       )
+  for (int i = 0; id[i]; i++)
+    if (!((id[i] >= 'a' && id[i] <= 'z') || (id[i] >= '0' && id[i] <= '9')))
       return 0;
   return 1;
 }
@@ -96,10 +92,10 @@ static struct zsv_ext *load_extension_dl(const unsigned char *extension_id, char
   char *extension_name;
   struct zsv_ext *ext = NULL;
   asprintf(&extension_name, "zsvext%s.%s", extension_id, DL_SUFFIX);
-  if(!extension_name)
+  if (!extension_name)
     fprintf(stderr, "Out of memory!\n");
-  else if((ext = zsv_ext_new(extension_name, (const char *)extension_id, verbose))) {
-    if(verbose)
+  else if ((ext = zsv_ext_new(extension_name, (const char *)extension_id, verbose))) {
+    if (verbose)
       fprintf(stderr, "Loaded extension %s\n", extension_name);
     free(extension_name);
   }
@@ -111,14 +107,14 @@ static int add_extension(const char *id, struct zsv_ext **exts, char ignore_err,
   int err = 0;
   size_t len = 2;
   unsigned char *extension_id = zsv_strtolowercase((const unsigned char *)id, &len);
-  if(extension_id) {
+  if (extension_id) {
     struct zsv_ext *ext = NULL;
-    if(!extension_id_ok(extension_id))
+    if (!extension_id_ok(extension_id))
       fprintf(stderr, "Invalid extension id: %s\n", extension_id), err = 1;
-    else if(!(ext = load_extension_dl(extension_id, verbose)))
+    else if (!(ext = load_extension_dl(extension_id, verbose)))
       fprintf(stderr, "Unexpected error loading extension %s\n", extension_id);
     else {
-      if(!ignore_err && !(ext && ext->ok)) {
+      if (!ignore_err && !(ext && ext->ok)) {
         fprintf(stderr, "Invalid extension: %s\n", extension_id), err = 1;
         zsv_ext_delete(ext);
       } else {
@@ -132,21 +128,19 @@ static int add_extension(const char *id, struct zsv_ext **exts, char ignore_err,
 }
 
 // get_config_file(): return zsv.ini
-static int config_ini_handler(void* ctx, const char* section,
-                              const char* name, const char* value,
-                              int lineno) {
+static int config_ini_handler(void *ctx, const char *section, const char *name, const char *value, int lineno) {
   int err = 0;
   struct cli_config *config = ctx;
-  if(section) {
-    if(!name && !value) { // initialize section
-      if(zsv_stricmp((const unsigned char *)section, (const unsigned char *)"default")) {
-        if(strlen(section) != 2) {
+  if (section) {
+    if (!name && !value) { // initialize section
+      if (zsv_stricmp((const unsigned char *)section, (const unsigned char *)"default")) {
+        if (strlen(section) != 2) {
           fprintf(stderr, "Invalid extension id: %s\n", section);
           err = 1;
         } else {
           struct zsv_ext *ext = find_extension(config, section);
-          if(!ext && add_extension(section, &config->extensions, 1, config->verbose)) {
-            if(config->err_if_not_found) {
+          if (!ext && add_extension(section, &config->extensions, 1, config->verbose)) {
+            if (config->err_if_not_found) {
               err = 1;
               fprintf(stderr, "At line %i in %s\n", lineno, config->filepath);
             }
@@ -160,9 +154,9 @@ static int config_ini_handler(void* ctx, const char* section,
 
 static size_t get_ini_file(char *buff, size_t buffsize) {
   size_t len = zsv_get_config_dir(buff, buffsize, PREFIX);
-  if(len) {
+  if (len) {
     size_t n = snprintf(buff + len, buffsize - len, "%czsv.ini", FILESLASH);
-    if(n > 0 && n + len < buffsize)
+    if (n > 0 && n + len < buffsize)
       return len + n;
   }
   return 0;
@@ -172,11 +166,10 @@ static size_t get_ini_file(char *buff, size_t buffsize) {
 static int parse_extensions_ini(struct cli_config *config, char err_if_not_found, char verbose) {
   int err = 0;
   FILE *f;
-  if(!(f = fopen(config->filepath, "r"))) {
-    if(err_if_not_found) {
+  if (!(f = fopen(config->filepath, "r"))) {
+    if (err_if_not_found) {
       err = -1;
-      fprintf(stderr, "No extensions configured%s%s\n",
-              verbose ? "or file not found: " : "",
+      fprintf(stderr, "No extensions configured%s%s\n", verbose ? "or file not found: " : "",
               verbose ? config->filepath : "");
     }
   } else {
@@ -184,15 +177,16 @@ static int parse_extensions_ini(struct cli_config *config, char err_if_not_found
     config->verbose = verbose;
     err = ini_parse_file(f, config_ini_handler, config);
     fclose(f);
-    if(err > 0)
+    if (err > 0)
       fprintf(stderr, "Error parsing %s on line %i\n", config->filepath, err);
   }
   return err;
 }
 
 static struct zsv_ext_command *ext_command_new(const char *id, const char *help,
-                                               enum zsv_ext_status (*extmain)(zsv_execution_context ctx, int argc, const char *argv[], struct zsv_opts *, const char *)
-                                               ) {
+                                               enum zsv_ext_status (*extmain)(zsv_execution_context ctx, int argc,
+                                                                              const char *argv[], struct zsv_opts *,
+                                                                              const char *)) {
   struct zsv_ext_command *cmd = calloc(1, sizeof(*cmd));
   cmd->id = strdup(id ? id : "");
   cmd->help = help ? strdup(help) : NULL;
@@ -201,7 +195,7 @@ static struct zsv_ext_command *ext_command_new(const char *id, const char *help,
 }
 
 static void ext_command_delete(struct zsv_ext_command *cmd) {
-  if(cmd) {
+  if (cmd) {
     free(cmd->id);
     free(cmd->help);
     free(cmd);

--- a/app/cli_internal.h
+++ b/app/cli_internal.h
@@ -28,7 +28,7 @@ struct zsv_ext {
 #define zsv_init_ok 2
   char inited;
   struct {
-# include "cli_internal.h.in"
+#include "cli_internal.h.in"
   } module;
 };
 

--- a/app/compare.c
+++ b/app/compare.c
@@ -32,10 +32,9 @@ extern sqlite3_module CsvModule;
 
 #define ZSV_COMPARE_OUTPUT_TYPE_JSON 'j'
 
-static struct zsv_compare_key **zsv_compare_key_add(struct zsv_compare_key **next,
-                                                    const char *s, int *err) {
+static struct zsv_compare_key **zsv_compare_key_add(struct zsv_compare_key **next, const char *s, int *err) {
   struct zsv_compare_key *k = calloc(1, sizeof(*k));
-  if(!k)
+  if (!k)
     *err = 1;
   else {
     k->name = s;
@@ -46,122 +45,107 @@ static struct zsv_compare_key **zsv_compare_key_add(struct zsv_compare_key **nex
 }
 
 static void zsv_compare_output_property_name(struct zsv_compare_data *data, int new_row, char skip) {
-  if(new_row)
+  if (new_row)
     data->writer.cell_ix = 0;
   else
     data->writer.cell_ix++;
-  if(!skip) {
-    if(data->writer.cell_ix < data->writer.properties.used)
+  if (!skip) {
+    if (data->writer.cell_ix < data->writer.properties.used)
       jsonwriter_object_key(data->writer.handle.jsw, data->writer.properties.names[data->writer.cell_ix]);
     else
       jsonwriter_object_key(data->writer.handle.jsw, "Error missing key!");
   }
 }
 
-static void zsv_compare_output_strn(struct zsv_compare_data *data,
-                                    const unsigned char *s, size_t len,
-                                    int new_row,
+static void zsv_compare_output_strn(struct zsv_compare_data *data, const unsigned char *s, size_t len, int new_row,
                                     int quoted) {
-  if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
-    if(data->writer.object && s == NULL) {
+  if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
+    if (data->writer.object && s == NULL) {
       zsv_compare_output_property_name(data, new_row, 1);
       return;
     }
-    if(data->writer.object)
+    if (data->writer.object)
       zsv_compare_output_property_name(data, new_row, 0);
-    if(s == NULL)
+    if (s == NULL)
       jsonwriter_null(data->writer.handle.jsw);
     else
       jsonwriter_strn(data->writer.handle.jsw, s, len);
   } else {
-    if(s == NULL)
+    if (s == NULL)
       zsv_writer_cell_blank(data->writer.handle.csv, ZSV_WRITER_SAME_ROW);
     else
       zsv_writer_cell(data->writer.handle.csv, new_row, s, len, quoted);
   }
 }
 
-static void zsv_compare_output_str(struct zsv_compare_data *data,
-                                   const unsigned char *s,
-                                   int new_row,
-                                   int quoted) {
+static void zsv_compare_output_str(struct zsv_compare_data *data, const unsigned char *s, int new_row, int quoted) {
   zsv_compare_output_strn(data, s, s ? strlen((const char *)s) : 0, new_row, quoted);
 }
 
-static void zsv_compare_output_zu(struct zsv_compare_data *data,
-                                  size_t n,
-                                  int new_row) {
-  if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
-    if(data->writer.object)
+static void zsv_compare_output_zu(struct zsv_compare_data *data, size_t n, int new_row) {
+  if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
+    if (data->writer.object)
       zsv_compare_output_property_name(data, new_row, 0);
     jsonwriter_int(data->writer.handle.jsw, n);
   } else
     zsv_writer_cell_zu(data->writer.handle.csv, ZSV_WRITER_NEW_ROW, data->row_count);
 }
 
-static void zsv_compare_header_str(struct zsv_compare_data *data,
-                                   const unsigned char *s,
-                                   int new_row,
-                                   int quoted) {
-  if(!(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON &&
-       data->writer.object))
+static void zsv_compare_header_str(struct zsv_compare_data *data, const unsigned char *s, int new_row, int quoted) {
+  if (!(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON && data->writer.object))
     zsv_compare_output_str(data, s, new_row, quoted);
   else {
     // we will output as JSON objects, so save the property names for later use
-    if(data->writer.properties.used + 1 < data->writer.properties.allocated)
+    if (data->writer.properties.used + 1 < data->writer.properties.allocated)
       data->writer.properties.names[data->writer.properties.used++] = strdup(s ? (const char *)s : "");
     else
       fprintf(stderr, "zsv_compare_header_str: insufficient header names allocation adding %s!\n", s);
   }
 }
 
-static void zsv_compare_allocate_properties(struct zsv_compare_data *data,
-                                            unsigned count) {
-  if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON &&
-     data->writer.object && count > 0) {
-    if((data->writer.properties.names = malloc(count*sizeof(*data->writer.properties.names))))
+static void zsv_compare_allocate_properties(struct zsv_compare_data *data, unsigned count) {
+  if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON && data->writer.object && count > 0) {
+    if ((data->writer.properties.names = malloc(count * sizeof(*data->writer.properties.names))))
       data->writer.properties.allocated = count;
   }
 }
 
 static void zsv_compare_json_row_start(struct zsv_compare_data *data) {
-  if(data->writer.object)
+  if (data->writer.object)
     jsonwriter_start_object(data->writer.handle.jsw);
   else
     jsonwriter_start_array(data->writer.handle.jsw);
 }
 
 static void zsv_compare_json_row_end(struct zsv_compare_data *data) {
-  if(data->writer.object)
+  if (data->writer.object)
     jsonwriter_end_object(data->writer.handle.jsw);
   else
     jsonwriter_end_array(data->writer.handle.jsw);
 }
 
-static void zsv_compare_output_tuple(struct zsv_compare_data *data,
-                                     struct zsv_compare_input *key_input,
+static void zsv_compare_output_tuple(struct zsv_compare_data *data, struct zsv_compare_input *key_input,
                                      const unsigned char *colname,
                                      struct zsv_cell *values, // in original input order
-                                     char is_key
-                                     ) {
+                                     char is_key) {
   // print ID | Column | Value 1 | ... | Value N
-  if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON)
+  if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON)
     zsv_compare_json_row_start(data);
 
-  // to do: output ID values
-  if(!data->keys) // id is effectively just row number
+  // TO DO: output ID values
+  if (!data->keys) // id is effectively just row number
     zsv_compare_output_zu(data, data->row_count, ZSV_WRITER_NEW_ROW);
   else {
-    for(unsigned idx = 0; idx < key_input->key_count; idx++) {
+    for (unsigned idx = 0; idx < key_input->key_count; idx++) {
       struct zsv_cell *c = &key_input->keys[idx].value;
       zsv_compare_output_strn(data, c->str, c->len, idx == 0 ? ZSV_WRITER_NEW_ROW : ZSV_WRITER_SAME_ROW, c->quoted);
     }
   }
 
   // output additional columns
-  for(struct zsv_compare_added_column *ac = data->added_columns; ac; ac = ac->next) {
-    if(!ac->input) {
-      if(data->writer.type != ZSV_COMPARE_OUTPUT_TYPE_JSON)
+  for (struct zsv_compare_added_column *ac = data->added_columns; ac; ac = ac->next) {
+    if (!ac->input) {
+      if (data->writer.type != ZSV_COMPARE_OUTPUT_TYPE_JSON)
         zsv_compare_output_str(data, NULL, ZSV_WRITER_SAME_ROW, 0);
     } else {
       struct zsv_cell c = data->get_cell(ac->input, ac->col_ix);
@@ -172,9 +156,9 @@ static void zsv_compare_output_tuple(struct zsv_compare_data *data,
   // output column name of this cell
   zsv_compare_output_str(data, colname, ZSV_WRITER_SAME_ROW, 1);
 
-  for(unsigned i = 0; i < data->input_count; i++) {
+  for (unsigned i = 0; i < data->input_count; i++) {
     struct zsv_compare_input *input = &data->inputs[i];
-    if((input->done || !input->row_loaded) && !is_key) { // no data for this input
+    if ((input->done || !input->row_loaded) && !is_key) { // no data for this input
       zsv_compare_output_str(data, NULL, ZSV_WRITER_SAME_ROW, 0);
     } else {
       struct zsv_cell *value = &values[i];
@@ -182,25 +166,25 @@ static void zsv_compare_output_tuple(struct zsv_compare_data *data,
     }
   }
 
-  if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON)
+  if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON)
     zsv_compare_json_row_end(data);
 }
 
 static const unsigned char *zsv_compare_combined_key_names(struct zsv_compare_data *data) {
-  if(!data->combined_key_names) {
+  if (!data->combined_key_names) {
     size_t len = 2;
 
-    for(unsigned key_ix = 0; key_ix < data->key_count; key_ix++) {
+    for (unsigned key_ix = 0; key_ix < data->key_count; key_ix++) {
       struct zsv_compare_key *key = &data->keys[key_ix];
-      if(key && key->name)
+      if (key && key->name)
         len += strlen(key->name) + 1;
     }
-    if((data->combined_key_names = calloc(1, len))) {
+    if ((data->combined_key_names = calloc(1, len))) {
       unsigned char *start = NULL;
-      for(unsigned key_ix = 0; key_ix < data->key_count; key_ix++) {
+      for (unsigned key_ix = 0; key_ix < data->key_count; key_ix++) {
         struct zsv_compare_key *key = &data->keys[key_ix];
-        if(key && key->name) {
-          if(start) {
+        if (key && key->name) {
+          if (start) {
             *start = (unsigned char)'|';
             start++;
           } else
@@ -215,15 +199,15 @@ static const unsigned char *zsv_compare_combined_key_names(struct zsv_compare_da
 }
 
 static void zsv_compare_print_row(struct zsv_compare_data *data,
-                                  const unsigned last_ix   // last input ix in inputs_to_sort
-                                  ) {
+                                  const unsigned last_ix // last input ix in inputs_to_sort
+) {
   struct zsv_compare_input *key_input = data->inputs_to_sort[0];
 
   // for now, output format is simple: for each value,
   // output a single scalar if the values are the same,
   // and a tuple if they differ
   struct zsv_cell *values = calloc(data->input_count, sizeof(*values));
-  if(!values) {
+  if (!values) {
     data->status = zsv_compare_status_memory;
     return;
   }
@@ -232,17 +216,18 @@ static void zsv_compare_print_row(struct zsv_compare_data *data,
 
   // if we don't have data from every input, then output "Missing" for missing inputs
   char got_missing = 0;
-  for(unsigned i = 0; i < data->input_count; i++) {
+  for (unsigned i = 0; i < data->input_count; i++) {
     struct zsv_compare_input *input = data->inputs_to_sort[i];
-    if(i > last_ix) {
+    if (i > last_ix) {
       got_missing = 1;
       unsigned input_ix = input->index;
       values[input_ix].str = (unsigned char *)ZSV_COMPARE_MISSING;
       values[input_ix].len = strlen(ZSV_COMPARE_MISSING);
     }
   }
-  if(got_missing) {
-    const unsigned char *key_names = data->print_key_col_names ? zsv_compare_combined_key_names(data) : (const unsigned char *)"<key>";
+  if (got_missing) {
+    const unsigned char *key_names =
+      data->print_key_col_names ? zsv_compare_combined_key_names(data) : (const unsigned char *)"<key>";
     zsv_compare_output_tuple(data, key_input, key_names, values, 1);
     // reset values
     memset(values, 0, data->input_count * sizeof(*values));
@@ -250,52 +235,52 @@ static void zsv_compare_print_row(struct zsv_compare_data *data,
 
   // for each output column
   zsv_compare_unique_colname *output_col = data->output_colnames_first;
-  for(unsigned output_ix = 0; output_ix < data->output_colcount && output_col != NULL;
-      output_ix++, output_col = output_col->next) {
-    if(output_col->is_key)
+  for (unsigned output_ix = 0; output_ix < data->output_colcount && output_col != NULL;
+       output_ix++, output_col = output_col->next) {
+    if (output_col->is_key)
       continue;
 
     char different = 0;
     unsigned first_input_ix = 0;
-    for(unsigned i = 0; i <= last_ix; i++) {
+    for (unsigned i = 0; i <= last_ix; i++) {
       struct zsv_compare_input *input = data->inputs_to_sort[i];
-      if(input->done || !input->row_loaded) continue;
+      if (input->done || !input->row_loaded)
+        continue;
 
       unsigned input_ix = input->index;
-      if(i == 0)
+      if (i == 0)
         first_input_ix = input_ix;
 
       unsigned col_ix_plus_1 = input->out2in[output_ix];
-      if(col_ix_plus_1 == 0)
+      if (col_ix_plus_1 == 0)
         values[input_ix].len = 0;
       else {
         unsigned input_col_ix = col_ix_plus_1 - 1;
-        if(!output_col)
+        if (!output_col)
           output_col = input->output_colnames[input_col_ix];
         values[input_ix] = data->get_cell(input, input_col_ix);
-        if(i > 0 && !different && data->cmp(data->cmp_ctx, values[first_input_ix], values[input_ix], data, input_col_ix)) {
+        if (i > 0 && !different &&
+            data->cmp(data->cmp_ctx, values[first_input_ix], values[input_ix], data, input_col_ix)) {
           different = 1;
-          if(data->tolerance.value
-             && values[first_input_ix].len < ZSV_COMPARE_MAX_NUMBER_BUFF_LEN
-             && values[input_ix].len < ZSV_COMPARE_MAX_NUMBER_BUFF_LEN) {
-            // check if both are numbers with a difference less than the given tolerance            
+          if (data->tolerance.value && values[first_input_ix].len < ZSV_COMPARE_MAX_NUMBER_BUFF_LEN &&
+              values[input_ix].len < ZSV_COMPARE_MAX_NUMBER_BUFF_LEN) {
+            // check if both are numbers with a difference less than the given tolerance
             double d1, d2;
             memcpy(data->tolerance.str1, values[first_input_ix].str, values[first_input_ix].len);
             data->tolerance.str1[values[first_input_ix].len] = '\0';
             memcpy(data->tolerance.str2, values[input_ix].str, values[input_ix].len);
             data->tolerance.str2[values[input_ix].len] = '\0';
-            if(!zsv_strtod_exact(data->tolerance.str1, &d1)
-               && !zsv_strtod_exact(data->tolerance.str2, &d2)
-               && fabs(d1 - d2) < data->tolerance.value)
+            if (!zsv_strtod_exact(data->tolerance.str1, &d1) && !zsv_strtod_exact(data->tolerance.str2, &d2) &&
+                fabs(d1 - d2) < data->tolerance.value)
               different = 0;
           }
         }
       }
     }
 
-    if(different) {
+    if (different) {
       zsv_compare_output_tuple(data, key_input, output_col->name, values, 0);
-      if(data->diff_count < INT_MAX)
+      if (data->diff_count < INT_MAX)
         data->diff_count++;
     }
   }
@@ -306,104 +291,100 @@ static void zsv_compare_input_free(struct zsv_compare_input *input) {
   zsv_delete(input->parser);
   zsv_compare_unique_colnames_delete(&input->colnames);
   free(input->out2in);
-  if(input->stream)
+  if (input->stream)
     fclose(input->stream);
   free(input->output_colnames);
   free(input->keys);
-  if(input->sort_stmt) {
+  if (input->sort_stmt) {
     sqlite3_finalize(input->sort_stmt);
   }
 }
 
 static enum zsv_compare_status zsv_compare_set_inputs(struct zsv_compare_data *data, unsigned input_count) {
-  if(!input_count || !(data->inputs = calloc(input_count, sizeof(*data->inputs)))
-     || !(data->inputs_to_sort = calloc(input_count, sizeof(*data->inputs_to_sort))))
+  if (!input_count || !(data->inputs = calloc(input_count, sizeof(*data->inputs))) ||
+      !(data->inputs_to_sort = calloc(input_count, sizeof(*data->inputs_to_sort))))
     return zsv_compare_status_memory;
   data->input_count = input_count;
-  for(unsigned i = 0; i < input_count; i++) {
+  for (unsigned i = 0; i < input_count; i++) {
     struct zsv_compare_input *input = &data->inputs[i];
     input->index = i;
     data->inputs_to_sort[i] = input;
-    if(data->key_count) {
-      if(!(input->keys = calloc(data->key_count, sizeof(*input->keys))))
+    if (data->key_count) {
+      if (!(input->keys = calloc(data->key_count, sizeof(*input->keys))))
         return zsv_compare_status_memory;
 
       input->key_count = data->key_count;
       unsigned j = 0;
-      for(struct zsv_compare_key *key = data->keys; key; key = key->next)
+      for (struct zsv_compare_key *key = data->keys; key; key = key->next)
         input->keys[j++].key = key;
     }
   }
   return zsv_compare_status_ok;
 }
 
-static int zsv_compare_cell(void *ctx, struct zsv_cell c1, struct zsv_cell c2,
-                            void *data, unsigned col_ix);
+static int zsv_compare_cell(void *ctx, struct zsv_cell c1, struct zsv_cell c2, void *data, unsigned col_ix);
 
 static void zsv_compare_output_begin(struct zsv_compare_data *data) {
-  if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
-    if(!(data->writer.handle.jsw = jsonwriter_new(stdout))) // to do: data->out
+  if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
+    if (!(data->writer.handle.jsw = jsonwriter_new(stdout))) // to do: data->out
       data->status = zsv_compare_status_memory;
     else {
-      if(data->writer.compact)
+      if (data->writer.compact)
         jsonwriter_set_option(data->writer.handle.jsw, jsonwriter_option_compact);
       jsonwriter_start_array(data->writer.handle.jsw);
     }
   } else {
-    if(!(data->writer.handle.csv = zsv_writer_new(NULL)))
+    if (!(data->writer.handle.csv = zsv_writer_new(NULL)))
       data->status = zsv_compare_status_memory;
   }
 
-  if(data->status == zsv_compare_status_ok) {
-    unsigned header_col_count =
-      (data->key_count ? data->key_count : 1) + // match keys
-      2 + // column name and column value
-      data->input_count + // input names
-      data->added_colcount; // added columns
+  if (data->status == zsv_compare_status_ok) {
+    unsigned header_col_count = (data->key_count ? data->key_count : 1) + // match keys
+                                2 +                                       // column name and column value
+                                data->input_count +                       // input names
+                                data->added_colcount;                     // added columns
 
     zsv_compare_allocate_properties(data, header_col_count);
 
     // write header row
-    if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON && !data->writer.object)
+    if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON && !data->writer.object)
       jsonwriter_start_array(data->writer.handle.jsw);
 
     // write keys
-    if(!data->keys) // id is effectively just row number
+    if (!data->keys) // id is effectively just row number
       zsv_compare_header_str(data, (const unsigned char *)"Row #", ZSV_WRITER_NEW_ROW, 0);
     else {
-      for(struct zsv_compare_key *key_name = data->keys; key_name; key_name = key_name->next)
-        zsv_compare_header_str(data,
-                               (const unsigned char *)key_name->name,
-                               key_name == data->keys ? ZSV_WRITER_NEW_ROW : ZSV_WRITER_SAME_ROW,
-                               1);
+      for (struct zsv_compare_key *key_name = data->keys; key_name; key_name = key_name->next)
+        zsv_compare_header_str(data, (const unsigned char *)key_name->name,
+                               key_name == data->keys ? ZSV_WRITER_NEW_ROW : ZSV_WRITER_SAME_ROW, 1);
     }
 
     // write additional column names
-    for(struct zsv_compare_added_column *ac = data->added_columns; ac; ac = ac->next)
+    for (struct zsv_compare_added_column *ac = data->added_columns; ac; ac = ac->next)
       zsv_compare_header_str(data, ac->colname->name, ZSV_WRITER_SAME_ROW, 1);
 
     // write "Column"
     zsv_compare_header_str(data, (const unsigned char *)"Column", ZSV_WRITER_SAME_ROW, 0);
 
     // write input name(s)
-    for(unsigned i = 0; i < data->input_count; i++) {
+    for (unsigned i = 0; i < data->input_count; i++) {
       struct zsv_compare_input *input = &data->inputs[i];
       zsv_compare_header_str(data, (const unsigned char *)input->path, ZSV_WRITER_SAME_ROW, 1);
     }
 
-    if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON && !data->writer.object)
+    if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON && !data->writer.object)
       jsonwriter_end_array(data->writer.handle.jsw);
   }
 }
 
 static void zsv_compare_output_end(struct zsv_compare_data *data) {
-  if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
-    if(data->writer.handle.jsw)
+  if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
+    if (data->writer.handle.jsw)
       jsonwriter_end(data->writer.handle.jsw);
   } else {
     zsv_writer_flush(data->writer.handle.csv);
   }
-  if(data->status == zsv_compare_status_no_more_input)
+  if (data->status == zsv_compare_status_no_more_input)
     data->status = zsv_compare_status_ok;
 }
 
@@ -411,8 +392,7 @@ static enum zsv_status zsv_compare_next_unsorted_row(struct zsv_compare_input *i
   return zsv_next_row(input->parser);
 }
 
-static struct zsv_cell zsv_compare_get_unsorted_cell(struct zsv_compare_input *input,
-                                                     unsigned ix) {
+static struct zsv_cell zsv_compare_get_unsorted_cell(struct zsv_compare_input *input, unsigned ix) {
   return zsv_get_cell_trimmed(input->parser, ix);
 }
 
@@ -420,24 +400,21 @@ static unsigned zsv_compare_get_unsorted_colcount(struct zsv_compare_input *inpu
   return zsv_cell_count(input->parser);
 }
 
-static enum zsv_compare_status
-input_init_unsorted(struct zsv_compare_data *data,
-                    struct zsv_compare_input *input,
-                    struct zsv_opts *opts,
-                    struct zsv_prop_handler *custom_prop_handler,
-                    const char *opts_used) {
+static enum zsv_compare_status input_init_unsorted(struct zsv_compare_data *data, struct zsv_compare_input *input,
+                                                   struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler,
+                                                   const char *opts_used) {
   (void)(opts_used);
-  if(!(input->stream = fopen(input->path, "rb"))) {
+  if (!(input->stream = fopen(input->path, "rb"))) {
     perror(input->path);
     return zsv_compare_status_error;
   }
   struct zsv_opts these_opts = *opts;
   these_opts.stream = input->stream;
   enum zsv_status stat = zsv_new_with_properties(&these_opts, custom_prop_handler, input->path, NULL, &input->parser);
-  if(stat != zsv_status_ok)
+  if (stat != zsv_status_ok)
     return zsv_compare_status_error;
 
-  if(data->next_row(input) != zsv_status_row)
+  if (data->next_row(input) != zsv_status_row)
     return zsv_compare_status_error;
 
   return zsv_compare_status_ok;
@@ -471,9 +448,8 @@ static void zsv_compare_set_sorted_callbacks(struct zsv_compare_data *data) {
 static enum zsv_compare_status zsv_compare_init_sorted(struct zsv_compare_data *data) {
   int rc;
   const char *db_url = data->sort_in_memory ? "file::memory:" : "";
-  if((rc = sqlite3_open_v2(db_url, &data->sort_db, SQLITE_OPEN_URI | SQLITE_OPEN_READWRITE, NULL)) == SQLITE_OK
-     && data->sort_db
-     && (rc = sqlite3_create_module(data->sort_db, "csv", &CsvModule, 0) == SQLITE_OK)) {
+  if ((rc = sqlite3_open_v2(db_url, &data->sort_db, SQLITE_OPEN_URI | SQLITE_OPEN_READWRITE, NULL)) == SQLITE_OK &&
+      data->sort_db && (rc = sqlite3_create_module(data->sort_db, "csv", &CsvModule, 0) == SQLITE_OK)) {
     zsv_compare_set_sorted_callbacks(data);
     return zsv_compare_status_ok;
   }
@@ -481,23 +457,23 @@ static enum zsv_compare_status zsv_compare_init_sorted(struct zsv_compare_data *
 }
 
 static void zsv_compare_data_free(struct zsv_compare_data *data) {
-  if(data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
-    if(data->writer.handle.jsw)
+  if (data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON) {
+    if (data->writer.handle.jsw)
       jsonwriter_delete(data->writer.handle.jsw);
   } else
     zsv_writer_delete(data->writer.handle.csv);
 
-  for(unsigned i = 0; i < data->input_count; i++)
+  for (unsigned i = 0; i < data->input_count; i++)
     zsv_compare_input_free(&data->inputs[i]);
   free(data->inputs);
   free(data->combined_key_names);
   free(data->inputs_to_sort);
-  for(unsigned i = 0; i < data->writer.properties.used; i++)
+  for (unsigned i = 0; i < data->writer.properties.used; i++)
     free(data->writer.properties.names[i]);
   free(data->writer.properties.names);
 
-  if(data->sort) {
-    if(data->sort_db)
+  if (data->sort) {
+    if (data->sort_db)
       sqlite3_close(data->sort_db);
   }
 
@@ -506,50 +482,47 @@ static void zsv_compare_data_free(struct zsv_compare_data *data) {
   zsv_compare_unique_colnames_delete(&data->output_colnames);
   zsv_compare_unique_colnames_delete(&data->added_colnames);
 
-  for(struct zsv_compare_key *next, *key = data->keys; key; key = next) {
+  for (struct zsv_compare_key *next, *key = data->keys; key; key = next) {
     next = key->next;
     free(key);
   }
 }
 
 void zsv_compare_delete(zsv_compare_handle z) {
-  if(z) {
+  if (z) {
     zsv_compare_data_free(z);
     free(z);
   }
 }
 
-void zsv_compare_set_comparison(struct zsv_compare_data *data,
-                                zsv_compare_cell_func cmp,
-                                void *cmp_ctx) {
+void zsv_compare_set_comparison(struct zsv_compare_data *data, zsv_compare_cell_func cmp, void *cmp_ctx) {
   data->cmp = cmp;
   data->cmp_ctx = cmp_ctx;
 }
 
-static int zsv_compare_cell(void *ctx, struct zsv_cell c1, struct zsv_cell c2,
-                            void *data, unsigned col_ix) {
+static int zsv_compare_cell(void *ctx, struct zsv_cell c1, struct zsv_cell c2, void *data, unsigned col_ix) {
   (void)(ctx);
   (void)(data);
   (void)(col_ix);
-  return zsv_strincmp(c1.str, c1.len,
-                      c2.str, c2.len);
+  return zsv_strincmp(c1.str, c1.len, c2.str, c2.len);
 }
 
 static enum zsv_compare_status zsv_compare_advance(struct zsv_compare_data *data) {
   // advance each input (if not row_loaded) to their next row
   char got = 0;
-  for(unsigned i = 0; i < data->input_count; i++) {
+  for (unsigned i = 0; i < data->input_count; i++) {
     struct zsv_compare_input *input = &data->inputs[i];
-    if(input->done) continue;
+    if (input->done)
+      continue;
 
-    if(input->row_loaded) {
+    if (input->row_loaded) {
       got = 1;
       continue;
     }
-    if(data->next_row(input) != zsv_status_row)
+    if (data->next_row(input) != zsv_status_row)
       input->done = 1;
     else {
-      for(unsigned idx = 0; idx < input->key_count; idx++)
+      for (unsigned idx = 0; idx < input->key_count; idx++)
         input->keys[idx].value = data->get_cell(input, input->keys[idx].col_ix);
       input->row_loaded = 1;
       got = 1;
@@ -558,45 +531,47 @@ static enum zsv_compare_status zsv_compare_advance(struct zsv_compare_data *data
   return got ? zsv_compare_status_ok : zsv_compare_status_no_more_input;
 }
 
-static int zsv_compare_inputp_cmp(const void *inputpx, const void* inputpy) {
-  struct zsv_compare_input * const *xp = inputpx;
-  struct zsv_compare_input * const *yp = inputpy;
+static int zsv_compare_inputp_cmp(const void *inputpx, const void *inputpy) {
+  struct zsv_compare_input *const *xp = inputpx;
+  struct zsv_compare_input *const *yp = inputpy;
   const struct zsv_compare_input *x = *xp;
   const struct zsv_compare_input *y = *yp;
 
-  if(!x->row_loaded && !y->row_loaded) return 0;
-  if(!x->row_loaded) return 1;
-  if(!y->row_loaded) return -1;
+  if (!x->row_loaded && !y->row_loaded)
+    return 0;
+  if (!x->row_loaded)
+    return 1;
+  if (!y->row_loaded)
+    return -1;
 
   int cmp = 0;
-  for(unsigned i = 0; !cmp && i < x->key_count && i < y->key_count; i++)
+  for (unsigned i = 0; !cmp && i < x->key_count && i < y->key_count; i++)
     // for multibyte input, the input must be also sorted lexicographically
     // to avoid potential mismatches
     // see e.g. https://stackoverflow.com/questions/4611302/sorting-utf-8-strings
-    cmp = zsv_strincmp(x->keys[i].value.str, x->keys[i].value.len,
-                       y->keys[i].value.str, y->keys[i].value.len);
+    cmp = zsv_strincmp(x->keys[i].value.str, x->keys[i].value.len, y->keys[i].value.str, y->keys[i].value.len);
   return cmp;
 }
 
-
 static enum zsv_compare_status zsv_compare_next(struct zsv_compare_data *data) {
   data->status = zsv_compare_advance(data);
-  if(data->status != zsv_compare_status_ok) return data->status;
+  if (data->status != zsv_compare_status_ok)
+    return data->status;
 
   data->row_count++;
   // sort the inputs by ID value first, and input position second
   // for as many inputs have the same smallest ID values, output them as a group
   //   and set input->row_loaded to 0
-  qsort(data->inputs_to_sort, data->input_count,
-        sizeof(*data->inputs_to_sort), zsv_compare_inputp_cmp);
+  qsort(data->inputs_to_sort, data->input_count, sizeof(*data->inputs_to_sort), zsv_compare_inputp_cmp);
 
   // find the next subset of inputs with identical id values and process those inputs
   unsigned last = 0;
   struct zsv_compare_input *min_input = data->inputs_to_sort[0];
-  for(unsigned tmp_i = 1; tmp_i < data->input_count; tmp_i++) {
+  for (unsigned tmp_i = 1; tmp_i < data->input_count; tmp_i++) {
     struct zsv_compare_input *tmp = data->inputs_to_sort[tmp_i];
-    if(!tmp->row_loaded) continue;
-    if(!zsv_compare_inputp_cmp(&min_input, &tmp)) { // keys are the same
+    if (!tmp->row_loaded)
+      continue;
+    if (!zsv_compare_inputp_cmp(&min_input, &tmp)) { // keys are the same
       last = tmp_i;
       continue;
     }
@@ -609,7 +584,7 @@ static enum zsv_compare_status zsv_compare_next(struct zsv_compare_data *data) {
   zsv_compare_print_row(data, last);
 
   // reset row_loaded
-  for(unsigned tmp = 0; tmp <= last; tmp++)
+  for (unsigned tmp = 0; tmp <= last; tmp++)
     data->inputs_to_sort[tmp]->row_loaded = 0;
 
   return zsv_compare_status_ok;
@@ -617,7 +592,8 @@ static enum zsv_compare_status zsv_compare_next(struct zsv_compare_data *data) {
 
 static int compare_usage(void) {
   static const char *usage[] = {
-    "Usage: compare [options] [file1.csv] [file2.csv] [...]",
+    "Usage: compare [options] <file.csv>...",
+    "",
     "Options:",
     "  -h,--help          : show usage",
     "  -k,--key <colname> : specify a column to match rows on",
@@ -640,49 +616,48 @@ static int compare_usage(void) {
     "",
     "NOTES",
     "",
-    "    If no keys are specified, each row from each input is compared to the",
-    "    row in the corresponding position in each other input (all the first rows",
-    "    from each input are compared to each other, all the second rows are compared to",
-    "    each other, etc).",
+    "  If no keys are specified, each row from each input is compared to the",
+    "  row in the corresponding position in each other input (all the first rows",
+    "  from each input are compared to each other, all the second rows are compared to",
+    "  each other, etc).",
     "",
-    "    If one or more key is specified, each input is assumed to already be",
-    "    lexicographically sorted in ascending order; this is a necessary condition",
-    "    for the output to be correct (unless the --sort option is used). However, it",
-    "    is not required for each input to contain the same population of row keys",
+    "  If one or more key is specified, each input is assumed to already be",
+    "  lexicographically sorted in ascending order; this is a necessary condition",
+    "  for the output to be correct (unless the --sort option is used). However, it",
+    "  is not required for each input to contain the same population of row keys",
     "",
-    "    The --sort option uses sqlite3 (unindexed) sort and is intended to be a",
-    "    convenience rather than performance feature. If you need high performance",
-    "    sorting, other solutions, such as a multi-threaded parallel sort, are likely",
-    "    superior. For handling quoted data, `2tsv` can be used to convert to a delimited",
-    "    format without quotes, that can be directly parsed with common UNIX utilities",
-    "    (such as `sort`), and `select --unescape` can be used to convert back",
-    NULL
+    "  The --sort option uses sqlite3 (unindexed) sort and is intended to be a",
+    "  convenience rather than performance feature. If you need high performance",
+    "  sorting, other solutions, such as a multi-threaded parallel sort, are likely",
+    "  superior. For handling quoted data, `2tsv` can be used to convert to a delimited",
+    "  format without quotes, that can be directly parsed with common UNIX utilities",
+    "  (such as `sort`), and `select --unescape` can be used to convert back",
+    NULL,
   };
 
-  for(unsigned i = 0; usage[i]; i++)
+  for (size_t i = 0; usage[i]; i++)
     printf("%s\n", usage[i]);
-  printf("\n");
+
   return 0;
 }
 
 // TO DO: consolidate w sql.c, move common code to utils/db.c
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  /**
-   * See sql.c re passing options to sqlite3 when sorting is used
-   */
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  // See sql.c re passing options to sqlite3 when sorting is used
   (void)(opts_used);
-  if(argc < 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
+  if (argc < 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
     compare_usage();
     return argc < 2 ? 1 : 0;
   }
 
   // temporarily hold the input file names
   const char **input_filenames = calloc(argc, sizeof(*input_filenames));
-  if(!input_filenames)
+  if (!input_filenames)
     return zsv_compare_status_memory;
 
   zsv_compare_handle data = zsv_compare_new();
-  if(!data) {
+  if (!data) {
     free(input_filenames);
     return zsv_compare_status_memory;
   }
@@ -692,56 +667,50 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   unsigned input_count = 0;
   struct zsv_compare_key **next_key = &data->keys;
   struct zsv_compare_added_column **added_column_next = &data->added_columns;
-  for(int arg_i = 1; data->status == zsv_compare_status_ok
-        && !err && arg_i < argc; arg_i++) {
+  for (int arg_i = 1; data->status == zsv_compare_status_ok && !err && arg_i < argc; arg_i++) {
     const char *arg = argv[arg_i];
 #include <zsv/utils/arg.h>
-    if(!strcmp(arg, "-k") || !strcmp(arg, "--key")) {
+    if (!strcmp(arg, "-k") || !strcmp(arg, "--key")) {
       const char *next_arg = zsv_next_arg(++arg_i, argc, argv, &err);
-      if(next_arg) {
+      if (next_arg) {
         next_key = zsv_compare_key_add(next_key, next_arg, &err);
         data->key_count++;
       }
-    } else if(!strcmp(arg, "-a") || !strcmp(arg, "--add")) {
+    } else if (!strcmp(arg, "-a") || !strcmp(arg, "--add")) {
       const char *next_arg = zsv_next_arg(++arg_i, argc, argv, &err);
-      if(next_arg) {
+      if (next_arg) {
         zsv_compare_unique_colname *colname;
-        if((data->status =
-            zsv_compare_unique_colname_add(&data->added_colnames,
-                                           (const unsigned char *)next_arg,
-                                           strlen(next_arg), &colname))
-           == zsv_compare_status_ok) {
+        if ((data->status = zsv_compare_unique_colname_add(&data->added_colnames, (const unsigned char *)next_arg,
+                                                           strlen(next_arg), &colname)) == zsv_compare_status_ok) {
           // add to linked list for use after all data->output_colnames are allocated
-          added_column_next =
-            zsv_compare_added_column_add(added_column_next, colname,
-                                         &data->status);
-          if(data->status == zsv_compare_status_ok)
+          added_column_next = zsv_compare_added_column_add(added_column_next, colname, &data->status);
+          if (data->status == zsv_compare_status_ok)
             data->added_colcount++;
         }
       }
-    } else if(!strcmp(arg, "--tolerance")) {
+    } else if (!strcmp(arg, "--tolerance")) {
       const char *next_arg = zsv_next_arg(++arg_i, argc, argv, &err);
-      if(next_arg) {
-        if(zsv_strtod_exact(next_arg, &data->tolerance.value))
+      if (next_arg) {
+        if (zsv_strtod_exact(next_arg, &data->tolerance.value))
           fprintf(stderr, "Invalid numeric value: %s\n", next_arg), err = 1;
-        else if(data->tolerance.value < 0)
+        else if (data->tolerance.value < 0)
           fprintf(stderr, "Tolerance must be greater than zero (got %s)\n", next_arg), err = 1;
         else
           data->tolerance.value = nextafterf(data->tolerance.value, INFINITY);
       }
-    } else if(!strcmp(arg, "--sort")) {
+    } else if (!strcmp(arg, "--sort")) {
       data->sort = 1;
-    } else if(!strcmp(arg, "--exit-code") || !strcmp(arg, "-e")) {
+    } else if (!strcmp(arg, "--exit-code") || !strcmp(arg, "-e")) {
       data->return_count = 1;
-    } else if(!strcmp(arg, "--json")) {
+    } else if (!strcmp(arg, "--json")) {
       data->writer.type = ZSV_COMPARE_OUTPUT_TYPE_JSON;
-    } else if(!strcmp(arg, "--json-object")) {
+    } else if (!strcmp(arg, "--json-object")) {
       data->writer.type = ZSV_COMPARE_OUTPUT_TYPE_JSON;
       data->writer.object = 1;
-    } else if(!strcmp(arg, "--json-compact")) {
+    } else if (!strcmp(arg, "--json-compact")) {
       data->writer.type = ZSV_COMPARE_OUTPUT_TYPE_JSON;
       data->writer.compact = 1;
-    } else if(!strcmp(arg, "--print-key-colname")) {
+    } else if (!strcmp(arg, "--print-key-colname")) {
       data->print_key_col_names = 1;
     } else
       input_filenames[input_count++] = arg;
@@ -749,69 +718,66 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
   struct zsv_opts original_default_opts;
   struct zsv_prop_handler original_default_custom_prop_handler;
-  if(data->sort) {
-    if(!data->key_count) {
+  if (data->sort) {
+    if (!data->key_count) {
       fprintf(stderr, "Error: --sort requires one or more keys\n");
       data->status = zsv_compare_status_error;
     } else {
       original_default_opts = zsv_get_default_opts();
       zsv_set_default_opts(*opts);
 
-      if(custom_prop_handler) {
+      if (custom_prop_handler) {
         original_default_custom_prop_handler = zsv_get_default_custom_prop_handler();
         zsv_set_default_custom_prop_handler(*custom_prop_handler);
       }
 
-      if(data->status == zsv_compare_status_ok)
+      if (data->status == zsv_compare_status_ok)
         data->status = zsv_compare_init_sorted(data);
     }
   }
 
-  if(err && data->status == zsv_compare_status_ok)
+  if (err && data->status == zsv_compare_status_ok)
     data->status = zsv_compare_status_error;
-  else if(!input_count)
+  else if (!input_count)
     data->status = zsv_compare_status_error;
-  else if(data->status == zsv_compare_status_ok) {
-    if((data->status = zsv_compare_set_inputs(data, input_count)) == zsv_compare_status_ok) {
+  else if (data->status == zsv_compare_status_ok) {
+    if ((data->status = zsv_compare_set_inputs(data, input_count)) == zsv_compare_status_ok) {
       // initialize parsers
-      for(unsigned ix = 0; data->status == zsv_compare_status_ok && ix < input_count; ix++) {
+      for (unsigned ix = 0; data->status == zsv_compare_status_ok && ix < input_count; ix++) {
         struct zsv_compare_input *input = &data->inputs[ix];
         input->path = input_filenames[ix];
         data->status = data->input_init(data, input, opts, custom_prop_handler, opts_used);
       }
     }
 
-    if(data->status == zsv_compare_status_ok) {
+    if (data->status == zsv_compare_status_ok) {
       // find keys
-      for(unsigned i = 0; data->status == zsv_compare_status_ok && i < data->input_count; i++) {
+      for (unsigned i = 0; data->status == zsv_compare_status_ok && i < data->input_count; i++) {
         struct zsv_compare_input *input = &data->inputs[i];
-        if((input->col_count = data->get_column_count(input))) {
-          if(!(input->output_colnames = calloc(input->col_count, sizeof(*input->output_colnames)))) {
+        if ((input->col_count = data->get_column_count(input))) {
+          if (!(input->output_colnames = calloc(input->col_count, sizeof(*input->output_colnames)))) {
             data->status = zsv_compare_status_memory;
             break;
           }
         }
 
         unsigned found_keys = 0;
-        for(unsigned j = 0; j < input->col_count && !input->done
-              && data->status == zsv_compare_status_ok; j++) {
+        for (unsigned j = 0; j < input->col_count && !input->done && data->status == zsv_compare_status_ok; j++) {
           struct zsv_cell colname = data->get_column_name(input, j);
           const unsigned char *colname_s = colname.str;
           unsigned colname_len = colname.len;
           zsv_compare_unique_colname *input_col;
-          data->status =
-            zsv_compare_unique_colname_add(&input->colnames,
-                                           colname_s, colname_len,
-                                           &input_col);
-          if(data->status != zsv_compare_status_ok)
+          data->status = zsv_compare_unique_colname_add(&input->colnames, colname_s, colname_len, &input_col);
+          if (data->status != zsv_compare_status_ok)
             break;
 
-          if(input_col) {
+          if (input_col) {
             // now that we know this colname+instance_num is unique to this input
             // check if it is a key
-            for(unsigned key_ix = 0; found_keys < input->key_count && key_ix < input->key_count; key_ix++) {
+            for (unsigned key_ix = 0; found_keys < input->key_count && key_ix < input->key_count; key_ix++) {
               struct zsv_compare_input_key *k = &input->keys[key_ix];
-              if(!k->found && !zsv_strincmp(colname_s, colname_len, (const unsigned char *)k->key->name, strlen(k->key->name))) {
+              if (!k->found &&
+                  !zsv_strincmp(colname_s, colname_len, (const unsigned char *)k->key->name, strlen(k->key->name))) {
                 k->found = 1;
                 found_keys++;
                 k->col_ix = j;
@@ -822,17 +788,15 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
             // add it to the output
             int added = 0;
-            zsv_compare_unique_colname *output_col =
-              zsv_compare_unique_colname_add_if_not_found(&data->output_colnames,
-                                                          colname_s, colname_len,
-                                                          input_col->instance_num, &added);
-            if(!output_col) // error
+            zsv_compare_unique_colname *output_col = zsv_compare_unique_colname_add_if_not_found(
+              &data->output_colnames, colname_s, colname_len, input_col->instance_num, &added);
+            if (!output_col) // error
               data->status = zsv_compare_status_error;
             else {
-              if(added) {
-                if(*data->output_colnames_next)
+              if (added) {
+                if (*data->output_colnames_next)
                   (*data->output_colnames_next)->next = output_col;
-                if(!data->output_colnames_first)
+                if (!data->output_colnames_first)
                   data->output_colnames_first = output_col;
 
                 *data->output_colnames_next = output_col;
@@ -845,11 +809,11 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
           }
         }
 
-        if(found_keys != data->key_count) {
+        if (found_keys != data->key_count) {
           fprintf(stderr, "Unable to find the following keys in %s: ", input->path);
-          for(unsigned int j = 0; j < input->key_count; j++) {
+          for (unsigned int j = 0; j < input->key_count; j++) {
             struct zsv_compare_input_key *k = &input->keys[j];
-            if(!k->found)
+            if (!k->found)
               fprintf(stderr, "\n  %s", k->key->name);
           }
           fprintf(stderr, "\n");
@@ -858,46 +822,44 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       }
     }
 
-    if(data->status == zsv_compare_status_ok) {
-      if(data->output_colcount == 0)
+    if (data->status == zsv_compare_status_ok) {
+      if (data->output_colcount == 0)
         data->status = zsv_compare_status_no_data;
     }
 
     char started = 0;
-    if(data->status == zsv_compare_status_ok) {
+    if (data->status == zsv_compare_status_ok) {
       started = 1;
       zsv_compare_output_begin(data);
 
       // match output colnames to added columns
-      for(struct zsv_compare_added_column *ac = data->added_columns;
-          ac; ac = ac->next) {
-        zsv_compare_unique_colname col = { 0 };
+      for (struct zsv_compare_added_column *ac = data->added_columns; ac; ac = ac->next) {
+        zsv_compare_unique_colname col = {0};
         col.name = ac->colname->name;
         col.name_len = ac->colname->name_len;
         col.instance_num = ac->colname->instance_num;
         ac->output_colname = sglib_zsv_compare_unique_colname_find_member(data->output_colnames, &col);
-        if(!ac->output_colname)
+        if (!ac->output_colname)
           fprintf(stderr, "Warning: added column %.*s not found in any input\n", (int)col.name_len, col.name);
       }
 
       // assign out2in mappings
-      for(unsigned i = 0; data->status == zsv_compare_status_ok && i < data->input_count; i++) {
+      for (unsigned i = 0; data->status == zsv_compare_status_ok && i < data->input_count; i++) {
         struct zsv_compare_input *input = &data->inputs[i];
-        if(input->done)
+        if (input->done)
           continue;
-        if(!(input->out2in = calloc(data->output_colcount, sizeof(*input->out2in))))
+        if (!(input->out2in = calloc(data->output_colcount, sizeof(*input->out2in))))
           data->status = zsv_compare_status_memory;
         else {
-          for(unsigned j = 0; j < input->col_count; j++) {
+          for (unsigned j = 0; j < input->col_count; j++) {
             zsv_compare_unique_colname *output_col = input->output_colnames[j];
-            if(output_col) {
+            if (output_col) {
               input->out2in[output_col->output_ix] = j + 1;
 
               // check if this should be the source of any additional columns
-              for(struct zsv_compare_added_column *ac = data->added_columns;
-                  ac; ac = ac->next) {
-                if(!ac->input && ac->output_colname) {
-                  if(output_col == ac->output_colname) {
+              for (struct zsv_compare_added_column *ac = data->added_columns; ac; ac = ac->next) {
+                if (!ac->input && ac->output_colname) {
+                  if (output_col == ac->output_colname) {
                     ac->input = input;
                     ac->col_ix = j;
                   }
@@ -910,22 +872,22 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     }
 
     // assertions
-    if(data->status == zsv_compare_status_ok) {
+    if (data->status == zsv_compare_status_ok) {
       int ok = 0;
-      for(unsigned i = 0; i < data->input_count; i++)
-        if(!data->inputs[i].done)
+      for (unsigned i = 0; i < data->input_count; i++)
+        if (!data->inputs[i].done)
           ok++;
 
-      if(ok < 2) {
+      if (ok < 2) {
         fprintf(stderr, "Compare requires at least two non-empty inputs\n");
         data->status = zsv_compare_status_error;
       }
     }
 
     // next, compare each row
-    while(data->status == zsv_compare_status_ok && zsv_compare_next(data) == zsv_compare_status_ok)
+    while (data->status == zsv_compare_status_ok && zsv_compare_next(data) == zsv_compare_status_ok)
       ;
-    if(started)
+    if (started)
       zsv_compare_output_end(data);
   }
 
@@ -933,14 +895,14 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
   err = data->status == zsv_compare_status_ok ? 0 : 1;
 
-  if(data->sort) {
+  if (data->sort) {
     zsv_set_default_opts(original_default_opts); // restore default options
-    if(custom_prop_handler)
+    if (custom_prop_handler)
       zsv_set_default_custom_prop_handler(original_default_custom_prop_handler);
   }
 
-  if(data->return_count) {
-    if(err)
+  if (data->return_count) {
+    if (err)
       err = -1;
     else
       err = data->diff_count;

--- a/app/compare.h
+++ b/app/compare.h
@@ -12,12 +12,10 @@ enum zsv_compare_status {
 
 typedef struct zsv_compare_data *zsv_compare_handle;
 
-typedef int (*zsv_compare_cell_func)(void *ctx, struct zsv_cell, struct zsv_cell,
-                                     void *struct_zsv_compare_data,
+typedef int (*zsv_compare_cell_func)(void *ctx, struct zsv_cell, struct zsv_cell, void *struct_zsv_compare_data,
                                      unsigned input_col_ix);
 
 zsv_compare_handle zsv_compare_new(void);
-// enum zsv_compare_status zsv_compare_set_inputs(zsv_compare_handle, unsigned input_count, unsigned key_count);
 void zsv_compare_set_input_parser(zsv_compare_handle cmp, zsv_parser p, unsigned ix);
 void zsv_compare_delete(zsv_compare_handle);
 void zsv_compare_set_comparison(zsv_compare_handle, zsv_compare_cell_func, void *);

--- a/app/compare.h
+++ b/app/compare.h
@@ -2,8 +2,7 @@
 #define ZSV_COMPARE_H
 
 // public
-enum zsv_compare_status
-{
+enum zsv_compare_status {
   zsv_compare_status_ok = 0,
   zsv_compare_status_memory,
   zsv_compare_status_no_data,

--- a/app/compare.h
+++ b/app/compare.h
@@ -2,7 +2,8 @@
 #define ZSV_COMPARE_H
 
 // public
-enum zsv_compare_status {
+enum zsv_compare_status
+{
   zsv_compare_status_ok = 0,
   zsv_compare_status_memory,
   zsv_compare_status_no_data,

--- a/app/compare_added_column.c
+++ b/app/compare_added_column.c
@@ -1,10 +1,8 @@
-static struct zsv_compare_added_column **
-zsv_compare_added_column_add(struct zsv_compare_added_column **next,
-                              struct zsv_compare_unique_colname *added_colname,
-                              enum zsv_compare_status *stat
-                              ) {
+static struct zsv_compare_added_column **zsv_compare_added_column_add(struct zsv_compare_added_column **next,
+                                                                      struct zsv_compare_unique_colname *added_colname,
+                                                                      enum zsv_compare_status *stat) {
   struct zsv_compare_added_column *e = calloc(1, sizeof(*e));
-  if(!e)
+  if (!e)
     *stat = zsv_compare_status_memory;
   else {
     e->colname = added_colname;
@@ -15,7 +13,7 @@ zsv_compare_added_column_add(struct zsv_compare_added_column **next,
 }
 
 static void zsv_compare_added_column_delete(struct zsv_compare_added_column *e) {
-  for(struct zsv_compare_added_column *next; e; e = next) {
+  for (struct zsv_compare_added_column *next; e; e = next) {
     next = e->next;
     free(e);
   }

--- a/app/compare_internal.h
+++ b/app/compare_internal.h
@@ -50,10 +50,10 @@ struct zsv_compare_input {
 
   sqlite3_stmt *sort_stmt;
 
-  unsigned char row_loaded:1;
-  unsigned char missing:1;
-  unsigned char done:1;
-  unsigned char _:5;
+  unsigned char row_loaded : 1;
+  unsigned char missing : 1;
+  unsigned char done : 1;
+  unsigned char _ : 5;
 };
 
 struct zsv_compare_key {
@@ -99,10 +99,8 @@ struct zsv_compare_data {
   struct zsv_cell (*get_cell)(struct zsv_compare_input *input, unsigned ix);
   struct zsv_cell (*get_column_name)(struct zsv_compare_input *input, unsigned ix);
   unsigned (*get_column_count)(struct zsv_compare_input *input);
-  enum zsv_compare_status (*input_init)(struct zsv_compare_data *data,
-                                        struct zsv_compare_input *input,
-                                        struct zsv_opts *opts,
-                                        struct zsv_prop_handler *custom_prop_handler,
+  enum zsv_compare_status (*input_init)(struct zsv_compare_data *data, struct zsv_compare_input *input,
+                                        struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler,
                                         const char *opts_used);
 
   sqlite3 *sort_db; // used when --sort option was specified
@@ -110,8 +108,8 @@ struct zsv_compare_data {
   struct {
     double value;
 #define ZSV_COMPARE_MAX_NUMBER_BUFF_LEN 128
-    char   str1[ZSV_COMPARE_MAX_NUMBER_BUFF_LEN];
-    char   str2[ZSV_COMPARE_MAX_NUMBER_BUFF_LEN];
+    char str1[ZSV_COMPARE_MAX_NUMBER_BUFF_LEN];
+    char str2[ZSV_COMPARE_MAX_NUMBER_BUFF_LEN];
   } tolerance;
   struct {
     char type; // 'j' for json
@@ -126,17 +124,17 @@ struct zsv_compare_data {
       char **names;
     } properties;
 
-    unsigned cell_ix;        // only used for json + object output
-    unsigned char compact:1; // whether to output compact JSON
-    unsigned char object:1;  // whether to output JSON as objects
-    unsigned char _:6;
+    unsigned cell_ix;          // only used for json + object output
+    unsigned char compact : 1; // whether to output compact JSON
+    unsigned char object : 1;  // whether to output JSON as objects
+    unsigned char _ : 6;
   } writer;
 
-  unsigned char sort:1;
-  unsigned char sort_in_memory:1;
-  unsigned char print_key_col_names:1;
-  unsigned char return_count:1;
-  unsigned char _:4;
+  unsigned char sort : 1;
+  unsigned char sort_in_memory : 1;
+  unsigned char print_key_col_names : 1;
+  unsigned char return_count : 1;
+  unsigned char _ : 4;
 };
 
 #endif

--- a/app/compare_sort.c
+++ b/app/compare_sort.c
@@ -2,23 +2,19 @@
  * To implement sorting, we will use sqlite, create a table for each CSV file and run "select * order by ..."
  */
 
-static int zsv_compare_sort_prep_table(struct zsv_compare_data *data,
-                                       const char *fname,
-                                       const char *opts_used,
-                                       int max_columns,
-                                       char **err_msg,
-                                       unsigned int table_ix
-                                       ) {
+static int zsv_compare_sort_prep_table(struct zsv_compare_data *data, const char *fname, const char *opts_used,
+                                       int max_columns, char **err_msg, unsigned int table_ix) {
 #define ZSV_COMPARE_MAX_TABLES 1000
   char *sql = NULL;
-  if(table_ix > ZSV_COMPARE_MAX_TABLES)
+  if (table_ix > ZSV_COMPARE_MAX_TABLES)
     return -1;
 
-  if(max_columns == 0)
+  if (max_columns == 0)
     max_columns = 2048;
 
-  sql = sqlite3_mprintf("CREATE VIRTUAL TABLE data%i USING csv(filename=%Q,options_used=%Q,max_columns=%i)", table_ix, fname, opts_used, max_columns);
-  if(!sql)
+  sql = sqlite3_mprintf("CREATE VIRTUAL TABLE data%i USING csv(filename=%Q,options_used=%Q,max_columns=%i)", table_ix,
+                        fname, opts_used, max_columns);
+  if (!sql)
     return -1;
 
   int rc = sqlite3_exec(data->sort_db, sql, NULL, NULL, err_msg);
@@ -28,49 +24,42 @@ static int zsv_compare_sort_prep_table(struct zsv_compare_data *data,
 
 static int zsv_compare_sort_stmt_prep(sqlite3 *db, sqlite3_stmt **stmtp,
                                       // struct zsv_compare_sort *sort,
-                                      struct zsv_compare_key *keys,
-                                      unsigned ix) {
+                                      struct zsv_compare_key *keys, unsigned ix) {
   sqlite3_str *select_clause = sqlite3_str_new(db);
-  if(!select_clause) {
+  if (!select_clause) {
     fprintf(stderr, "Out of memory!\n");
     return -1;
   }
 
   sqlite3_str_appendf(select_clause, "select * from data%i order by ", ix);
-  for(struct zsv_compare_key *key = keys; key; key = key->next)
+  for (struct zsv_compare_key *key = keys; key; key = key->next)
     sqlite3_str_appendf(select_clause, "%s\"%w\"", key == keys ? "" : ", ", key->name);
 
   int rc = sqlite3_prepare_v2(db, sqlite3_str_value(select_clause), -1, stmtp, NULL);
-  if(rc != SQLITE_OK)
+  if (rc != SQLITE_OK)
     fprintf(stderr, "%s: %s\n", sqlite3_errstr(rc), sqlite3_str_value(select_clause));
   sqlite3_free(sqlite3_str_finish(select_clause));
   return rc;
 }
 
-static enum zsv_compare_status
-input_init_sorted(struct zsv_compare_data *data,
-                  struct zsv_compare_input *input,
-                  struct zsv_opts *_opts,
-                  struct zsv_prop_handler *_prop_handler,
-                  const char *opts_used
-                  ) {
+static enum zsv_compare_status input_init_sorted(struct zsv_compare_data *data, struct zsv_compare_input *input,
+                                                 struct zsv_opts *_opts, struct zsv_prop_handler *_prop_handler,
+                                                 const char *opts_used) {
   (void)(_opts);
   (void)(_prop_handler);
   char *err_msg = NULL;
   int rc = zsv_compare_sort_prep_table(data, input->path, opts_used, 0, &err_msg, input->index);
-  if(err_msg) {
+  if (err_msg) {
     fprintf(stderr, "%s\n", err_msg);
     sqlite3_free(err_msg);
   }
-  if(rc == SQLITE_OK)
-    rc = zsv_compare_sort_stmt_prep(data->sort_db, &input->sort_stmt,
-                                    data->keys,
-                                    input->index);
+  if (rc == SQLITE_OK)
+    rc = zsv_compare_sort_stmt_prep(data->sort_db, &input->sort_stmt, data->keys, input->index);
   return rc == SQLITE_OK ? zsv_compare_status_ok : zsv_compare_status_error;
 }
 
 static enum zsv_status zsv_compare_next_sorted_row(struct zsv_compare_input *input) {
-  if(sqlite3_step(input->sort_stmt) == SQLITE_ROW)
+  if (sqlite3_step(input->sort_stmt) == SQLITE_ROW)
     return zsv_status_row;
 
   // to do: check if error; if so return zsv_status_error
@@ -87,17 +76,16 @@ static struct zsv_cell zsv_compare_get_sorted_colname(struct zsv_compare_input *
 
 static unsigned zsv_compare_get_sorted_colcount(struct zsv_compare_input *input) {
   int col_count = sqlite3_column_count(input->sort_stmt);
-  if(col_count >= 0)
-    return (unsigned) col_count;
+  if (col_count >= 0)
+    return (unsigned)col_count;
   return 0;
 }
-
 
 static struct zsv_cell zsv_compare_get_sorted_cell(struct zsv_compare_input *input, unsigned ix) {
   struct zsv_cell c;
   c.str = (unsigned char *)sqlite3_column_text(input->sort_stmt, (int)ix);
   c.len = c.str ? sqlite3_column_bytes(input->sort_stmt, (int)ix) : 0;
-  if(c.len)
+  if (c.len)
     c.str = (unsigned char *)zsv_strtrim(c.str, &c.len);
   c.quoted = 1;
   return c;

--- a/app/compare_unique_colname.c
+++ b/app/compare_unique_colname.c
@@ -1,31 +1,32 @@
 static int zsv_compare_unique_colname_cmp(zsv_compare_unique_colname *x, zsv_compare_unique_colname *y) {
-  return x->instance_num == y->instance_num ?
-    zsv_stricmp(x->name, y->name) : x->instance_num > y->instance_num ? 1 : x->instance_num < y->instance_num ? -1 : 0;
+  return x->instance_num == y->instance_num  ? zsv_stricmp(x->name, y->name)
+         : x->instance_num > y->instance_num ? 1
+         : x->instance_num < y->instance_num ? -1
+                                             : 0;
 }
 
 SGLIB_DEFINE_RBTREE_FUNCTIONS(zsv_compare_unique_colname, left, right, color, zsv_compare_unique_colname_cmp);
 
 static void zsv_compare_unique_colname_delete(zsv_compare_unique_colname *e) {
-  if(e)
+  if (e)
     free(e->name);
   free(e);
 }
 
 static void zsv_compare_unique_colnames_delete(zsv_compare_unique_colname **tree) {
-  if(tree && *tree) {
+  if (tree && *tree) {
     struct sglib_zsv_compare_unique_colname_iterator it;
     struct zsv_compare_unique_colname *e;
-    for(e=sglib_zsv_compare_unique_colname_it_init(&it,*tree); e; e=sglib_zsv_compare_unique_colname_it_next(&it))
+    for (e = sglib_zsv_compare_unique_colname_it_init(&it, *tree); e; e = sglib_zsv_compare_unique_colname_it_next(&it))
       zsv_compare_unique_colname_delete(e);
     *tree = NULL;
   }
 }
 
-static struct zsv_compare_unique_colname *
-zsv_compare_unique_colname_new(const unsigned char *name, size_t len,
-                               unsigned instance_num) {
+static struct zsv_compare_unique_colname *zsv_compare_unique_colname_new(const unsigned char *name, size_t len,
+                                                                         unsigned instance_num) {
   zsv_compare_unique_colname *col = calloc(1, sizeof(*col));
-  if(!col || !(col->name = malloc(len + 1)))
+  if (!col || !(col->name = malloc(len + 1)))
     ; // handle out-of-memory error!
   else {
     memcpy(col->name, name, len);
@@ -37,15 +38,14 @@ zsv_compare_unique_colname_new(const unsigned char *name, size_t len,
 }
 
 // zsv_desc_column_update_unique(): return 1 if unique, 0 if dupe
-static zsv_compare_unique_colname *
-zsv_compare_unique_colname_add_if_not_found(struct zsv_compare_unique_colname **tree,
-                                            const unsigned char *utf8_value, size_t len,
-                                            unsigned instance_num,
-                                            int *added) {
+static zsv_compare_unique_colname *zsv_compare_unique_colname_add_if_not_found(struct zsv_compare_unique_colname **tree,
+                                                                               const unsigned char *utf8_value,
+                                                                               size_t len, unsigned instance_num,
+                                                                               int *added) {
   *added = 0;
   zsv_compare_unique_colname *col = zsv_compare_unique_colname_new(utf8_value, len, instance_num);
   zsv_compare_unique_colname *found = sglib_zsv_compare_unique_colname_find_member(*tree, col);
-  if(found) // not unique
+  if (found) // not unique
     zsv_compare_unique_colname_delete(col);
   else {
     sglib_zsv_compare_unique_colname_add(tree, col);
@@ -57,25 +57,19 @@ zsv_compare_unique_colname_add_if_not_found(struct zsv_compare_unique_colname **
 
 // add a colname to a list. allow duplicate names, but track instances
 // separately (i.e.
-static enum zsv_compare_status
-zsv_compare_unique_colname_add(zsv_compare_unique_colname **tree,
-                               const unsigned char *s,
-                               unsigned len,
-                               zsv_compare_unique_colname **new_col) {
+static enum zsv_compare_status zsv_compare_unique_colname_add(zsv_compare_unique_colname **tree, const unsigned char *s,
+                                                              unsigned len, zsv_compare_unique_colname **new_col) {
   int added = 0;
   unsigned instance_num = 0;
   zsv_compare_unique_colname *_new_col =
-    zsv_compare_unique_colname_add_if_not_found(tree, s, len,
-                                                instance_num, &added);
-  if(!_new_col)
+    zsv_compare_unique_colname_add_if_not_found(tree, s, len, instance_num, &added);
+  if (!_new_col)
     return zsv_compare_status_error;
 
-  if(!added) { // we've seen this column before in this input
+  if (!added) { // we've seen this column before in this input
     instance_num = ++_new_col->total_instances;
-    _new_col =
-      zsv_compare_unique_colname_add_if_not_found(tree, s, len,
-                                                  instance_num, &added);
-    if(!added) { // should not happen
+    _new_col = zsv_compare_unique_colname_add_if_not_found(tree, s, len, instance_num, &added);
+    if (!added) { // should not happen
 #ifndef NDEBUG
       fprintf(stderr, "Unexpected error! %s: %i\n", __FILE__, __LINE__);
 #endif

--- a/app/count-pull.c
+++ b/app/count-pull.c
@@ -14,31 +14,33 @@
 #include "zsv_command.h"
 
 static int count_usage() {
-  static const char *usage =
-    "Usage: count [options]\n"
-    "Options:\n"
-    " -h, --help            : show usage\n"
-    " [-i, --input] <filename>: use specified file input\n";
+  static const char *usage = "Usage: count [options]\n"
+                             "\n"
+                             "Options:\n"
+                             "  -h,--help              : show usage\n"
+                             "  -i,--input <filename>  : use specified file input\n";
   printf("%s\n", usage);
   return 0;
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
   const char *input_path = NULL;
   int err = 0;
-  for(int i = 1; !err && i < argc; i++) {
+  for (int i = 1; !err && i < argc; i++) {
     const char *arg = argv[i];
-    if(!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
+    if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
       count_usage();
       goto count_done;
-    } if(!strcmp(arg, "-i") || !strcmp(arg, "--input") || *arg != '-') {
+    }
+    if (!strcmp(arg, "-i") || !strcmp(arg, "--input") || *arg != '-') {
       err = 1;
-      if((!strcmp(arg, "-i") || !strcmp(arg, "--input")) && ++i >= argc)
+      if ((!strcmp(arg, "-i") || !strcmp(arg, "--input")) && ++i >= argc)
         fprintf(stderr, "%s option requires a filename\n", arg);
       else {
-        if(opts->stream)
+        if (opts->stream)
           fprintf(stderr, "Input may not be specified more than once\n");
-        else if(!(opts->stream = fopen(argv[i], "rb")))
+        else if (!(opts->stream = fopen(argv[i], "rb")))
           fprintf(stderr, "Unable to open for reading: %s\n", argv[i]);
         else {
           input_path = argv[i];
@@ -52,30 +54,28 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   }
 
 #ifdef NO_STDIN
-  if(!opts->stream || opts->stream == stdin) {
+  if (!opts->stream || opts->stream == stdin) {
     fprintf(stderr, "Please specify an input file\n");
     err = 1;
   }
 #endif
 
-  if(!err) {
+  if (!err) {
     zsv_parser parser;
-//    if(zsv_pull_new_with_properties(opts, input_path, opts_used, &parser) != zsv_status_ok) {
-    if(zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &parser) != zsv_status_ok) {
+    if (zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &parser) != zsv_status_ok) {
       fprintf(stderr, "Unable to initialize parser\n");
       err = 1;
     } else {
       size_t count = 0;
-//      zsv_pull_row r;
-      while(zsv_next_row(parser) == zsv_status_row)
+      while (zsv_next_row(parser) == zsv_status_row)
         count++;
       zsv_delete(parser);
-      printf("%zu\n", count  > 0 ? count - 1 : 0);
+      printf("%zu\n", count > 0 ? count - 1 : 0);
     }
   }
 
- count_done:
-  if(opts->stream && opts->stream != stdin)
+count_done:
+  if (opts->stream && opts->stream != stdin)
     fclose(opts->stream);
 
   return err;

--- a/app/count.c
+++ b/app/count.c
@@ -23,32 +23,34 @@ static void row(void *ctx) {
 }
 
 static int count_usage() {
-  static const char *usage =
-    "Usage: count [options]\n"
-    "Options:\n"
-    " -h, --help            : show usage\n"
-    " [-i, --input] <filename>: use specified file input\n";
+  static const char *usage = "Usage: count [options]\n"
+                             "\n"
+                             "Options:\n"
+                             "  -h,--help             : show usage\n"
+                             "  -i,--input <filename> : use specified file input\n";
   printf("%s\n", usage);
   return 0;
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  struct data data = { 0 };
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  struct data data = {0};
   const char *input_path = NULL;
   int err = 0;
-  for(int i = 1; !err && i < argc; i++) {
+  for (int i = 1; !err && i < argc; i++) {
     const char *arg = argv[i];
-    if(!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
+    if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
       count_usage();
       goto count_done;
-    } if(!strcmp(arg, "-i") || !strcmp(arg, "--input") || *arg != '-') {
+    }
+    if (!strcmp(arg, "-i") || !strcmp(arg, "--input") || *arg != '-') {
       err = 1;
-      if((!strcmp(arg, "-i") || !strcmp(arg, "--input")) && ++i >= argc)
+      if ((!strcmp(arg, "-i") || !strcmp(arg, "--input")) && ++i >= argc)
         fprintf(stderr, "%s option requires a filename\n", arg);
       else {
-        if(opts->stream)
+        if (opts->stream)
           fprintf(stderr, "Input may not be specified more than once\n");
-        else if(!(opts->stream = fopen(argv[i], "rb")))
+        else if (!(opts->stream = fopen(argv[i], "rb")))
           fprintf(stderr, "Unable to open for reading: %s\n", argv[i]);
         else {
           input_path = argv[i];
@@ -62,30 +64,30 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   }
 
 #ifdef NO_STDIN
-  if(!opts->stream || opts->stream == stdin) {
+  if (!opts->stream || opts->stream == stdin) {
     fprintf(stderr, "Please specify an input file\n");
     err = 1;
   }
 #endif
 
-  if(!err) {
+  if (!err) {
     opts->row_handler = row;
     opts->ctx = &data;
-    if(zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &data.parser) != zsv_status_ok) {
+    if (zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &data.parser) != zsv_status_ok) {
       fprintf(stderr, "Unable to initialize parser\n");
       err = 1;
     } else {
       enum zsv_status status;
-      while((status = zsv_parse_more(data.parser)) == zsv_status_ok)
+      while ((status = zsv_parse_more(data.parser)) == zsv_status_ok)
         ;
       zsv_finish(data.parser);
       zsv_delete(data.parser);
-      printf("%zu\n", data.rows  > 0 ? data.rows - 1 : 0);
+      printf("%zu\n", data.rows > 0 ? data.rows - 1 : 0);
     }
   }
 
- count_done:
-  if(opts->stream && opts->stream != stdin)
+count_done:
+  if (opts->stream && opts->stream != stdin)
     fclose(opts->stream);
 
   return err;

--- a/app/desc.c
+++ b/app/desc.c
@@ -40,17 +40,17 @@ struct zsv_desc_string_list {
 
 void zsv_desc_string_list_free(struct zsv_desc_string_list *e) {
   struct zsv_desc_string_list *n;
-  for( ; e; e = n) {
+  for (; e; e = n) {
     n = e->next;
-    if(e->value)
+    if (e->value)
       free(e->value);
     free(e);
   }
 }
 
 typedef struct zsv_desc_unique_key {
-  unsigned char color:1;
-  unsigned char _:7;
+  unsigned char color : 1;
+  unsigned char _ : 7;
   unsigned char *value;
   struct zsv_desc_unique_key *left;
   struct zsv_desc_unique_key *right;
@@ -60,13 +60,13 @@ struct zsv_desc_unique_key_container {
   struct zsv_desc_unique_key *key;
   size_t max_count;
   size_t count;
-  unsigned char not_enum:1;
-  unsigned char dummy:7;
+  unsigned char not_enum : 1;
+  unsigned char dummy : 7;
 };
 
 static struct zsv_desc_unique_key *zsv_desc_unique_key_new(const unsigned char *value, size_t len) {
   zsv_desc_unique_key *key = calloc(1, sizeof(*key));
-  if(!key || !(key->value = malloc(len + 1)))
+  if (!key || !(key->value = malloc(len + 1)))
     ; // handle out-of-memory error!
   else {
     memcpy(key->value, value, len);
@@ -76,7 +76,7 @@ static struct zsv_desc_unique_key *zsv_desc_unique_key_new(const unsigned char *
 }
 
 static void zsv_desc_unique_key_delete(zsv_desc_unique_key *e) {
-  if(e)
+  if (e)
     free(e->value);
   free(e);
 }
@@ -93,9 +93,9 @@ struct zsv_desc_column_data {
   char *name;
   unsigned int position;
 
-  unsigned char not_unique:1;
-  unsigned char not_unique_ci:1;
-  unsigned char _:6;
+  unsigned char not_unique : 1;
+  unsigned char not_unique_ci : 1;
+  unsigned char _ : 6;
 
   struct zsv_desc_unique_key_container unique_values;
   struct zsv_desc_unique_key_container unique_values_ci;
@@ -119,10 +119,10 @@ static void zsv_desc_column_data_finalize(struct zsv_desc_column_data *col, unsi
 }
 
 static void zsv_desc_column_unique_values_delete(zsv_desc_unique_key **tree) {
-  if(tree && *tree) {
+  if (tree && *tree) {
     struct sglib_zsv_desc_unique_key_iterator it;
     struct zsv_desc_unique_key *e;
-    for(e=sglib_zsv_desc_unique_key_it_init(&it,*tree); e; e=sglib_zsv_desc_unique_key_it_next(&it))
+    for (e = sglib_zsv_desc_unique_key_it_init(&it, *tree); e; e = sglib_zsv_desc_unique_key_it_next(&it))
       zsv_desc_unique_key_delete(e);
     *tree = NULL;
   }
@@ -140,11 +140,10 @@ struct zsv_desc_column_name {
   char *name;
 };
 
-
 static void zsv_desc_column_names_delete(struct zsv_desc_column_name **p) {
-  if(p && *p) {
+  if (p && *p) {
     struct zsv_desc_column_name *next;
-    for(struct zsv_desc_column_name *e = *p; e; e = next) {
+    for (struct zsv_desc_column_name *e = *p; e; e = next) {
       next = e->next;
       free(e->name);
       free(e);
@@ -199,66 +198,45 @@ struct zsv_desc_data {
   char *overflowed;
   size_t overflow_count;
 
-  unsigned char quick:1;
-  unsigned char _:7;
+  unsigned char quick : 1;
+  unsigned char _ : 7;
 };
 
 static void zsv_desc_finalize(struct zsv_desc_data *data) {
-  for(unsigned int i = 0; i < data->col_count; i++)
+  for (unsigned int i = 0; i < data->col_count; i++)
     zsv_desc_column_data_finalize(&data->columns[i], i);
 }
 
 static void write_headers(struct zsv_desc_data *data) {
-  // to do: adjust header for ZSV_DESC_FLAG options
-  const char *headers1[] =
-    {
-     "#",
-     "Column name",
-     "Min Length",
-     "Max Length",
-     NULL
-    };
-    const char *headers2[] = {
-     "Count",
-     "Blank %",
-     "Example 1",
-     "Example 2",
-     "Example 3",
-     "Example 4",
-     "Example 5",
-     NULL
-    };
-  for(int i = 0; headers1[i]; i++)
-    zsv_writer_cell(data->csv_writer, i == 0,
-                      (const unsigned char *)headers1[i],
-                      strlen(headers1[i]), 1);
+  // TO DO: adjust header for ZSV_DESC_FLAG options
+  const char *headers1[] = {"#", "Column name", "Min Length", "Max Length", NULL};
+  const char *headers2[] = {"Count", "Blank %", "Example 1", "Example 2", "Example 3", "Example 4", "Example 5", NULL};
+  for (int i = 0; headers1[i]; i++)
+    zsv_writer_cell(data->csv_writer, i == 0, (const unsigned char *)headers1[i], strlen(headers1[i]), 1);
 
-  if(data->flags & ZSV_DESC_FLAG_UNIQUE)
+  if (data->flags & ZSV_DESC_FLAG_UNIQUE)
     zsv_writer_cell_s(data->csv_writer, 0, (const unsigned char *)"Unique", 0);
 
-  if(data->flags & ZSV_DESC_FLAG_UNIQUE_CI)
+  if (data->flags & ZSV_DESC_FLAG_UNIQUE_CI)
     zsv_writer_cell_s(data->csv_writer, 0, (const unsigned char *)"Unique (case-insensitive)", 0);
 
-  for(int i = 0; headers2[i]; i++)
-    zsv_writer_cell(data->csv_writer, 0,
-                      (const unsigned char *)headers2[i],
-                      strlen(headers2[i]), 1);
+  for (int i = 0; headers2[i]; i++)
+    zsv_writer_cell(data->csv_writer, 0, (const unsigned char *)headers2[i], strlen(headers2[i]), 1);
 }
 
 static void zsv_desc_print(struct zsv_desc_data *data) {
-  if(data->header_only) {
-    for(unsigned int i = 0; i < data->col_count; i++) {
+  if (data->header_only) {
+    for (unsigned int i = 0; i < data->col_count; i++) {
       struct zsv_desc_column_data *c = &data->columns[i];
-      zsv_writer_cell(data->csv_writer, 1, (const unsigned char *)c->name,
-                      c->name ? strlen(c->name) : 0, 1);
+      zsv_writer_cell(data->csv_writer, 1, (const unsigned char *)c->name, c->name ? strlen(c->name) : 0, 1);
     }
   } else {
     write_headers(data);
-    for(unsigned int i = 0; i < data->col_count; i++) {
+    for (unsigned int i = 0; i < data->col_count; i++) {
       struct zsv_desc_column_data *c = &data->columns[i];
-      zsv_writer_cell_zu(data->csv_writer, 1, i+1);
+      zsv_writer_cell_zu(data->csv_writer, 1, i + 1);
       zsv_writer_cell_s(data->csv_writer, 0, (unsigned char *)c->name, 1);
-      if(c->lengths.lo) {
+      if (c->lengths.lo) {
         zsv_writer_cell_zu(data->csv_writer, 0, c->lengths.lo);
         zsv_writer_cell_zu(data->csv_writer, 0, c->lengths.hi);
       } else {
@@ -267,13 +245,13 @@ static void zsv_desc_print(struct zsv_desc_data *data) {
       }
 
       // unique
-      if(data->flags & ZSV_DESC_FLAG_UNIQUE) {
+      if (data->flags & ZSV_DESC_FLAG_UNIQUE) {
         const char *s = c->not_unique ? "FALSE" : "TRUE";
         zsv_writer_cell_s(data->csv_writer, 0, (const unsigned char *)s, 0);
       }
 
       // unique_ci
-      if(data->flags & ZSV_DESC_FLAG_UNIQUE_CI) {
+      if (data->flags & ZSV_DESC_FLAG_UNIQUE_CI) {
         const char *s = c->not_unique_ci ? "FALSE" : "TRUE";
         zsv_writer_cell_s(data->csv_writer, 0, (const unsigned char *)s, 0);
       }
@@ -281,11 +259,10 @@ static void zsv_desc_print(struct zsv_desc_data *data) {
       // count, blank %
       zsv_writer_cell_zu(data->csv_writer, 0, c->total_count);
       zsv_writer_cell_Lf(data->csv_writer, 0, ".2",
-                           ((long double)c->mblank.count) / (long double) (c->total_count)
-                           * (long double)100);
+                         ((long double)c->mblank.count) / (long double)(c->total_count) * (long double)100);
 
-      for(struct zsv_desc_string_list *sl = c->examples; sl; sl = sl->next) {
-        if(sl->count) {
+      for (struct zsv_desc_string_list *sl = c->examples; sl; sl = sl->next) {
+        if (sl->count) {
           char *tmp;
           asprintf(&tmp, "%s (%zu)", sl->value, sl->count + 1);
           zsv_writer_cell_s(data->csv_writer, 0, (unsigned char *)tmp, 1);
@@ -299,8 +276,8 @@ static void zsv_desc_print(struct zsv_desc_data *data) {
 
 static void zsv_desc_set_err(struct zsv_desc_data *data, enum zsv_desc_status err, char *msg) {
   data->err = err;
-  if(msg) {
-    if(data->err_msg)
+  if (msg) {
+    if (data->err_msg)
       free(msg);
     else
       data->err_msg = msg;
@@ -309,10 +286,10 @@ static void zsv_desc_set_err(struct zsv_desc_data *data, enum zsv_desc_status er
 
 // zsv_desc_column_update_unique(): return 1 if unique, 0 if dupe
 static int zsv_desc_column_update_unique(struct zsv_desc_unique_key_container *key_container,
-                                     const unsigned char *utf8_value, size_t len) {
+                                         const unsigned char *utf8_value, size_t len) {
   zsv_desc_unique_key *key = zsv_desc_unique_key_new(utf8_value, len);
-  if(sglib_zsv_desc_unique_key_find_member(key_container->key, key)) { // not unique
-    if(key_container->count > key_container->max_count) {
+  if (sglib_zsv_desc_unique_key_find_member(key_container->key, key)) { // not unique
+    if (key_container->count > key_container->max_count) {
       zsv_desc_column_unique_values_delete(&key_container->key);
       key_container->not_enum = 1;
     }
@@ -327,50 +304,49 @@ static int zsv_desc_column_update_unique(struct zsv_desc_unique_key_container *k
 
 static void zsv_desc_cell(void *ctx, unsigned char *restrict utf8_value, size_t len) {
   struct zsv_desc_data *data = ctx;
-  if(!data || data->err || data->done)
+  if (!data || data->err || data->done)
     return;
 
   // trim the cell values, so we don't count e.g. " abc" as different from "abc"
   utf8_value = (unsigned char *)zsv_strtrim(utf8_value, &len);
-  if(data->row_count == 0) {
-    if(data->current_column_ix < data->max_cols) {
+  if (data->row_count == 0) {
+    if (data->current_column_ix < data->max_cols) {
       struct zsv_desc_column_name *e = calloc(1, sizeof(*e));
-      if(!e) {
+      if (!e) {
         zsv_desc_set_err(data, zsv_desc_status_memory, NULL);
         return;
       }
 
-      if(len)
+      if (len)
         e->name = zsv_memdup(utf8_value, len);
       *data->column_names_tail = e;
       data->column_names_tail = &e->next;
     }
   } else {
-    if(data->current_column_ix < data->col_count) {
+    if (data->current_column_ix < data->col_count) {
       struct zsv_desc_column_data *col = &data->columns[data->current_column_ix];
-      if(col) {
+      if (col) {
         col->total_count++;
-        if(!len)
+        if (!len)
           col->mblank.count++;
         else {
-          if(col->lengths.lo == 0 || len < col->lengths.lo)
+          if (col->lengths.lo == 0 || len < col->lengths.lo)
             col->lengths.lo = len;
-          if(len > col->lengths.hi)
+          if (len > col->lengths.hi)
             col->lengths.hi = len;
-          if(col->examples_count < ZSV_DESC_MAX_EXAMPLE_COUNT || !data->quick) {
+          if (col->examples_count < ZSV_DESC_MAX_EXAMPLE_COUNT || !data->quick) {
             char already_have = 0;
-            if(!col->examples_tail)
+            if (!col->examples_tail)
               col->examples_tail = &col->examples;
-            for(struct zsv_desc_string_list *sl = col->examples; !already_have && sl; sl = sl->next) {
-              if(sl->value
-                 && !zsv_strincmp(utf8_value, len, sl->value, strlen((char *)sl->value))) {
+            for (struct zsv_desc_string_list *sl = col->examples; !already_have && sl; sl = sl->next) {
+              if (sl->value && !zsv_strincmp(utf8_value, len, sl->value, strlen((char *)sl->value))) {
                 already_have = 1;
                 sl->count++;
               }
             }
-            if(!already_have && col->examples_count < ZSV_DESC_MAX_EXAMPLE_COUNT) {
+            if (!already_have && col->examples_count < ZSV_DESC_MAX_EXAMPLE_COUNT) {
               struct zsv_desc_string_list *sl;
-              if((sl = *col->examples_tail = calloc(1, sizeof(*sl)))) {
+              if ((sl = *col->examples_tail = calloc(1, sizeof(*sl)))) {
                 col->examples_tail = &sl->next;
                 sl->value = zsv_memdup(utf8_value, len);
                 col->examples_count++;
@@ -378,20 +354,19 @@ static void zsv_desc_cell(void *ctx, unsigned char *restrict utf8_value, size_t 
             }
           }
 
-          if(data->flags & ZSV_DESC_FLAG_UNIQUE) {
-            if(!col->not_unique)
-              if(!zsv_desc_column_update_unique(&col->unique_values, utf8_value, len)) // dupe
+          if (data->flags & ZSV_DESC_FLAG_UNIQUE) {
+            if (!col->not_unique)
+              if (!zsv_desc_column_update_unique(&col->unique_values, utf8_value, len)) // dupe
                 col->not_unique = 1;
           }
 
-          if(data->flags & ZSV_DESC_FLAG_UNIQUE_CI) {
-            if(!col->not_unique_ci ||
-               !col->unique_values_ci.not_enum
-               // )
-               ) {
+          if (data->flags & ZSV_DESC_FLAG_UNIQUE_CI) {
+            if (!col->not_unique_ci || !col->unique_values_ci.not_enum
+                // )
+            ) {
               unsigned char *lc = zsv_strtolowercase(utf8_value, &len);
-              if(lc) {
-                if(!zsv_desc_column_update_unique(&col->unique_values_ci, lc, len))
+              if (lc) {
+                if (!zsv_desc_column_update_unique(&col->unique_values_ci, lc, len))
                   col->not_unique_ci = 1;
                 free(lc);
               }
@@ -407,33 +382,33 @@ static void zsv_desc_cell(void *ctx, unsigned char *restrict utf8_value, size_t 
 static void zsv_desc_row(void *ctx) {
   struct zsv_desc_data *data = ctx;
 
-  if(!data || data->err)
+  if (!data || data->err)
     return;
 
-  if(data->row_count == 0) {
-    if(data->current_column_ix < data->max_cols)
+  if (data->row_count == 0) {
+    if (data->current_column_ix < data->max_cols)
       data->col_count = data->current_column_ix;
     else
       data->current_column_ix = data->max_cols;
-    if(!(data->columns = calloc(data->col_count, sizeof(*data->columns)))) {
+    if (!(data->columns = calloc(data->col_count, sizeof(*data->columns)))) {
       zsv_desc_set_err(data, zsv_desc_status_memory, NULL);
       return;
     }
 
     struct zsv_desc_column_name *cn = data->column_names;
-    for(unsigned int i = 0; i < data->col_count && cn; cn = cn->next, i++) {
+    for (unsigned int i = 0; i < data->col_count && cn; cn = cn->next, i++) {
       struct zsv_desc_column_data *col = &data->columns[i];
-      if(cn->name && *cn->name) {
+      if (cn->name && *cn->name) {
         col->name = cn->name;
         cn->name = NULL;
       }
       col->unique_values_ci.max_count = data->max_enum;
     }
 
-    if(data->header_only)
+    if (data->header_only)
       data->done = 1;
   } else {
-    if(data->row_count % 50000 == 0 && data->opts->verbose)
+    if (data->row_count % 50000 == 0 && data->opts->verbose)
       fprintf(stderr, "%zu rows read\n", data->row_count);
   }
 
@@ -441,34 +416,30 @@ static void zsv_desc_row(void *ctx) {
   ++data->row_count;
 }
 
-const char *zsv_desc_usage_msg[] =
-  {
-   APPNAME ": get column-level information about a table's content",
-   "",
-   "Usage: " APPNAME " [<options>] <filename, or - for stdin>",
-   "  Describes a CSV table",
-   "  e.g. " APPNAME " data.csv",
-   "       " APPNAME " data.csv -a",
-   "",
-   "Options:",
-   "  -b, --with-bom : output with BOM",
-   "  -C <maximum_number_of_columns>: defaults to 1024",
-   "  -H: only output header names",
-   "  -q, --quick: minimize example counts,",
-   "  -a, --all: calculate all metadata (for now, this only adds uniqueness info)",
-   "  -o <output filename>: name of file to save output to (defaults to stdout)",
-   NULL
-  };
+const char *zsv_desc_usage_msg[] = {
+  APPNAME ": get column-level information about a table's content",
+  "",
+  "Usage: " APPNAME " [options] <filename>",
+  "",
+  "Options:",
+  "  -b,--with-bom            : output with BOM",
+  "  -C <max_num_of_columns>  : maximum number of columns (default: 1024)",
+  "  -H                       : output header names only",
+  "  -q,--quick               : minimize example counts",
+  "  -a,--all                 : calculate all metadata (for now, this only adds uniqueness info)",
+  "  -o <filename>            : filename to save output to (default: stdout)",
+  NULL,
+};
 
 static int zsv_desc_usage() {
-  for(int i = 0; zsv_desc_usage_msg[i]; i++)
+  for (size_t i = 0; zsv_desc_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_desc_usage_msg[i]);
   return 0;
 }
 
 static void zsv_desc_cleanup(struct zsv_desc_data *data) {
-  if(data->columns) {
-    for(unsigned int i = 0; i < data->col_count; i++)
+  if (data->columns) {
+    for (unsigned int i = 0; i < data->col_count; i++)
       zsv_desc_column_data_free(&data->columns[i]);
     free(data->columns);
     data->columns = NULL;
@@ -478,12 +449,12 @@ static void zsv_desc_cleanup(struct zsv_desc_data *data) {
   free(data->err_msg);
   data->err_msg = NULL;
 
-  if(data->opts->stream && data->opts->stream != stdin) {
+  if (data->opts->stream && data->opts->stream != stdin) {
     fclose(data->opts->stream);
     data->opts->stream = NULL;
   }
 
-  if(data->overflowed) {
+  if (data->overflowed) {
     fprintf(stderr, "Warning: data overflowed %zu times (example: %s)\n", data->overflow_count, data->overflowed);
     free(data->overflowed);
   }
@@ -492,42 +463,40 @@ static void zsv_desc_cleanup(struct zsv_desc_data *data) {
 
 #define ZSV_DESC_TMPFN_TEMPLATE "zsv_desc_XXXXXXXXXXXX"
 
-static void zsv_desc_execute(struct zsv_desc_data *data,
-                             struct zsv_prop_handler *custom_prop_handler,
-                             const char *input_path,
-                             const char *opts_used) {
+static void zsv_desc_execute(struct zsv_desc_data *data, struct zsv_prop_handler *custom_prop_handler,
+                             const char *input_path, const char *opts_used) {
   data->opts->cell_handler = zsv_desc_cell;
   data->opts->row_handler = zsv_desc_row;
   data->opts->ctx = data;
 
-  if(!data->max_enum)
+  if (!data->max_enum)
     data->max_enum = ZSV_DESC_MAX_ENUM_DEFAULT;
-  if(zsv_new_with_properties(data->opts, custom_prop_handler, input_path, opts_used, &data->parser)
-     == zsv_status_ok) {
+  if (zsv_new_with_properties(data->opts, custom_prop_handler, input_path, opts_used, &data->parser) == zsv_status_ok) {
     FILE *input_temp_file = NULL;
     enum zsv_status status;
-    if(input_temp_file)
+    if (input_temp_file)
       zsv_set_scan_filter(data->parser, zsv_filter_write, input_temp_file);
-    while(!zsv_signal_interrupted && (status = zsv_parse_more(data->parser)) == zsv_status_ok)
+    while (!zsv_signal_interrupted && (status = zsv_parse_more(data->parser)) == zsv_status_ok)
       ;
 
-    if(input_temp_file)
+    if (input_temp_file)
       fclose(input_temp_file);
     zsv_finish(data->parser);
     zsv_delete(data->parser);
   }
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  if(argc < 1)
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  if (argc < 1)
     zsv_desc_usage();
-  else if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
+  else if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
     zsv_desc_usage();
   else {
-    struct zsv_desc_data data = { 0 };
+    struct zsv_desc_data data = {0};
     const char *input_path = NULL;
     int err = 0;
-    if(opts->malformed_utf8_replace != ZSV_MALFORMED_UTF8_DO_NOT_REPLACE) // user specified to be 'none'
+    if (opts->malformed_utf8_replace != ZSV_MALFORMED_UTF8_DO_NOT_REPLACE) // user specified to be 'none'
       opts->malformed_utf8_replace = '?';
 
     data.opts = opts;
@@ -536,52 +505,50 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
     struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
 
-    for(int arg_i = 1; !data.err && arg_i < argc; arg_i++) {
-      if(!strcmp(argv[arg_i], "-b") || !strcmp(argv[arg_i], "--with-bom"))
+    for (int arg_i = 1; !data.err && arg_i < argc; arg_i++) {
+      if (!strcmp(argv[arg_i], "-b") || !strcmp(argv[arg_i], "--with-bom"))
         writer_opts.with_bom = 1;
-      else if(!strcmp(argv[arg_i], "-o") || !strcmp(argv[arg_i], "--output")) {
-        if(++arg_i >= argc)
-          data.err = zsv_printerr(zsv_desc_status_error,
-                                  "%s option requires a filename", argv[arg_i-1]);
-        else if(!(writer_opts.stream = fopen(argv[arg_i], "wb")))
-          data.err = zsv_printerr(zsv_desc_status_error,
-                                  "Unable to open for write: %s", argv[arg_i]);
-      } else if(!strcmp(argv[arg_i], "-a") || !strcmp(argv[arg_i], "--all"))
+      else if (!strcmp(argv[arg_i], "-o") || !strcmp(argv[arg_i], "--output")) {
+        if (++arg_i >= argc)
+          data.err = zsv_printerr(zsv_desc_status_error, "%s option requires a filename", argv[arg_i - 1]);
+        else if (!(writer_opts.stream = fopen(argv[arg_i], "wb")))
+          data.err = zsv_printerr(zsv_desc_status_error, "Unable to open for write: %s", argv[arg_i]);
+      } else if (!strcmp(argv[arg_i], "-a") || !strcmp(argv[arg_i], "--all"))
         data.flags = 0xff;
-      else if(!strcmp(argv[arg_i], "-q") || !strcmp(argv[arg_i], "--quick"))
+      else if (!strcmp(argv[arg_i], "-q") || !strcmp(argv[arg_i], "--quick"))
         data.quick = 1;
-      else if(!strcmp(argv[arg_i], "-H"))
+      else if (!strcmp(argv[arg_i], "-H"))
         data.header_only = 1;
-      else if(!strcmp(argv[arg_i], "-C")) {
+      else if (!strcmp(argv[arg_i], "-C")) {
         arg_i++;
-        if(!(arg_i < argc && atoi(argv[arg_i]) > 9))
-          data.err = zsv_printerr(zsv_desc_status_error, "-C (max cols) invalid: should be positive integer > 9 (got %s)", argv[arg_i]);
+        if (!(arg_i < argc && atoi(argv[arg_i]) > 9))
+          data.err = zsv_printerr(zsv_desc_status_error,
+                                  "-C (max cols) invalid: should be positive integer > 9 (got %s)", argv[arg_i]);
         else
           data.max_cols = atoi(argv[arg_i]);
-      }
-      else {
-        if(data.opts->stream) {
+      } else {
+        if (data.opts->stream) {
           err = 1;
           fprintf(stderr, "Input file specified twice, or unrecognized argument: %s\n", argv[arg_i]);
-        } else if(!(data.opts->stream = fopen(argv[arg_i], "rb"))) {
+        } else if (!(data.opts->stream = fopen(argv[arg_i], "rb"))) {
           err = 1;
           fprintf(stderr, "Could not open for reading: %s\n", argv[arg_i]);
         } else
           input_path = argv[arg_i];
 
-        if(data.opts->stream && data.opts->stream != stdin)
+        if (data.opts->stream && data.opts->stream != stdin)
           data.input_filename = argv[arg_i];
-        if(err)
+        if (err)
           data.err = err;
       }
     }
 
     zsv_handle_ctrl_c_signal();
 
-    if(!data.err && !(data.csv_writer = zsv_writer_new(&writer_opts)))
+    if (!data.err && !(data.csv_writer = zsv_writer_new(&writer_opts)))
       data.err = zsv_printerr(zsv_desc_status_error, "Unable to create csv writer");
 
-    if(!data.opts->stream) {
+    if (!data.opts->stream) {
 #ifdef NO_STDIN
       data.err = zsv_printerr(zsv_desc_status_error, "Please specify an input file");
 #else
@@ -589,7 +556,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #endif
     }
 
-    if(data.err) {
+    if (data.err) {
       zsv_desc_cleanup(&data);
       return 1;
     }

--- a/app/desc.c
+++ b/app/desc.c
@@ -152,7 +152,8 @@ static void zsv_desc_column_names_delete(struct zsv_desc_column_name **p) {
   }
 }
 
-enum zsv_desc_status {
+enum zsv_desc_status
+{
   zsv_desc_status_ok = 0,
   zsv_desc_status_error, // generic error
   zsv_desc_status_memory,

--- a/app/desc.c
+++ b/app/desc.c
@@ -152,8 +152,7 @@ static void zsv_desc_column_names_delete(struct zsv_desc_column_name **p) {
   }
 }
 
-enum zsv_desc_status
-{
+enum zsv_desc_status {
   zsv_desc_status_ok = 0,
   zsv_desc_status_error, // generic error
   zsv_desc_status_memory,

--- a/app/echo.c
+++ b/app/echo.c
@@ -22,8 +22,7 @@
 #include <zsv/utils/string.h>
 #include <zsv/utils/mem.h>
 
-enum zsv_echo_overwrite_input_type
-{ zsv_echo_overwrite_input_type_sqlite3 = 0 };
+enum zsv_echo_overwrite_input_type { zsv_echo_overwrite_input_type_sqlite3 = 0 };
 
 struct zsv_echo_data {
   FILE *in;

--- a/app/echo.c
+++ b/app/echo.c
@@ -169,7 +169,7 @@ const char *zsv_echo_usage_msg[] = {
   "",
   "- /path/to/file.csv",
   "  path to CSV file with columns row,col,val (in that order) and rows pre-sorted by row and column",
-  "" NULL,
+  NULL,
 };
 
 static int zsv_echo_usage() {

--- a/app/echo.c
+++ b/app/echo.c
@@ -22,9 +22,8 @@
 #include <zsv/utils/string.h>
 #include <zsv/utils/mem.h>
 
-enum zsv_echo_overwrite_input_type {
-  zsv_echo_overwrite_input_type_sqlite3 = 0
-};
+enum zsv_echo_overwrite_input_type
+{ zsv_echo_overwrite_input_type_sqlite3 = 0 };
 
 struct zsv_echo_data {
   FILE *in;

--- a/app/echo.c
+++ b/app/echo.c
@@ -22,7 +22,9 @@
 #include <zsv/utils/string.h>
 #include <zsv/utils/mem.h>
 
-enum zsv_echo_overwrite_input_type { zsv_echo_overwrite_input_type_sqlite3 = 0 };
+enum zsv_echo_overwrite_input_type {
+  zsv_echo_overwrite_input_type_sqlite3 = 0
+};
 
 struct zsv_echo_data {
   FILE *in;

--- a/app/ext_example/my_extension.c
+++ b/app/ext_example/my_extension.c
@@ -79,16 +79,14 @@ static enum zsv_ext_status echo_main(zsv_execution_context ctx, int argc, const 
 enum zsv_ext_status zsv_ext_init(struct zsv_ext_callbacks *cb, zsv_execution_context ctx) {
   zsv_cb = *cb;
   zsv_cb.ext_set_help(ctx, "Sample zsv extension");
-  zsv_cb.ext_set_license(ctx, "Unlicense. See https://github.com/spdx/license-list-data/blob/master/text/Unlicense.txt");
+  zsv_cb.ext_set_license(ctx,
+                         "Unlicense. See https://github.com/spdx/license-list-data/blob/master/text/Unlicense.txt");
   /**
    * In the common case where your extension uses third-party software, you can add
    * the related licenses and acknowledgements here, which `zsv` will display whenever
    * `zsv thirdparty` is invoked
    */
-  const char *third_party_licenses[] = {
-    "If we used any third-party software, we would list each license here",
-    NULL
-  };
+  const char *third_party_licenses[] = {"If we used any third-party software, we would list each license here", NULL};
   zsv_cb.ext_set_thirdparty(ctx, third_party_licenses);
   zsv_cb.ext_add_command(ctx, "count", "print the number of rows", count_main);
   zsv_cb.ext_add_command(ctx, "echo", "print the input data back to stdout", echo_main);
@@ -149,14 +147,14 @@ static void echo_rowhandler(void *ctx) {
    */
   zsv_parser parser = zsv_cb.ext_get_parser(ctx);
   unsigned j = zsv_cb.cell_count(parser);
-  for(unsigned i = 0; i < j; i++) {
+  for (unsigned i = 0; i < j; i++) {
     struct zsv_cell c = zsv_cb.get_cell(parser, i);
 
-     /**
-      * get_cell() returns a zsv_cell structure that holds a pointer to the text,
-      * the length (in bytes) of the data,
-      * and other parser-generated info (e.g. QUOTED flags)
-      */
+    /**
+     * get_cell() returns a zsv_cell structure that holds a pointer to the text,
+     * the length (in bytes) of the data,
+     * and other parser-generated info (e.g. QUOTED flags)
+     */
     /* write the cell contents to csv output */
     zsv_writer_cell(data->csv_writer, i == 0, c.str, c.len, c.quoted);
   }
@@ -183,7 +181,7 @@ static enum zsv_ext_status echo_main(zsv_execution_context ctx, int argc, const 
    * it accepts a 'quoted' flag that, if zero, tells it to not bother
    * checking for quote requirements and to just output the contents 'raw'
    */
-  if(!(data.csv_writer = zsv_writer_new(NULL)))
+  if (!(data.csv_writer = zsv_writer_new(NULL)))
     return zsv_ext_status_memory;
   zsv_writer_set_temp_buff(data.csv_writer, writer_buff, sizeof(writer_buff));
 
@@ -234,24 +232,22 @@ static enum zsv_ext_status echo_main(zsv_execution_context ctx, int argc, const 
  * Our main routine for counting is just like the one for echo, but even simpler
  * since we need not bother with a csv writer
  */
-static const char *count_help =
-  "count: print the number of rows in a CSV data file\n"
-  "\n"
-  "usage: count [-h,--help] [filename]\n"
-  ;
+static const char *count_help = "count: print the number of rows in a CSV data file\n"
+                                "\n"
+                                "usage: count [-h,--help] [filename]\n";
 
 enum zsv_ext_status count_main(zsv_execution_context ctx, int argc, const char *argv[]) {
   /* help */
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
     printf("%s", count_help);
     return zsv_ext_status_ok;
   }
 
   /* initialize private data. see above for details */
-  struct my_data data = { 0 };
+  struct my_data data = {0};
   struct zsv_opts opts = zsv_cb.ext_parser_opts(ctx);
 
-  if(argc > 1 && !(opts.stream = fopen(argv[1], "rb"))) {
+  if (argc > 1 && !(opts.stream = fopen(argv[1], "rb"))) {
     fprintf(stderr, "Unable to open for reading: %s\n", argv[1]);
     return 1;
   }
@@ -260,7 +256,7 @@ enum zsv_ext_status count_main(zsv_execution_context ctx, int argc, const char *
   enum zsv_ext_status stat = zsv_cb.ext_parse_all(ctx, &data, count_rowhandler, &opts);
 
   /* finish up */
-  if(stat == zsv_ext_status_ok)
+  if (stat == zsv_ext_status_ok)
     printf("Rows: %zu\n", data.rows > 0 ? data.rows - 1 : 0);
 
   return stat;

--- a/app/ext_example/test/expected/zsvext-test-3.out
+++ b/app/ext_example/test/expected/zsvext-test-3.out
@@ -7,14 +7,14 @@ zsv: streaming csv processor
 
 Usage:
   zsv version: display version info (and if applicable, extension info)
-  zsv (un)register [<extension_id>]: (un)register an extension
+  zsv (un)register [<extension_id>]    : (un)register an extension
       Registration info is saved in zsv.ini located in a directory determined as:
         ZSV_CONFIG_DIR environment variable value, if set
         otherwise, /usr/local/etc
   zsv help [<command>]
-  zsv <command> <options> <arguments>: run a command on data (see below for details)
-  zsv <id>-<cmd> <options> <arguments>: invoke command 'cmd' of extension 'id'
-  zsv thirdparty: view third-party licenses & acknowledgements
+  zsv <command> <options> <arguments>  : run a command on data (see below for details)
+  zsv <id>-<cmd> <options> <arguments> : invoke command 'cmd' of extension 'id'
+  zsv thirdparty                       : view third-party licenses & acknowledgements
   zsv license [<extension_id>]
 
 Options common to all commands except `prop`, `rm` and `jq`:
@@ -27,12 +27,12 @@ Options common to all commands except `prop`, `rm` and `jq`:
   -q,--no-quote            : turn off quote handling
   -R,--skip-head <n>       : skip specified number of initial rows
   -d,--header-row-span <n> : apply header depth (rowspan) of n
-  -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed UTF8 input
+  -u,--malformed-utf8-replacement <string>: replacement string (can be empty) in case of malformed UTF8 input
        (default for "desc" command is '?')
   -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows
   -0,--header-row <header> : insert the provided CSV as the first row (in position 0)
                              e.g. --header-row 'col1,col2,"my col 3"'
-  -v,--verbose: verbose output
+  -v,--verbose             : verbose output
 
 Commands that parse CSV or other tabular data:
   select   : extract rows/columns by name or position and perform other basic and 'cleanup' operations
@@ -65,14 +65,14 @@ zsv: streaming csv processor
 
 Usage:
   zsv version: display version info (and if applicable, extension info)
-  zsv (un)register [<extension_id>]: (un)register an extension
+  zsv (un)register [<extension_id>]    : (un)register an extension
       Registration info is saved in zsv.ini located in a directory determined as:
         ZSV_CONFIG_DIR environment variable value, if set
         otherwise, /usr/local/etc
   zsv help [<command>]
-  zsv <command> <options> <arguments>: run a command on data (see below for details)
-  zsv <id>-<cmd> <options> <arguments>: invoke command 'cmd' of extension 'id'
-  zsv thirdparty: view third-party licenses & acknowledgements
+  zsv <command> <options> <arguments>  : run a command on data (see below for details)
+  zsv <id>-<cmd> <options> <arguments> : invoke command 'cmd' of extension 'id'
+  zsv thirdparty                       : view third-party licenses & acknowledgements
   zsv license [<extension_id>]
 
 Options common to all commands except `prop`, `rm` and `jq`:
@@ -85,12 +85,12 @@ Options common to all commands except `prop`, `rm` and `jq`:
   -q,--no-quote            : turn off quote handling
   -R,--skip-head <n>       : skip specified number of initial rows
   -d,--header-row-span <n> : apply header depth (rowspan) of n
-  -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed UTF8 input
+  -u,--malformed-utf8-replacement <string>: replacement string (can be empty) in case of malformed UTF8 input
        (default for "desc" command is '?')
   -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows
   -0,--header-row <header> : insert the provided CSV as the first row (in position 0)
                              e.g. --header-row 'col1,col2,"my col 3"'
-  -v,--verbose: verbose output
+  -v,--verbose             : verbose output
 
 Commands that parse CSV or other tabular data:
   select   : extract rows/columns by name or position and perform other basic and 'cleanup' operations

--- a/app/ext_example/test/expected/zsvext-test-3.out
+++ b/app/ext_example/test/expected/zsvext-test-3.out
@@ -28,7 +28,7 @@ Options common to all commands except `prop`, `rm` and `jq`:
   -R,--skip-head <n>       : skip specified number of initial rows
   -d,--header-row-span <n> : apply header depth (rowspan) of n
   -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed UTF8 input
-       (default for "desc" commamnd is '?')
+       (default for "desc" command is '?')
   -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows
   -0,--header-row <header> : insert the provided CSV as the first row (in position 0)
                              e.g. --header-row 'col1,col2,"my col 3"'
@@ -86,7 +86,7 @@ Options common to all commands except `prop`, `rm` and `jq`:
   -R,--skip-head <n>       : skip specified number of initial rows
   -d,--header-row-span <n> : apply header depth (rowspan) of n
   -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed UTF8 input
-       (default for "desc" commamnd is '?')
+       (default for "desc" command is '?')
   -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows
   -0,--header-row <header> : insert the provided CSV as the first row (in position 0)
                              e.g. --header-row 'col1,col2,"my col 3"'

--- a/app/ext_example/test/expected/zsvext-test-thirdparty.out
+++ b/app/ext_example/test/expected/zsvext-test-thirdparty.out
@@ -1,10 +1,10 @@
-Third-party licenses and acknowldgements
+Third-party licenses and acknowledgements
 
 ==========================
 ZSV/lib third-party dependencies
 ==========================
 See https://github.com/liquidaty/zsv/blob/main/misc/THIRDPARTY.md
-Third-party licenses and acknowldgements
+Third-party licenses and acknowledgements
 
 ==========================
 ZSV/lib third-party dependencies

--- a/app/ext_template/README.md
+++ b/app/ext_template/README.md
@@ -1,34 +1,40 @@
-## Extension template
+# Extension template
 
-`zsv` can easily be extended by simply creating a shared library
-that implements the interface specified in zsv/ext/implementation.h
+`zsv` can easily be extended by simply creating a shared library that implements
+the interface specified in `zsv/ext/implementation.h`.
 
 This C file is a template you can use to implement your own extension.
 
 ## Using the template
 
 To use the template:
-1. Copy the files in this directory
-   (Makefile, configure, and YOUR_EXTENSION_zsvext.c)
-   to the location where your extension source will reside
-2. Customize YOUR_EXTENSION_zsvext.c as appropriate (see comments in
-   the C code for further details)
-3. Optionally, rename YOUR_EXTENSION_zsvext.c and update the Makefile
+
+1. Copy the files in this directory (Makefile, configure, and
+   `YOUR_EXTENSION_zsvext.c`) to the location where your extension source will
+   reside
+2. Customize `YOUR_EXTENSION_zsvext.c` as appropriate (see comments in the C
+   code for further details)
+3. Optionally, rename `YOUR_EXTENSION_zsvext.c` and update the Makefile
    accordingly
 
 ## Dependencies
+
 To build the extension, `zsvlib` and related include files must be installed
-(Obviously, since this is a zsv extension, you need `zsv` to run it)
+(Obviously, since this is a zsv extension, you need `zsv` to run it).
 
 ## Building
+
 To build the shared library file, run:
-```
+
+```shell
 ./configure && make
 ```
 
 To install, place the shared library file in any system path, or in the same
 folder as `zsv`, then run:
-```
+
+```shell
 zsv register XX
 ```
-where XX is the ID of your extension
+
+where XX is the ID of your extension.

--- a/app/ext_template/YOUR_EXTENSION_zsvext.c
+++ b/app/ext_template/YOUR_EXTENSION_zsvext.c
@@ -12,23 +12,22 @@
 #include <zsv/ext/implementation.h>
 
 /**
- * `zsv` can easily be extended by simply creating a shared library
- * that implements the interface specified in zsv/ext/implementation.h
+ * `zsv` can easily be extended by simply creating a shared library that
+ * implements the interface specified in zsv/ext/implementation.h
  *
- * This file is a template you can use to implement your own extension.
- * All you need to do is customize the sections marked with the word
- *   `YOUR`
+ * This file is a template you can use to implement your own extension. All you
+ * need to do is customize the sections marked with the word `YOUR`
  *
  * e.g. `YOUR_COMMAND` or `... YOUR CODE GOES HERE ...`
  *
- * replace any occurrences of "YOUR_COMMAND" with your (first) command, and
- * dupe any occurrences of "YOUR_COMMAND" for any additional commands
+ * replace any occurrences of "YOUR_COMMAND" with your (first) command, and dupe
+ * any occurrences of "YOUR_COMMAND" for any additional commands
  */
 
 /**
- * Define our extension ID. You canm make this anything you want, so long
- * as it is comprised of two ascii characters. In the rest of this file
- * commentary, XX refers to this extension ID
+ * Define our extension ID. You can make this anything you want, so long as it
+ * is comprised of two ascii characters. In the rest of this file commentary, XX
+ * refers to this extension ID
  */
 #define ZSV_THIS_EXT_ID "xx" /* YOUR EXTENSION ID GOES HERE */
 
@@ -72,9 +71,7 @@ static struct zsv_ext_callbacks zsv_cb;
  * but with an additional preceding zsv_execution_context parameter.
  * Here, we just declare the functions; we fully define them further below
  */
-static enum zsv_ext_status YOUR_COMMAND_main(
-  zsv_execution_context ctx, int argc, const char *argv[]
-);
+static enum zsv_ext_status YOUR_COMMAND_main(zsv_execution_context ctx, int argc, const char *argv[]);
 
 /*
   static enum zsv_ext_status YOUR_COMMAND2_main(...);
@@ -85,7 +82,7 @@ static enum zsv_ext_status YOUR_COMMAND_main(
 /**
  * *Required*. Initialization is called when our extension is loaded. Our
  * initialization routine uses `ext_add_command` to register our commands and
- * `ext_set_help` to set the help text. For each registerd command, we provide a
+ * `ext_set_help` to set the help text. For each registered command, we provide a
  * `*_main()` callback for zsv to invoke when a user runs our command
  *
  * @param callbacks pointers to zsvlib functions that we must save for later use
@@ -102,10 +99,7 @@ enum zsv_ext_status zsv_ext_init(struct zsv_ext_callbacks *cb, zsv_execution_con
    * the related licenses and acknowledgements here, which `zsv` will display whenever
    * `zsv thirdparty` is invoked
    */
-  static const char *third_party_licenses[] = {
-    "YOUR third-party licenses & acknowledgements go here",
-    NULL
-  };
+  static const char *third_party_licenses[] = {"YOUR third-party licenses & acknowledgements go here", NULL};
   zsv_cb.ext_set_thirdparty(ctx, third_party_licenses);
   zsv_cb.ext_add_command(ctx, "YOUR_COMMAND", "YOUR command description", YOUR_COMMAND_main);
 
@@ -167,7 +161,7 @@ static void YOUR_COMMAND_rowhandler(void *ctx) {
   /* get our private data */
   struct xx_data *data = zsv_cb.ext_get_context(ctx);
   data->rows++; /* replace this line with YOUR CODE */
-  
+
   /**
    * In most cases, we will want to do something with the row that was just parsed,
    * in which case we can use ext_get_parser(), column_count() and get_cell()
@@ -176,7 +170,7 @@ static void YOUR_COMMAND_rowhandler(void *ctx) {
    */
   zsv_parser parser = zsv_cb.ext_get_parser(ctx);
   unsigned cell_count = zsv_cb.column_count(parser);
-  for(unsigned i = 0; i < cell_count; i++) {
+  for (unsigned i = 0; i < cell_count; i++) {
     /**
      * get_cell() returns a zsv_cell structure that holds a pointer to the text,
      * the length (in bytes) of the data,
@@ -251,7 +245,7 @@ static enum zsv_ext_status YOUR_COMMAND_main(zsv_execution_context ctx, int argc
    */
 
   /* done parsing */
-  if(stat == zsv_ext_status_ok) {
+  if (stat == zsv_ext_status_ok) {
     /* Successful run. Replace the below line with YOUR CODE */
     printf("Rows: %zu\n", data.rows > 0 ? data.rows - 1 : 0);
   }

--- a/app/flatten.c
+++ b/app/flatten.c
@@ -21,8 +21,7 @@
 #include <zsv/utils/mem.h>
 #include <zsv/utils/string.h>
 
-enum flatten_agg_method
-{
+enum flatten_agg_method {
   flatten_agg_method_none = 1,
   flatten_agg_method_array
 };

--- a/app/flatten.c
+++ b/app/flatten.c
@@ -30,8 +30,8 @@ struct flatten_column_name_and_ix {
   unsigned char *name;
   size_t name_len;
   unsigned int ix_plus_1;
-  unsigned char free_name:1;
-  unsigned char	dummy:7;
+  unsigned char free_name : 1;
+  unsigned char dummy : 7;
 };
 
 struct chars_list {
@@ -41,19 +41,21 @@ struct chars_list {
 
 static struct chars_list *chars_list_new(const unsigned char *utf8_value, size_t len) {
   struct chars_list *e = calloc(1, sizeof(*e));
-  if(e)
+  if (e)
     e->value = zsv_memdup(utf8_value, len);
   return e;
 }
 
 #ifndef FREEIF
-#define FREEIF(x) if(x) free(x), x = NULL
+#define FREEIF(x)                                                                                                      \
+  if (x)                                                                                                               \
+  free(x), x = NULL
 #endif
 
 static void chars_lists_delete(struct chars_list **p) {
-  if(p && *p) {
+  if (p && *p) {
     struct chars_list *next;
-    for(struct chars_list *e = *p; e; e = next) {
+    for (struct chars_list *e = *p; e; e = next) {
       next = e->next;
       FREEIF(e->value);
       free(e);
@@ -78,12 +80,11 @@ struct flatten_agg_col_iterator {
   struct chars_list *current_cl;
 };
 
-static void flatten_agg_col_iterator_init(struct flatten_agg_col *c,
-                                   struct flatten_agg_col_iterator *i) {
+static void flatten_agg_col_iterator_init(struct flatten_agg_col *c, struct flatten_agg_col_iterator *i) {
   memset(i, 0, sizeof(*i));
-  switch(c->agg_method) {
+  switch (c->agg_method) {
   case flatten_agg_method_array:
-    if((i->current_cl = c->values))
+    if ((i->current_cl = c->values))
       i->str = i->current_cl->value;
     break;
   default:
@@ -92,7 +93,7 @@ static void flatten_agg_col_iterator_init(struct flatten_agg_col *c,
 }
 
 static void flatten_agg_col_iterator_replace_str(struct flatten_agg_col_iterator *i, unsigned char **new_s) {
-  if(i->current_cl)
+  if (i->current_cl)
     i->current_cl->value = *new_s;
   else {
     fprintf(stderr, "flatten_agg_col_iterator_replace_str() error: no current value to replace\n");
@@ -102,7 +103,7 @@ static void flatten_agg_col_iterator_replace_str(struct flatten_agg_col_iterator
 }
 
 static void flatten_agg_col_iterator_next(struct flatten_agg_col_iterator *i) {
-  if(i->current_cl && (i->current_cl = i->current_cl->next))
+  if (i->current_cl && (i->current_cl = i->current_cl->next))
     i->str = i->current_cl->value;
 }
 
@@ -111,9 +112,9 @@ static char flatten_agg_col_iterator_done(struct flatten_agg_col_iterator *i) {
 }
 
 static const unsigned char *flatten_agg_col_delimiter(struct flatten_agg_col *c) {
-  if(c->delimiter)
+  if (c->delimiter)
     return c->delimiter;
-  switch(c->agg_method) {
+  switch (c->agg_method) {
   case flatten_agg_method_none:
   case flatten_agg_method_array:
     return (const unsigned char *)"|";
@@ -122,10 +123,10 @@ static const unsigned char *flatten_agg_col_delimiter(struct flatten_agg_col *c)
 }
 
 static void flatten_agg_col_add_value(struct flatten_agg_col *c, const unsigned char *utf8_value, size_t len) {
-  if(!c->last_value)
+  if (!c->last_value)
     c->last_value = &c->values;
   struct chars_list *e = chars_list_new(utf8_value, len);
-  if(e) {
+  if (e) {
     *c->last_value = e;
     c->last_value = &e->next;
   }
@@ -140,8 +141,8 @@ typedef struct flatten_output_column {
 
   struct flatten_output_column *left;
   struct flatten_output_column *right;
-  unsigned char color:1;
-  unsigned char dummy:7;
+  unsigned char color : 1;
+  unsigned char dummy : 7;
 } flatten_output_column;
 
 void flatten_output_column_free(struct flatten_output_column *e) {
@@ -201,17 +202,15 @@ struct flatten_data {
 
   enum flatten_agg_method all_aggregation_method;
 
-  unsigned char cancelled:1;
-  unsigned char verbose:1;
-  unsigned char have_agg:1;
-  unsigned char dummy:5;
+  unsigned char cancelled : 1;
+  unsigned char verbose : 1;
+  unsigned char have_agg : 1;
+  unsigned char dummy : 5;
 };
 
-static int flatten_output_column_add(struct flatten_data *data,
-                                     const unsigned char *utf8_value, size_t len,
-                                     unsigned char *compare_name
-                                     ) {
-  if(data->output_column_total_count == data->max_cols) {
+static int flatten_output_column_add(struct flatten_data *data, const unsigned char *utf8_value, size_t len,
+                                     unsigned char *compare_name) {
+  if (data->output_column_total_count == data->max_cols) {
     free(compare_name);
     return zsv_printerr(1, "ERROR: Maximum number of columns (%i) exceeded", data->max_cols);
   }
@@ -231,20 +230,17 @@ static int flatten_output_column_add(struct flatten_data *data,
   return 0;
 }
 
-static flatten_output_column *flatten_output_column_find(struct flatten_data *data,
-                                                         const unsigned char *utf8_value,
-                                                         size_t len,
-                                                         unsigned char **compare_name
-                                                         ) {
+static flatten_output_column *flatten_output_column_find(struct flatten_data *data, const unsigned char *utf8_value,
+                                                         size_t len, unsigned char **compare_name) {
   flatten_output_column node, *found;
   node.compare_name = zsv_strtolowercase(utf8_value, &len);
-  if(node.compare_name) {
-    if((found = sglib_flatten_output_column_find_member(data->output_columns_by_value, &node))) {
+  if (node.compare_name) {
+    if ((found = sglib_flatten_output_column_find_member(data->output_columns_by_value, &node))) {
       free(node.compare_name);
       return found;
     }
     // not found
-    if(compare_name)
+    if (compare_name)
       *compare_name = node.compare_name;
     else
       free(node.compare_name);
@@ -252,15 +248,16 @@ static flatten_output_column *flatten_output_column_find(struct flatten_data *da
   return NULL;
 }
 
-static void set_cnx(struct flatten_column_name_and_ix *cnx, const unsigned char *utf8_value, size_t len, unsigned int current_column_ix) {
-  if(!cnx->ix_plus_1) {
-    if(!cnx->name) { // none provided, assume its the next column
-      if((cnx->name = zsv_memdup(utf8_value, len))) {
+static void set_cnx(struct flatten_column_name_and_ix *cnx, const unsigned char *utf8_value, size_t len,
+                    unsigned int current_column_ix) {
+  if (!cnx->ix_plus_1) {
+    if (!cnx->name) { // none provided, assume its the next column
+      if ((cnx->name = zsv_memdup(utf8_value, len))) {
         cnx->free_name = 1;
         cnx->name_len = len;
       }
       cnx->ix_plus_1 = current_column_ix + 1;
-    } else if(!zsv_strincmp(cnx->name, len, utf8_value, len))
+    } else if (!zsv_strincmp(cnx->name, len, utf8_value, len))
       cnx->ix_plus_1 = current_column_ix + 1;
   }
 }
@@ -268,21 +265,17 @@ static void set_cnx(struct flatten_column_name_and_ix *cnx, const unsigned char 
 // flatten_cell1(): for any value in the "column name" column, add it to the list of columns
 static void flatten_cell1(void *hook, unsigned char *utf8_value, size_t len) {
   struct flatten_data *data = hook;
-  if(!data->cancelled) {
-    if(data->row_count == 0) {
-      struct flatten_column_name_and_ix *cnxlist[] =
-        {
-         &data->row_id_column,
-         &data->column_name_column,
-         &data->value_column
-        };
-      for(unsigned int i = 0; i < 3; i++)
-        if(cnxlist[i]->name || (!data->have_agg && i == data->current_column_index))
+  if (!data->cancelled) {
+    if (data->row_count == 0) {
+      struct flatten_column_name_and_ix *cnxlist[] = {&data->row_id_column, &data->column_name_column,
+                                                      &data->value_column};
+      for (unsigned int i = 0; i < 3; i++)
+        if (cnxlist[i]->name || (!data->have_agg && i == data->current_column_index))
           set_cnx(cnxlist[i], utf8_value, len, data->current_column_index);
-    } else if(data->current_column_index + 1 == data->column_name_column.ix_plus_1) {
+    } else if (data->current_column_index + 1 == data->column_name_column.ix_plus_1) {
       // we are in the "column name" column, so make sure we've added this to our columns to output
       unsigned char *compare_name = NULL;
-      if(!flatten_output_column_find(data, utf8_value, len, &compare_name) && compare_name)
+      if (!flatten_output_column_find(data, utf8_value, len, &compare_name) && compare_name)
         data->cancelled = flatten_output_column_add(data, utf8_value, len, compare_name);
     }
   }
@@ -291,7 +284,7 @@ static void flatten_cell1(void *hook, unsigned char *utf8_value, size_t len) {
 
 static void flatten_row1(void *hook) {
   struct flatten_data *data = hook;
-  if(data->cancelled)
+  if (data->cancelled)
     return;
   data->row_count++;
   data->current_column_index = 0;
@@ -299,35 +292,34 @@ static void flatten_row1(void *hook) {
 
 static void flatten_cell2(void *hook, unsigned char *utf8_value, size_t len) {
   struct flatten_data *data = hook;
-  if(!data->cancelled) {
-    if(data->row_count2 == 0) {
-      if(!data->row_id_column.ix_plus_1)
-        if(data->row_id_column.name || !data->have_agg)
+  if (!data->cancelled) {
+    if (data->row_count2 == 0) {
+      if (!data->row_id_column.ix_plus_1)
+        if (data->row_id_column.name || !data->have_agg)
           set_cnx(&data->row_id_column, utf8_value, len, data->current_column_index);
 
-      for(struct flatten_agg_col *c = data->agg_output_cols; c; c = c->next) {
-        if(c->column.name_len == len
-           && !zsv_strincmp(c->column.name, len, utf8_value, len))
+      for (struct flatten_agg_col *c = data->agg_output_cols; c; c = c->next) {
+        if (c->column.name_len == len && !zsv_strincmp(c->column.name, len, utf8_value, len))
           c->column.ix_plus_1 = data->current_column_index + 1;
       }
     } else {
-      if(data->current_column_index < data->agg_output_cols_vector_size) {
+      if (data->current_column_index < data->agg_output_cols_vector_size) {
         struct flatten_agg_col *c = data->agg_output_cols_vector[data->current_column_index];
-        if(c)
+        if (c)
           flatten_agg_col_add_value(c, utf8_value, len);
       }
 
-      if(data->current_column_index + 1 == data->column_name_column.ix_plus_1) // column name
+      if (data->current_column_index + 1 == data->column_name_column.ix_plus_1) // column name
         data->current_column_name_column = flatten_output_column_find(data, utf8_value, len, NULL);
 
-      else if(data->current_column_index + 1 == data->value_column.ix_plus_1) // value
+      else if (data->current_column_index + 1 == data->value_column.ix_plus_1) // value
         data->current_column_name_value = zsv_memdup(utf8_value, len);
 
-      else if(data->current_column_index + 1 == data->row_id_column.ix_plus_1) { // asset ID
-        if(!data->last_asset_id) { // no prior asset, so this is the first one
+      else if (data->current_column_index + 1 == data->row_id_column.ix_plus_1) { // asset ID
+        if (!data->last_asset_id) { // no prior asset, so this is the first one
           data->last_asset_id = data->current_asset_id = zsv_memdup(utf8_value, len);
           data->last_asset_id_len = len;
-        } else if(len != data->last_asset_id_len || memcmp(data->last_asset_id, utf8_value, len)) {
+        } else if (len != data->last_asset_id_len || memcmp(data->last_asset_id, utf8_value, len)) {
           // this is a different asset from the last one
           data->current_asset_id = zsv_memdup(utf8_value, len);
           data->current_asset_id_len = len;
@@ -342,25 +334,22 @@ static void flatten_cell2(void *hook, unsigned char *utf8_value, size_t len) {
 }
 
 static void flatten_output_header(struct flatten_data *data) {
-  zsv_writer_cell(data->csv_writer, 1, data->row_id_column.name,
-                    data->row_id_column.name_len, 1);
+  zsv_writer_cell(data->csv_writer, 1, data->row_id_column.name, data->row_id_column.name_len, 1);
   unsigned int i = 1;
-  for(struct flatten_output_column *col = data->output_columns_by_value_head;
-      col; col = col->next, i++) {
+  for (struct flatten_output_column *col = data->output_columns_by_value_head; col; col = col->next, i++) {
     zsv_writer_cell(data->csv_writer, 0, col->name, col->name_len, 1);
   }
 
-  for(struct flatten_agg_col *c = data->agg_output_cols; c; c = c->next)
+  for (struct flatten_agg_col *c = data->agg_output_cols; c; c = c->next)
     zsv_writer_cell(data->csv_writer, !i++, c->column.name, c->column.name_len, 1);
   data->output_row = 1;
 }
 
-static unsigned char *flatten_replace_delim(unsigned char *inout,
-                                            const unsigned char *delimiter, char replacement) {
-  if(!inout)
+static unsigned char *flatten_replace_delim(unsigned char *inout, const unsigned char *delimiter, char replacement) {
+  if (!inout)
     return NULL;
 
-  if(!strstr((char *)inout, (char *)delimiter))
+  if (!strstr((char *)inout, (char *)delimiter))
     return inout;
 
   unsigned int delim_len = strlen((char *)delimiter);
@@ -368,35 +357,32 @@ static unsigned char *flatten_replace_delim(unsigned char *inout,
   unsigned char *new_s = malloc(j + 1);
   int new_s_len = 0;
   char clen;
-  for(unsigned int i = 0; i < j; i += clen) {
+  for (unsigned int i = 0; i < j; i += clen) {
     clen = ZSV_UTF8_CHARLEN_NOERR((int)inout[i]);
-    if(i + clen <= j && strncmp((char *)inout + i, (char *)delimiter, delim_len))
-      for(int k = 0; k < clen; k++)
+    if (i + clen <= j && strncmp((char *)inout + i, (char *)delimiter, delim_len))
+      for (int k = 0; k < clen; k++)
         new_s[new_s_len++] = inout[i + k];
     else
       new_s[new_s_len++] = replacement;
   }
-  if(new_s)
+  if (new_s)
     new_s[new_s_len++] = 0;
   free(inout);
   return new_s;
 }
 
 static void output_current_row(struct flatten_data *data) {
-  if(data->last_asset_id) {
+  if (data->last_asset_id) {
     data->output_row++;
-    zsv_writer_cell(data->csv_writer, 1, data->last_asset_id,
-                      data->last_asset_id_len, 1);
-    for(struct flatten_output_column *col = data->output_columns_by_value_head;
-        col; col = col->next) {
+    zsv_writer_cell(data->csv_writer, 1, data->last_asset_id, data->last_asset_id_len, 1);
+    for (struct flatten_output_column *col = data->output_columns_by_value_head; col; col = col->next) {
       zsv_writer_cell(data->csv_writer, 0, col->current_value,
-                        col->current_value ? strlen((char *)col->current_value) : 0,
-                        1);
+                      col->current_value ? strlen((char *)col->current_value) : 0, 1);
     }
 
-    for(struct flatten_agg_col *c = data->agg_output_cols; c; c = c->next) {
+    for (struct flatten_agg_col *c = data->agg_output_cols; c; c = c->next) {
       const unsigned char *delimiter = flatten_agg_col_delimiter(c);
-      if(!delimiter)
+      if (!delimiter)
         delimiter = (const unsigned char *)"";
       size_t delimiter_len = strlen((const char *)delimiter);
       const char replacement = (*delimiter == '_' ? '.' : '_');
@@ -406,19 +392,19 @@ static void output_current_row(struct flatten_data *data) {
 
       struct flatten_agg_col_iterator it;
       int i = 0;
-      for(flatten_agg_col_iterator_init(c, &it); !flatten_agg_col_iterator_done(&it);
-          flatten_agg_col_iterator_next(&it), i++) {
-        if(i)
+      for (flatten_agg_col_iterator_init(c, &it); !flatten_agg_col_iterator_done(&it);
+           flatten_agg_col_iterator_next(&it), i++) {
+        if (i)
           joined_len += delimiter_len;
         it.str = flatten_replace_delim(it.str, delimiter, replacement);
         flatten_agg_col_iterator_replace_str(&it, &it.str);
-        if(it.str && *it.str)
+        if (it.str && *it.str)
           joined_len += strlen((char *)it.str);
       }
 
       unsigned char *value_to_print;
       size_t length_to_print;
-      if(!joined_len || !(value_to_print = malloc(joined_len))) {
+      if (!joined_len || !(value_to_print = malloc(joined_len))) {
         value_to_print = NULL;
         length_to_print = 0;
       } else {
@@ -426,16 +412,16 @@ static void output_current_row(struct flatten_data *data) {
         length_to_print = joined_len;
 
         i = 0;
-        for(flatten_agg_col_iterator_init(c, &it); !flatten_agg_col_iterator_done(&it);
-            flatten_agg_col_iterator_next(&it), i++) {
+        for (flatten_agg_col_iterator_init(c, &it); !flatten_agg_col_iterator_done(&it);
+             flatten_agg_col_iterator_next(&it), i++) {
           // append delimiter
-          if(i) {
+          if (i) {
             memcpy(cursor, delimiter, delimiter_len);
             cursor += delimiter_len;
           }
 
           // append value
-          if(it.str && *it.str) {
+          if (it.str && *it.str) {
             size_t len = strlen((char *)it.str);
             memcpy(cursor, it.str, len);
             cursor += len;
@@ -449,36 +435,36 @@ static void output_current_row(struct flatten_data *data) {
     }
   }
 
-  for(struct flatten_output_column *col = data->output_columns_by_value_head; col; col = col->next)
+  for (struct flatten_output_column *col = data->output_columns_by_value_head; col; col = col->next)
     FREEIF(col->current_value);
   FREEIF(data->last_asset_id);
 }
 
 static void flatten_row2(void *hook) {
   struct flatten_data *data = hook;
-  if(data->row_count2 == 0) {
-    if(!data->row_id_column.ix_plus_1)
+  if (data->row_count2 == 0) {
+    if (!data->row_id_column.ix_plus_1)
       fprintf(stderr, "No ID column found");
-    if(data->current_column_index) {
+    if (data->current_column_index) {
       // set up the agg column vector
       data->agg_output_cols_vector_size = data->current_column_index;
       data->agg_output_cols_vector = calloc(data->agg_output_cols_vector_size, sizeof(*data->agg_output_cols_vector));
-      for(struct flatten_agg_col *c = data->agg_output_cols; c; c = c->next) {
-        if(c->column.ix_plus_1)
-          data->agg_output_cols_vector[c->column.ix_plus_1-1] = c;
+      for (struct flatten_agg_col *c = data->agg_output_cols; c; c = c->next) {
+        if (c->column.ix_plus_1)
+          data->agg_output_cols_vector[c->column.ix_plus_1 - 1] = c;
       }
     }
   } else {
-    if(!data->current_asset_id && !data->last_asset_id)
+    if (!data->current_asset_id && !data->last_asset_id)
       fprintf(stderr, "Warning: disregarding row %i: no asset id", data->row_count2);
     else {
-      if(data->last_asset_id && data->last_asset_id != data->current_asset_id) {
+      if (data->last_asset_id && data->last_asset_id != data->current_asset_id) {
         output_current_row(data);
         data->last_asset_id = data->current_asset_id;
         data->last_asset_id_len = data->current_asset_id_len;
       }
-      if(data->current_column_name_column && data->current_column_name_value) {
-        if(data->current_column_name_column->current_value) {
+      if (data->current_column_name_column && data->current_column_name_value) {
+        if (data->current_column_name_column->current_value) {
           fprintf(stderr, "Warning: multiple values for column %s, id %s: %s and %s",
                   data->current_column_name_column->name, data->last_asset_id,
                   data->current_column_name_column->current_value, data->current_column_name_value);
@@ -495,40 +481,43 @@ static void flatten_row2(void *hook) {
   data->row_count2++;
 }
 
-const char *flatten_usage_msg[] =
-  {
-   APPNAME ": flatten a table, based on a single-column key assuming that rows to flatten always appear in contiguous blocks",
-   "",
-   "Usage: " APPNAME " [<filename>] [<options>] -- [aggregate_output_spec ...]",
-   "Each aggregate output specification is either (i) a single-column aggregation or (future: (ii) the \"*\" placeholder (in conjunction with -a)).",
-   "A single-column aggregation consists of the column name or index, followed by the equal sign (=) and then an aggregation method.",
-   "If the equal sign should be part of the column name, it can be escaped with a preceding backslash.",
-   "",
-   "The following aggregation methods may be used:"
-//   "  max",
-//   "  min",
-   "  array (pipe-delimited)",
-//   "  arrayjs (json)",
-   "  array_<delim> (user-specified delimiter)",
-//   "  unique (pipe-delimited)",
-//   "  uniquejs (json)",
-//   "  unique_<delim> (user-specified delimiter)",
-   "",
-   "Options:",
-   "  -b: output with BOM",
-   "  -v, --verbose: display verbose messages",
-   "  -C <max columns to output>: maximum number of columns to output",
-   "  -m <max rows per aggregation>: defaults to 1024. If this limit is reached for any aggregation,",
-   "     an error will be output",
-   "  --row-id <Row ID column name>: Required. name of column to group by",
-   "  --col-name <Column ID column name>: name of column specifying the output column name",
-   "  -V <Value column name>: name of column specifying the output value",
-   "  (future: -a <Aggregation method>: aggregation method to use for the select-all placeholder)",
-   "  -o <output filename>: name of file to save output to",
-   NULL
-   /*
-     EXAMPLE
-     echo 'row,col,val
+const char *flatten_usage_msg[] = {
+  APPNAME ": flatten a table",
+  "          based on a single-column key assuming that rows to flatten always appear in contiguous blocks",
+  "",
+  "Usage: " APPNAME " [<filename>] [<options>] -- [aggregate_output_spec ...]",
+  "",
+  "Each aggregate output specification is either (i) a single-column aggregation or (future: (ii) the \"*\"",
+  "placeholder (in conjunction with -a)). A single-column aggregation consists of the column name or index, followed",
+  "by the equal sign (=) and then an aggregation method. If the equal sign should be part of the column name, it can",
+  "be escaped with a preceding backslash.",
+  "",
+  "Aggregation methods:",
+  // "  max",
+  // "  min",
+  "  array (pipe-delimited)",
+  // "  arrayjs (json)",
+  "  array_<delim> (user-specified delimiter)",
+  // "  unique (pipe-delimited)",
+  // "  uniquejs (json)",
+  // "  unique_<delim> (user-specified delimiter)",
+  "",
+  "Options:",
+  "  -b                               : output with BOM",
+  "  -v,--verbose                     : display verbose messages",
+  "  -C <max_columns_to_output>       : maximum number of columns to output",
+  "  -m <max_rows_per_aggregation>    : maximum number of rows (default: 1024)",
+  "  --row-id <column_name>           : column name to group by",
+  "  --col-name <column_name>         : column name specifying the output column name",
+  "  -V <column_name>                 : column name specifying the output value",
+  "  -a <aggregation_method>          : aggregation method to use for the select-all placeholder (future)",
+  "  -o <filename>                    : filename to save output to",
+  NULL,
+};
+
+/*
+EXAMPLE
+echo 'row,col,val
 > A,ltv,100
 > A,loanid,A
 > A,hi,there
@@ -539,18 +528,17 @@ const char *flatten_usage_msg[] =
 row,ltv,loanid,hi,xxx
 A,100,A,there,
 B,90,B,you,zzz
-   */
-};
+*/
 
 static void flatten_usage() {
-  for(int i = 0; flatten_usage_msg[i]; i++)
+  for (size_t i = 0; flatten_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", flatten_usage_msg[i]);
 }
 
 void flatten_agg_cols_delete(struct flatten_agg_col **p) {
-  if(p && *p) {
+  if (p && *p) {
     struct flatten_agg_col *next;
-    for(struct flatten_agg_col *e = *p; e; e = next) {
+    for (struct flatten_agg_col *e = *p; e; e = next) {
       next = e->next;
       FREEIF(e->column.name);
       chars_lists_delete(&e->values);
@@ -562,7 +550,7 @@ void flatten_agg_cols_delete(struct flatten_agg_col **p) {
 
 static struct flatten_agg_col *flatten_agg_col_new(const char *arg, int *err) {
   struct flatten_agg_col *e = calloc(1, sizeof(*e));
-  if((e->column.name = (unsigned char *)strdup(arg))) {
+  if ((e->column.name = (unsigned char *)strdup(arg))) {
     e->column.name_len = strlen(arg);
   }
 
@@ -572,15 +560,15 @@ static struct flatten_agg_col *flatten_agg_col_new(const char *arg, int *err) {
 
   unsigned char *agg_method_s = NULL;
 
-  while(read && *read) {
-    if(*read == '=') { // end of name!
+  while (read && *read) {
+    if (*read == '=') { // end of name!
       *read = '\0';
       agg_method_s = read + 1;
       e->column.name_len = read - e->column.name;
       break;
-    } else if(*read == '\\') {
+    } else if (*read == '\\') {
       read++;
-      if(!*read)
+      if (!*read)
         break;
     }
 
@@ -589,24 +577,23 @@ static struct flatten_agg_col *flatten_agg_col_new(const char *arg, int *err) {
     read++;
   }
 
-  if(agg_method_s) {
-    if(!strcmp((const char *)agg_method_s, "array"))
+  if (agg_method_s) {
+    if (!strcmp((const char *)agg_method_s, "array"))
       e->agg_method = flatten_agg_method_array;
-    else if(!strncmp((const char *)agg_method_s, "array_", strlen("array_")) &&
-            strlen((const char *)agg_method_s) > strlen("array_")) {
+    else if (!strncmp((const char *)agg_method_s, "array_", strlen("array_")) &&
+             strlen((const char *)agg_method_s) > strlen("array_")) {
       e->agg_method = flatten_agg_method_array;
       e->delimiter = agg_method_s + strlen("array_");
     } else
-      *err = zsv_printerr(1, "Unrecognized aggregation method (expected array or array_<delim>): %s",
-                      agg_method_s);
+      *err = zsv_printerr(1, "Unrecognized aggregation method (expected array or array_<delim>): %s", agg_method_s);
   } else {
     *err = zsv_printerr(1, "No aggregation method specified for %s", arg);
-    while(write < write_end) {
+    while (write < write_end) {
       *write = '\0';
       write++;
     }
   }
-  if(!e->agg_method) {
+  if (!e->agg_method) {
     *err = 1;
     flatten_agg_cols_delete(&e);
   }
@@ -617,25 +604,20 @@ static struct flatten_agg_col *flatten_agg_col_new(const char *arg, int *err) {
 static void flatten_cleanup(struct flatten_data *data) {
   flatten_agg_cols_delete(&data->agg_output_cols);
 
-  if(data->in && data->in != stdin)
+  if (data->in && data->in != stdin)
     fclose(data->in);
 
-  if(data->out && data->out != stdout)
+  if (data->out && data->out != stdout)
     fclose(data->out);
 
-  struct flatten_column_name_and_ix *cnxlist[] =
-    {
-     &data->row_id_column,
-     &data->column_name_column,
-     &data->value_column
-    };
-  for(int i = 0; i < 3; i++) {
+  struct flatten_column_name_and_ix *cnxlist[] = {&data->row_id_column, &data->column_name_column, &data->value_column};
+  for (int i = 0; i < 3; i++) {
     struct flatten_column_name_and_ix *cnx = cnxlist[i];
-    if(cnx->free_name)
+    if (cnx->free_name)
       free(cnx->name);
   }
 
-  for(struct flatten_output_column *next, *e = data->output_columns_by_value_head; e; e = next) {
+  for (struct flatten_output_column *next, *e = data->output_columns_by_value_head; e; e = next) {
     next = e->next;
     flatten_output_column_free(e);
     free(e);
@@ -645,13 +627,14 @@ static void flatten_cleanup(struct flatten_data *data) {
   zsv_writer_delete(data->csv_writer);
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
     flatten_usage();
     return 0;
   }
 
-  struct flatten_data data = { 0 };
+  struct flatten_data data = {0};
   struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
 
   data.output_columns_by_value_tail = &data.output_columns_by_value_head;
@@ -661,59 +644,59 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   int err = 0;
   int agg_arg_i = 0;
 
-  for(int arg_i = 1; arg_i < argc; arg_i++) {
-    if(!strcmp(argv[arg_i], "--")) {
+  for (int arg_i = 1; arg_i < argc; arg_i++) {
+    if (!strcmp(argv[arg_i], "--")) {
       agg_arg_i = arg_i + 1;
       break;
-    } else if(!strcmp(argv[arg_i], "-b"))
+    } else if (!strcmp(argv[arg_i], "-b"))
       writer_opts.with_bom = 1;
-    else if(!strcmp(argv[arg_i], "-C")) {
-      if(!(arg_i + 1 < argc && atoi(argv[arg_i+1]) > 9))
-        err = zsv_printerr(1, "%s invalid: should be positive integer > 9 (got %s)", argv[arg_i], argv[arg_i+1]);
+    else if (!strcmp(argv[arg_i], "-C")) {
+      if (!(arg_i + 1 < argc && atoi(argv[arg_i + 1]) > 9))
+        err = zsv_printerr(1, "%s invalid: should be positive integer > 9 (got %s)", argv[arg_i], argv[arg_i + 1]);
       else
         data.max_cols = atoi(argv[++arg_i]);
-    } else if(!strcmp(argv[arg_i], "-m")) {
-      if(!(arg_i + 1 < argc && atoi(argv[arg_i+1]) > 1))
-        err = zsv_printerr(1, "%s invalid: should be positive integer > 1 (got %s)", argv[arg_i], argv[arg_i+1]);
+    } else if (!strcmp(argv[arg_i], "-m")) {
+      if (!(arg_i + 1 < argc && atoi(argv[arg_i + 1]) > 1))
+        err = zsv_printerr(1, "%s invalid: should be positive integer > 1 (got %s)", argv[arg_i], argv[arg_i + 1]);
       else
         data.max_rows_per_aggregation = atoi(argv[++arg_i]);
-    } else if(!strcmp(argv[arg_i], "--row-id")) { // used to be -i
-      if(!(arg_i + 1 < argc && *argv[arg_i + 1]))
+    } else if (!strcmp(argv[arg_i], "--row-id")) { // used to be -i
+      if (!(arg_i + 1 < argc && *argv[arg_i + 1]))
         err = zsv_printerr(1, "%s option: missing column name", argv[arg_i]);
       else {
         data.row_id_column.name = (unsigned char *)argv[++arg_i];
         data.row_id_column.name_len = strlen((char *)data.row_id_column.name);
       }
-    } else if(!strcmp(argv[arg_i], "--col-name")) { // used to be -c
-      if(!(arg_i + 1 < argc && *argv[arg_i + 1]))
+    } else if (!strcmp(argv[arg_i], "--col-name")) { // used to be -c
+      if (!(arg_i + 1 < argc && *argv[arg_i + 1]))
         err = zsv_printerr(1, "%s option: missing column name", argv[arg_i]);
       else {
         data.column_name_column.name = (unsigned char *)argv[++arg_i];
         data.column_name_column.name_len = strlen((char *)data.column_name_column.name);
       }
-    } else if(!strcmp(argv[arg_i], "-V")) {
-      if(!(arg_i + 1 < argc))
+    } else if (!strcmp(argv[arg_i], "-V")) {
+      if (!(arg_i + 1 < argc))
         err = zsv_printerr(1, "-V option: missing column name");
       else {
         data.value_column.name = (unsigned char *)argv[++arg_i];
         data.value_column.name_len = strlen((char *)data.value_column.name);
       }
-    } else if(!strcmp(argv[arg_i], "-o")) {
-      if(!(arg_i + 1 < argc))
+    } else if (!strcmp(argv[arg_i], "-o")) {
+      if (!(arg_i + 1 < argc))
         err = zsv_printerr(1, "-o option: missing filename");
-      else if(*argv[arg_i+1] == '-')
-        err = zsv_printerr(1, "-o option: filename may not start with '-' (got %s)", argv[arg_i+1]);
+      else if (*argv[arg_i + 1] == '-')
+        err = zsv_printerr(1, "-o option: filename may not start with '-' (got %s)", argv[arg_i + 1]);
       else
         data.output_filename = argv[++arg_i];
-    } else if(data.in)
+    } else if (data.in)
       err = zsv_printerr(1, "Input file was specified, cannot also read: %s", argv[arg_i]);
-    else if(!(data.in = fopen(argv[arg_i], "rb")))
+    else if (!(data.in = fopen(argv[arg_i], "rb")))
       err = zsv_printerr(1, "Could not open for reading: %s", argv[arg_i]);
     else
       data.input_path = argv[arg_i];
   }
 
-  if(!data.in) {
+  if (!data.in) {
 #ifdef NO_STDIN
     err = zsv_printerr(1, "Please specify an input file");
 #else
@@ -721,17 +704,17 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #endif
   }
 
-  if(err) {
+  if (err) {
     flatten_cleanup(&data);
     return 1;
   }
 
-  if(agg_arg_i && agg_arg_i < argc) {
+  if (agg_arg_i && agg_arg_i < argc) {
     struct flatten_agg_col **nextp = &data.agg_output_cols;
-    for(int arg_i = 0; !err && arg_i + agg_arg_i < argc; arg_i++) {
+    for (int arg_i = 0; !err && arg_i + agg_arg_i < argc; arg_i++) {
       const char *arg = argv[arg_i + agg_arg_i];
       struct flatten_agg_col *cs = flatten_agg_col_new(arg, &err);
-      if(cs) {
+      if (cs) {
         data.have_agg = 1;
         *nextp = cs;
         nextp = &cs->next;
@@ -739,7 +722,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     }
   }
 
-  if(!(data.out = data.output_filename ? fopen(data.output_filename, "wb") : stdout))
+  if (!(data.out = data.output_filename ? fopen(data.output_filename, "wb") : stdout))
     err = zsv_printerr(1, "Unable to open %s for writing", data.output_filename);
 
   int passes = data.column_name_column.name || !data.have_agg ? 2 : 1;
@@ -747,11 +730,11 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   FILE *in = NULL;
   char *tmp_fn = NULL;
   zsv_handle_ctrl_c_signal();
-  if(passes == 1)
+  if (passes == 1)
     in = data.in;
   else {
     tmp_fn = zsv_get_temp_filename("zsv_flatten_XXXXXXXX");
-    if(tmp_fn) {
+    if (tmp_fn) {
       FILE *tmp_f = fopen(tmp_fn, "w+b");
       opts->cell_handler = flatten_cell1;
       opts->row_handler = flatten_row1;
@@ -760,13 +743,12 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       opts->ctx = &data;
 
       zsv_parser handle;
-      if(zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &handle) != zsv_status_ok)
+      if (zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &handle) != zsv_status_ok)
         err = data.cancelled = zsv_printerr(1, "Unable to create csv parser");
       else {
         zsv_set_scan_filter(handle, zsv_filter_write, tmp_f);
         enum zsv_status status;
-        while(!data.cancelled && !zsv_signal_interrupted
-              && (status = zsv_parse_more(handle)) == zsv_status_ok)
+        while (!data.cancelled && !zsv_signal_interrupted && (status = zsv_parse_more(handle)) == zsv_status_ok)
           ;
         zsv_finish(handle);
         zsv_delete(handle);
@@ -777,26 +759,25 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     }
   }
 
-  if(!err) {
-    struct zsv_opts opts2 = { 0 };
+  if (!err) {
+    struct zsv_opts opts2 = {0};
     opts2.cell_handler = flatten_cell2;
     opts2.row_handler = flatten_row2;
     opts2.ctx = &data;
     data.current_column_index = 0;
 
-    if(!(data.csv_writer = zsv_writer_new(&writer_opts)))
+    if (!(data.csv_writer = zsv_writer_new(&writer_opts)))
       err = data.cancelled = zsv_printerr(1, "Unable to create csv writer");
 
     flatten_output_header(&data);
 
     opts2.stream = in;
     zsv_parser parser = zsv_new(&opts2);
-    if(!parser)
+    if (!parser)
       err = data.cancelled = zsv_printerr(1, "Unable to create csv parser");
 
     enum zsv_status status;
-    while(!data.cancelled && !zsv_signal_interrupted
-          && (status = zsv_parse_more(parser)) == zsv_status_ok)
+    while (!data.cancelled && !zsv_signal_interrupted && (status = zsv_parse_more(parser)) == zsv_status_ok)
       ;
     zsv_finish(parser);
     zsv_delete(parser);
@@ -804,10 +785,10 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   }
   flatten_cleanup(&data);
 
-  if(in && in != stdin)
+  if (in && in != stdin)
     fclose(in);
 
-  if(tmp_fn) {
+  if (tmp_fn) {
     unlink(tmp_fn);
     free(tmp_fn);
   }

--- a/app/flatten.c
+++ b/app/flatten.c
@@ -21,7 +21,8 @@
 #include <zsv/utils/mem.h>
 #include <zsv/utils/string.h>
 
-enum flatten_agg_method {
+enum flatten_agg_method
+{
   flatten_agg_method_none = 1,
   flatten_agg_method_array
 };

--- a/app/jq.c
+++ b/app/jq.c
@@ -15,7 +15,7 @@
  * separate `jq` installation for basic JSON parsing and manipulation
  */
 int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
-  if(argc < 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
+  if (argc < 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
     printf("Usage: " APPNAME " <filter> filename [-o,--output filename] [--csv]\n");
     return 0;
   }
@@ -26,7 +26,7 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
 #else
   const int min_args = 2;
 #endif
-  if(argc < min_args) {
+  if (argc < min_args) {
     fprintf(stderr, "Please provide a filter and an input file\n");
     return 1;
   }
@@ -42,21 +42,21 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
   int err = 0;
   const unsigned char *jqfilter = (const unsigned char *)argv[1];
 
-  for(int i = 2; !err && i < argc; i++) { // jq filter filename
+  for (int i = 2; !err && i < argc; i++) { // jq filter filename
     const char *arg = argv[i];
-    if(i == 2 && *arg != '-') {
-      if(!(f_in = fopen(arg, "rb"))) {
+    if (i == 2 && *arg != '-') {
+      if (!(f_in = fopen(arg, "rb"))) {
         err = 1;
         fprintf(stderr, "Unable to open for read: %s\n", arg);
       }
-    } else if(!strcmp(arg, "--csv")) {
+    } else if (!strcmp(arg, "--csv")) {
       to_csv = 1;
-    } else if(!strcmp(arg, "-o") || !strcmp(arg, "--output")) {
+    } else if (!strcmp(arg, "-o") || !strcmp(arg, "--output")) {
       i++;
-      if(!(i < argc)) {
+      if (!(i < argc)) {
         err = 1;
         fprintf(stderr, "Option %s requires a filename\n", arg);
-      } else if(!(f_out = fopen(argv[i], "wb"))) {
+      } else if (!(f_out = fopen(argv[i], "wb"))) {
         err = 1;
         fprintf(stderr, "Unable to open for write: %s\n", argv[i]);
       }
@@ -66,12 +66,12 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
     }
   }
 
-  if(!f_in) {
+  if (!f_in) {
     fprintf(stderr, "Please specify an input file\n");
     err = 1;
   }
 
-  if(!err) {
+  if (!err) {
     void (*jqfunc)(jv, void *) = to_csv ? jv_to_csv : jv_to_json_func;
     struct jv_to_json_ctx ctx;
     ctx.write1 = zsv_jq_fwrite1;
@@ -81,23 +81,23 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
     void *jqctx = to_csv ? (void *)f_out : (void *)&ctx;
     enum zsv_jq_status jqstat;
     zsv_jq_handle zjq = zsv_jq_new(jqfilter, jqfunc, jqctx, &jqstat);
-    if(jqstat != zsv_jq_status_ok) {
+    if (jqstat != zsv_jq_status_ok) {
       fprintf(stderr, "Invalid filter: %s\n", jqfilter);
       err = 1;
     } else {
-      if((jqstat = zsv_jq_parse_file(zjq, f_in)))
+      if ((jqstat = zsv_jq_parse_file(zjq, f_in)))
         err = jqstat;
-      if((jqstat = zsv_jq_finish(zjq)) && !err)
+      if ((jqstat = zsv_jq_finish(zjq)) && !err)
         err = jqstat;
-      if(!err && !to_csv)
+      if (!err && !to_csv)
         fprintf(f_out, "\n");
     }
     zsv_jq_delete(zjq);
   }
 
-  if(f_out && f_out != stdout)
+  if (f_out && f_out != stdout)
     fclose(f_out);
-  if(f_in && f_in != stdin)
+  if (f_in && f_in != stdin)
     fclose(f_in);
 
   return err;

--- a/app/mv.c
+++ b/app/mv.c
@@ -9,7 +9,8 @@
  * 1. check that the destination file doesn't exist. if it does, exit with an error
  * 2. if a cache exists, check that the destination file cache dir doesn't exist. if it does, exit with an error
  * 3. move the file. if it fails, exit with an error
- * 4. move the cache, if it exists. if it fails, attempt to move the file back to its original location, and exit with an error
+ * 4. move the cache, if it exists. if it fails, attempt to move the file back to its original location, and exit with
+ * an error
  */
 
 #include <stdlib.h>
@@ -31,23 +32,24 @@ const char *zsv_mv_usage_msg[] = {
   APPNAME ": move a file and its related cache",
   "",
   "Usage: " APPNAME " [options] <source> <destination>",
-  "  where options may be:",
-  "    -v,--verbose: verbose output",
-  "    -C,--cache  : only move related cache (not the file)",
-  NULL
+  "",
+  "Options:",
+  "  -v,--verbose         : verbose output",
+  "  -C,--cache           : only move related cache (not the file)",
+  NULL,
 };
 
 static int zsv_mv_usage(FILE *target) {
-  for(int j = 0; zsv_mv_usage_msg[j]; j++)
+  for (size_t j = 0; zsv_mv_usage_msg[j]; j++)
     fprintf(target, "%s\n", zsv_mv_usage_msg[j]);
   return target == stdout ? 0 : 1;
 }
 
 int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
   int err = 0;
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
     err = zsv_mv_usage(stdout);
-  else if(argc < 2)
+  else if (argc < 2)
     err = zsv_mv_usage(stderr);
   else {
     const char *source = NULL;
@@ -55,52 +57,50 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
 
     char move_file = 1;
     char verbose = 0;
-    for(int i = 1; !err && i < argc; i++) {
+    for (int i = 1; !err && i < argc; i++) {
       const char *arg = argv[i];
-      if(*arg == '-') {
-        if(!strcmp(arg, "-v") || !strcmp(arg, "--verbose"))
+      if (*arg == '-') {
+        if (!strcmp(arg, "-v") || !strcmp(arg, "--verbose"))
           verbose = 1;
-        else if(!strcmp(arg, "-C") || !strcmp(arg, "--cache"))
+        else if (!strcmp(arg, "-C") || !strcmp(arg, "--cache"))
           move_file = 0;
         else
           err = zsv_printerr(1, "Unrecognized option: %s", arg);
-      } else if(!source)
+      } else if (!source)
         source = arg;
-      else if(!dest)
+      else if (!dest)
         dest = arg;
       else
         err = zsv_printerr(1, "Unrecognized option: %s", arg);
     }
 
-    if(!err) {
+    if (!err) {
       unsigned char *source_cache_dir = zsv_cache_path((const unsigned char *)source, NULL, 0);
       unsigned char *dest_cache_dir = zsv_cache_path((const unsigned char *)dest, NULL, 0);
-      if(!source || !dest) {
+      if (!source || !dest) {
         err = zsv_mv_usage(stderr);
-      } else if(move_file && !zsv_file_exists(source)) {
+      } else if (move_file && !zsv_file_exists(source)) {
         err = errno = ENOENT;
         perror(source);
-      } else if(move_file && zsv_file_exists(dest)) {
+      } else if (move_file && zsv_file_exists(dest)) {
         err = errno = EEXIST;
         perror(dest);
-      } else if(zsv_dir_exists((const char *)source_cache_dir) && zsv_dir_exists((const char *)dest_cache_dir)) {
+      } else if (zsv_dir_exists((const char *)source_cache_dir) && zsv_dir_exists((const char *)dest_cache_dir)) {
         err = errno = EEXIST;
-        perror((char*)dest_cache_dir);
+        perror((char *)dest_cache_dir);
         fprintf(stderr, "Use `mv --cache %s <destination>` to move or `rm --cache %s` to remove, then try again\n",
                 dest, dest);
-      } else if(move_file && (verbose ? fprintf(stderr, "Renaming files\n") : 1)
-                && zsv_replace_file(source, dest)) {
+      } else if (move_file && (verbose ? fprintf(stderr, "Renaming files\n") : 1) && zsv_replace_file(source, dest)) {
         err = errno;
         fprintf(stderr, "%s -> %s: ", source, dest);
         zsv_perror(NULL);
-      } else if(zsv_dir_exists((const char *)source_cache_dir) && (verbose ? fprintf(stderr, "Moving caches\n") : 1)
-                && rename(// rename(): not sure will work on Win with NFS dirs...
-                          (char*)source_cache_dir, (char*)dest_cache_dir)
-                ) {
+      } else if (zsv_dir_exists((const char *)source_cache_dir) && (verbose ? fprintf(stderr, "Moving caches\n") : 1) &&
+                 rename( // rename(): not sure will work on Win with NFS dirs...
+                   (char *)source_cache_dir, (char *)dest_cache_dir)) {
         err = errno;
         fprintf(stderr, "%s -> %s: ", source_cache_dir, dest_cache_dir);
         perror(NULL);
-        if(rename(dest, source)) { // try to revert the prior rename. see above re Win + NFS
+        if (rename(dest, source)) { // try to revert the prior rename. see above re Win + NFS
           fprintf(stderr, "%s -> %s: ", dest, source);
           perror(NULL);
         }

--- a/app/noop.c
+++ b/app/noop.c
@@ -18,7 +18,8 @@ struct data {
   zsv_parser parser;
 };
 
-static void error(void *ctx, enum zsv_status status, const unsigned char *err_msg, size_t err_msg_len, unsigned char error_c, size_t cum_scanned_length) {
+static void error(void *ctx, enum zsv_status status, const unsigned char *err_msg, size_t err_msg_len,
+                  unsigned char error_c, size_t cum_scanned_length) {
   (void)(ctx);
   (void)(status);
   (void)(err_msg);
@@ -46,27 +47,27 @@ static void row(void *ctx) {
 int main(int argc, const char *argv[]) {
   FILE *f = NULL;
   struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
-  struct data data = { 0 };
+  struct data data = {0};
 
-  for(int i = 1; i < argc; i++) {
-    if(!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
+  for (int i = 1; i < argc; i++) {
+    if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
       fprintf(stdout, "Usage: noop [filename]\n");
       fprintf(stdout, "  Reads CSV input and does nothing. For performance testing\n\n");
       return 0;
-    } else if(!f) {
-      if(!(f = fopen(argv[i], "rb"))) {
+    } else if (!f) {
+      if (!(f = fopen(argv[i], "rb"))) {
         fprintf(stderr, "Unable to open %s for writing\n", argv[i]);
         return 1;
       }
     } else {
       fprintf(stderr, "Input file specified more than once (second was %s)\n", argv[i]);
-      if(f)
+      if (f)
         fclose(f);
       return 1;
     }
   }
 
-  if(!f)
+  if (!f)
     f = stdin;
 
   struct zsv_opts opts = zsv_get_default_opts();
@@ -77,10 +78,9 @@ int main(int argc, const char *argv[]) {
   opts.error = error;
 
   opts.stream = f;
-  if((data.parser = zsv_new(&opts))) {
+  if ((data.parser = zsv_new(&opts))) {
     zsv_handle_ctrl_c_signal();
-    enum zsv_status status;
-    while(!zsv_signal_interrupted && (status = zsv_parse_more(data.parser)) == zsv_status_ok)
+    while (!zsv_signal_interrupted && zsv_parse_more(data.parser) == zsv_status_ok)
       ;
     zsv_finish(data.parser);
     zsv_delete(data.parser);

--- a/app/paste.c
+++ b/app/paste.c
@@ -15,11 +15,10 @@
 #include "zsv_command.h"
 
 static int zsv_paste_usage() {
-  static const char *usage =
-    "Usage: paste <filename> [<filename> ...]\n"
-    "\n"
-    "Options:\n"
-    " -h, --help            : show usage\n";
+  static const char *usage = "Usage: paste <filename> [<filename> ...]\n"
+                             "\n"
+                             "Options:\n"
+                             "  -h,--help            : show usage\n";
   printf("%s\n", usage);
   return 1;
 }
@@ -44,10 +43,10 @@ enum zsv_paste_status {
 // zsv_paste_load_row: return number of inputs that a row was retrieved from
 static int zsv_paste_load_row(struct zsv_paste_input_file *inputs) {
   int have_row = 0;
-  for(struct zsv_paste_input_file *pf = inputs; pf; pf = pf->next) {
-    if(pf->zsv_status == zsv_status_row) {
+  for (struct zsv_paste_input_file *pf = inputs; pf; pf = pf->next) {
+    if (pf->zsv_status == zsv_status_row) {
       pf->zsv_status = zsv_next_row(pf->parser);
-      if(pf->zsv_status == zsv_status_row)
+      if (pf->zsv_status == zsv_status_row)
         have_row++;
     }
   }
@@ -56,16 +55,16 @@ static int zsv_paste_load_row(struct zsv_paste_input_file *inputs) {
 
 static void zsv_paste_print_row(zsv_csv_writer w, struct zsv_paste_input_file *inputs) {
   char first = 1;
-  for(struct zsv_paste_input_file *pf = inputs; pf; pf = pf->next) {
+  for (struct zsv_paste_input_file *pf = inputs; pf; pf = pf->next) {
     unsigned int j = pf->zsv_status == zsv_status_row ? zsv_cell_count(pf->parser) : 0;
     unsigned int k = pf->col_count;
 
-    for(unsigned int i = 0; i < j && i < k; i++) {
+    for (unsigned int i = 0; i < j && i < k; i++) {
       struct zsv_cell cell = zsv_get_cell(pf->parser, i);
       zsv_writer_cell(w, first, cell.str, cell.len, cell.quoted);
       first = 0;
     }
-    for(unsigned int i = j; i < k; i++) {
+    for (unsigned int i = j; i < k; i++) {
       zsv_writer_cell(w, first, (const unsigned char *)"", 0, 0);
       first = 0;
     }
@@ -73,29 +72,24 @@ static void zsv_paste_print_row(zsv_csv_writer w, struct zsv_paste_input_file *i
 }
 
 static void zsv_paste_delete_input(struct zsv_paste_input_file *pf) {
-  if(pf->parser)
+  if (pf->parser)
     zsv_delete(pf->parser);
-  if(pf->opts.stream)
+  if (pf->opts.stream)
     fclose(pf->opts.stream);
   free(pf);
 }
 
 // zsv_paste_add_input(): return error
-static enum zsv_paste_status zsv_paste_add_input(
-                                                 const char *fname,
-                                                 struct zsv_paste_input_file **next,
-                                                 struct zsv_paste_input_file ***next_next,
-                                                 struct zsv_opts *opts,
-                                                 struct zsv_prop_handler *custom_prop_handler,
-                                                 const char *opts_used
-                                                 ) {
+static enum zsv_paste_status zsv_paste_add_input(const char *fname, struct zsv_paste_input_file **next,
+                                                 struct zsv_paste_input_file ***next_next, struct zsv_opts *opts,
+                                                 struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
   FILE *f = fopen(fname, "rb");
-  if(!f) {
+  if (!f) {
     perror(fname);
     return zsv_paste_status_file;
   }
   struct zsv_paste_input_file *pf = calloc(1, sizeof(*pf));
-  if(!pf) {
+  if (!pf) {
     fclose(f);
     return zsv_paste_status_memory;
   }
@@ -106,11 +100,11 @@ static enum zsv_paste_status zsv_paste_add_input(
   *next = pf;
   *next_next = &pf->next;
 
-  if(zsv_new_with_properties(&pf->opts, custom_prop_handler, fname, opts_used, &pf->parser) != zsv_status_ok) {
+  if (zsv_new_with_properties(&pf->opts, custom_prop_handler, fname, opts_used, &pf->parser) != zsv_status_ok) {
     fprintf(stderr, "Unable to initialize parser for %s\n", fname);
     return zsv_paste_status_error;
   } else {
-    if((pf->zsv_status = zsv_next_row(pf->parser)) == zsv_status_row)
+    if ((pf->zsv_status = zsv_next_row(pf->parser)) == zsv_status_row)
       pf->col_count = zsv_cell_count(pf->parser);
     else
       fprintf(stderr, "Warning: no data read from %s\n", fname);
@@ -118,33 +112,34 @@ static enum zsv_paste_status zsv_paste_add_input(
   return zsv_paste_status_ok;
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
   struct zsv_paste_input_file *inputs = NULL;
   struct zsv_paste_input_file **next_input = &inputs;
   enum zsv_paste_status status = zsv_paste_status_ok;
 
   struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
   zsv_csv_writer writer = zsv_writer_new(&writer_opts);
-  if(!writer) {
+  if (!writer) {
     status = zsv_printerr(zsv_paste_status_error, "Unable to create csv writer");
     goto zsv_paste_done;
   }
 
-  for(int i = 1; status == zsv_paste_status_ok && i < argc; i++) {
+  for (int i = 1; status == zsv_paste_status_ok && i < argc; i++) {
     const char *arg = argv[i];
-    if(!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
+    if (!strcmp(arg, "-h") || !strcmp(arg, "--help")) {
       zsv_paste_usage();
       goto zsv_paste_done;
     }
 
-    if(0) { // !strcmp(arg, "-x") || !strcmp(arg, "--my-arg")) { ...
+    if (0) { // !strcmp(arg, "-x") || !strcmp(arg, "--my-arg")) { ...
     } else {
       status = zsv_paste_add_input(arg, next_input, &next_input, opts, custom_prop_handler, opts_used);
     }
   }
 
-  if(status == zsv_paste_status_ok) {
-    if(!inputs) {
+  if (status == zsv_paste_status_ok) {
+    if (!inputs) {
       fprintf(stderr, "Please specify at least one input file\n");
       status = zsv_paste_status_error;
       goto zsv_paste_done;
@@ -154,17 +149,17 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     zsv_paste_print_row(writer, inputs);
 
     // print one row at a time
-    while(zsv_paste_load_row(inputs))
+    while (zsv_paste_load_row(inputs))
       zsv_paste_print_row(writer, inputs);
   }
 
- zsv_paste_done:
-  for(struct zsv_paste_input_file *next, *pf = inputs; pf; pf = next) {
+zsv_paste_done:
+  for (struct zsv_paste_input_file *next, *pf = inputs; pf; pf = next) {
     next = pf->next;
     zsv_paste_delete_input(pf);
   }
 
-  if(opts->stream && opts->stream != stdin)
+  if (opts->stream && opts->stream != stdin)
     fclose(opts->stream);
 
   zsv_writer_delete(writer);

--- a/app/paste.c
+++ b/app/paste.c
@@ -33,8 +33,7 @@ struct zsv_paste_input_file {
   enum zsv_status zsv_status; // parser status
 };
 
-enum zsv_paste_status
-{
+enum zsv_paste_status {
   zsv_paste_status_ok = 0,
   zsv_paste_status_file,
   zsv_paste_status_memory,

--- a/app/paste.c
+++ b/app/paste.c
@@ -33,7 +33,8 @@ struct zsv_paste_input_file {
   enum zsv_status zsv_status; // parser status
 };
 
-enum zsv_paste_status {
+enum zsv_paste_status
+{
   zsv_paste_status_ok = 0,
   zsv_paste_status_file,
   zsv_paste_status_memory,

--- a/app/pretty.c
+++ b/app/pretty.c
@@ -37,7 +37,8 @@ struct zsv_pretty_opts {
   unsigned char dummy : 4;
 };
 
-enum zsv_pretty_status {
+enum zsv_pretty_status
+{
   zsv_pretty_status_ok = 0,
   zsv_pretty_status_error,
   zsv_pretty_status_memory,

--- a/app/pretty.c
+++ b/app/pretty.c
@@ -30,11 +30,11 @@ struct zsv_pretty_opts {
 
   FILE *out;
 
-  unsigned char ignore_header_lengths:1;
-  unsigned char markdown:1;
-  unsigned char markdown_pad:1;
-  unsigned char no_align:1;
-  unsigned char dummy:4;
+  unsigned char ignore_header_lengths : 1;
+  unsigned char markdown : 1;
+  unsigned char markdown_pad : 1;
+  unsigned char no_align : 1;
+  unsigned char dummy : 4;
 };
 
 enum zsv_pretty_status {
@@ -52,8 +52,8 @@ enum zsv_pretty_status {
 static size_t get_console_width() {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   int ret;
-  ret = GetConsoleScreenBufferInfo(GetStdHandle( STD_OUTPUT_HANDLE ),&csbi);
-  if(ret)
+  ret = GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+  if (ret)
     return csbi.dwSize.X;
   return 0;
 }
@@ -63,7 +63,9 @@ static size_t get_console_width() {
 #include <stdlib.h>
 
 #ifndef HAVE_TGETENT
-static size_t get_console_width() { return 0; }
+static size_t get_console_width() {
+  return 0;
+}
 
 #else
 #include <termcap.h>
@@ -80,7 +82,7 @@ static size_t get_console_width() {
 
 #endif // WIN32-else
 
-const unsigned char UTF8_ELLIPSIS[] = { 226,128,166,'\0'}; // e2 80 a6
+const unsigned char UTF8_ELLIPSIS[] = {226, 128, 166, '\0'}; // e2 80 a6
 
 struct zsv_cached_row {
   struct zsv_cached_row *next;
@@ -88,15 +90,13 @@ struct zsv_cached_row {
   unsigned int count;
 };
 
-static struct zsv_cell
-zsv_pretty_get_cell(zsv_parser parser,
-                           struct zsv_cached_row *r, unsigned ix) {
+static struct zsv_cell zsv_pretty_get_cell(zsv_parser parser, struct zsv_cached_row *r, unsigned ix) {
   struct zsv_cell c;
   memset(&c, 0, sizeof(c));
-  if(r) {
-    if(ix < r->count)
+  if (r) {
+    if (ix < r->count)
       c.str = r->values[ix];
-    if(!c.str)
+    if (!c.str)
       c.str = (unsigned char *)"";
     c.len = strlen((char *)c.str);
   } else
@@ -105,9 +105,9 @@ zsv_pretty_get_cell(zsv_parser parser,
 }
 
 static void zsv_cached_rows_delete(struct zsv_cached_row *first) {
-  for(struct zsv_cached_row *next, *e = first; e; e = next) {
+  for (struct zsv_cached_row *next, *e = first; e; e = next) {
     next = e->next;
-    for(unsigned int i = 0; i < e->count; i++)
+    for (unsigned int i = 0; i < e->count; i++)
       free(e->values[i]);
     free(e->values);
     free(e);
@@ -116,21 +116,21 @@ static void zsv_cached_rows_delete(struct zsv_cached_row *first) {
 
 static struct zsv_cached_row *zsv_pretty_dupe_row(zsv_parser parser) {
   unsigned col_count = zsv_cell_count(parser);
-  if(col_count) {
+  if (col_count) {
     struct zsv_cached_row *r = calloc(1, sizeof(*r));
-    if(r) {
+    if (r) {
       r->count = col_count;
       r->values = calloc(r->count, sizeof(*r->values));
-      if(!r->values) {
+      if (!r->values) {
         fprintf(stderr, "Error: out of memory\n");
         free(r);
         return NULL;
       }
 
-      for(unsigned int i = 0; i < r->count; i++) {
+      for (unsigned int i = 0; i < r->count; i++) {
         struct zsv_cell cell = zsv_get_cell(parser, i);
         cell.str = (unsigned char *)zsv_strtrim(cell.str, &cell.len);
-        if((r->values[i] = malloc(cell.len + 1))) {
+        if ((r->values[i] = malloc(cell.len + 1))) {
           memcpy(r->values[i], cell.str, cell.len);
           r->values[i][cell.len] = '\0';
         }
@@ -174,50 +174,46 @@ struct zsv_pretty_data {
 
   size_t first_column_count;
 
-  unsigned char no_trim:1;
-  unsigned char verbose:1;
-  unsigned char ignore_header_lengths:1;
-  unsigned char markdown:1;
-  unsigned char markdown_pad:1;
-  unsigned char no_align:1;
-  unsigned char dummy:2;
+  unsigned char no_trim : 1;
+  unsigned char verbose : 1;
+  unsigned char ignore_header_lengths : 1;
+  unsigned char markdown : 1;
+  unsigned char markdown_pad : 1;
+  unsigned char no_align : 1;
+  unsigned char dummy : 2;
 };
 
 static size_t zsv_pretty_get_width(struct zsv_pretty_data *data, size_t ix) {
-  if(ix < data->widths.used)
+  if (ix < data->widths.used)
     return data->widths.values[ix];
   return 0;
 }
 
-static size_t zsv_pretty_get_row_count(struct zsv_pretty_data *data,
-                                         struct zsv_cached_row *r) {
+static size_t zsv_pretty_get_row_count(struct zsv_pretty_data *data, struct zsv_cached_row *r) {
   return r ? r->count : zsv_cell_count(data->parser);
 }
 
-static void zsv_pretty_output_lineend(struct zsv_pretty_data *data,
-                                        struct zsv_cached_row *r) {
+static void zsv_pretty_output_lineend(struct zsv_pretty_data *data, struct zsv_cached_row *r) {
   size_t columns_used = zsv_pretty_get_row_count(data, r);
-//  size_t columns_used = zsv_row_cells_count(r);
-  char empty_line = columns_used == 0 ||
-    (columns_used == 1 &&
-     zsv_pretty_get_cell(data->parser, r, 0).len == 0);
+  //  size_t columns_used = zsv_row_cells_count(r);
+  char empty_line = columns_used == 0 || (columns_used == 1 && zsv_pretty_get_cell(data->parser, r, 0).len == 0);
 
-  if(empty_line)
+  if (empty_line)
     data->current_table_lines_written = 0;
-  else if(columns_used > 1) {
+  else if (columns_used > 1) {
     data->current_table_lines_written++;
-    if(data->markdown || data->markdown_pad) {
-      if(data->current_table_lines_written == 1) {
+    if (data->markdown || data->markdown_pad) {
+      if (data->current_table_lines_written == 1) {
         data->write("|\n", 1, 2, data->write_arg);
         size_t printed = 0;
-        for(unsigned col_ix = 0; printed < data->line.max && col_ix < columns_used; col_ix++) {
+        for (unsigned col_ix = 0; printed < data->line.max && col_ix < columns_used; col_ix++) {
           data->write("|", 1, 1, data->write_arg);
           printed++;
-          if(data->markdown_pad && col_ix <= data->widths.used) {
+          if (data->markdown_pad && col_ix <= data->widths.used) {
             int j = zsv_pretty_get_width(data, col_ix);
-            if(!j)
+            if (!j)
               j = 1;
-            for(; j-- && printed <= data->line.max; printed++)
+            for (; j-- && printed <= data->line.max; printed++)
               data->write("-", 1, 1, data->write_arg);
           } else
             data->write("--", 1, 2, data->write_arg);
@@ -232,39 +228,36 @@ static void zsv_pretty_output_lineend(struct zsv_pretty_data *data,
 }
 
 static void zsv_pretty_output_linestart(struct zsv_pretty_data *data) {
- if(data->markdown || data->markdown_pad)
-   data->write("|", 1, 1, data->write_arg);
+  if (data->markdown || data->markdown_pad)
+    data->write("|", 1, 1, data->write_arg);
 }
 
-
 static size_t is_newline(const unsigned char *utf8, int wchar_len) {
-  return (wchar_len == 1 && strchr("\n\r", utf8[0] ));
+  return (wchar_len == 1 && strchr("\n\r", utf8[0]));
   // add multibyte newline check?
 }
 
 // utf8_bytes_up_to_max_width: return number of bytes used up to a maximum screen width
 // max will be set to the actual width used
-static size_t
-utf8_bytes_up_to_max_width_and_replace_newlines(unsigned char *str1, size_t len1,
-                                                size_t max_width, size_t *used_width,
-                                                int *err) {
+static size_t utf8_bytes_up_to_max_width_and_replace_newlines(unsigned char *str1, size_t len1, size_t max_width,
+                                                              size_t *used_width, int *err) {
   utf8proc_int32_t codepoint1;
   utf8proc_ssize_t bytes_read1;
   size_t width_so_far = *used_width = 0;
   int this_char_width = 0;
   size_t bytes_so_far = 0;
-  while(bytes_so_far < len1) {
+  while (bytes_so_far < len1) {
     bytes_read1 = utf8proc_iterate((utf8proc_uint8_t *)str1 + bytes_so_far, len1, &codepoint1);
-    if(!bytes_read1) {
+    if (!bytes_read1) {
       bytes_read1 = 1;
       *err = 1;
       this_char_width = 1;
-    } else if(is_newline(str1 + bytes_so_far, bytes_read1)) {
+    } else if (is_newline(str1 + bytes_so_far, bytes_read1)) {
       memset((void *)(str1 + bytes_so_far), ' ', bytes_read1);
       continue;
     } else {
       this_char_width = utf8proc_charwidth(codepoint1);
-      if(width_so_far + this_char_width > max_width) {
+      if (width_so_far + this_char_width > max_width) {
         *used_width = width_so_far;
         return bytes_so_far;
       }
@@ -276,34 +269,34 @@ utf8_bytes_up_to_max_width_and_replace_newlines(unsigned char *str1, size_t len1
   return bytes_so_far;
 }
 
-void zsv_pretty_write_cell(unsigned char *buff, size_t bytes, struct zsv_pretty_data *data, size_t max_col_width, char last_column) {
-  if(data->line.max > data->line.printed) {
+void zsv_pretty_write_cell(unsigned char *buff, size_t bytes, struct zsv_pretty_data *data, size_t max_col_width,
+                           char last_column) {
+  if (data->line.max > data->line.printed) {
     size_t used_width = 0;
-    size_t max_width = max_col_width == 0 || max_col_width > data->line.max - data->line.printed ?
-      data->line.max - data->line.printed : max_col_width;
-    if(bytes) {
+    size_t max_width = max_col_width == 0 || max_col_width > data->line.max - data->line.printed
+                         ? data->line.max - data->line.printed
+                         : max_col_width;
+    if (bytes) {
       int utf8_err;
-      size_t bytes_to_print = utf8_bytes_up_to_max_width_and_replace_newlines(buff, bytes, max_width,
-                                                                              &used_width, &utf8_err);
+      size_t bytes_to_print =
+        utf8_bytes_up_to_max_width_and_replace_newlines(buff, bytes, max_width, &used_width, &utf8_err);
       char ellipsis = 0;
-      if(bytes_to_print && bytes_to_print < bytes && max_col_width == max_width && used_width == max_col_width) {
+      if (bytes_to_print && bytes_to_print < bytes && max_col_width == max_width && used_width == max_col_width) {
         ellipsis = 1;
-        if(max_width > 1)
-          bytes_to_print = utf8_bytes_up_to_max_width_and_replace_newlines(buff, bytes, max_width - 1,
-                                                                           &used_width, &utf8_err);
+        if (max_width > 1)
+          bytes_to_print =
+            utf8_bytes_up_to_max_width_and_replace_newlines(buff, bytes, max_width - 1, &used_width, &utf8_err);
       }
-      if(bytes_to_print) {
-        if((data->markdown || data->markdown_pad)
-           && (memchr(buff, '|', bytes_to_print)
-               || memchr(buff, '\\', bytes_to_print))
-           ) {
-          char *tmp = malloc(bytes_to_print*2);
-          if(!tmp)
+      if (bytes_to_print) {
+        if ((data->markdown || data->markdown_pad) &&
+            (memchr(buff, '|', bytes_to_print) || memchr(buff, '\\', bytes_to_print))) {
+          char *tmp = malloc(bytes_to_print * 2);
+          if (!tmp)
             data->parser_status = zsv_status_memory;
           else {
             size_t tmp_len = 0;
-            for(size_t i = 0; i < bytes_to_print; i++) {
-              if(memchr("|\\", buff[i], 2))
+            for (size_t i = 0; i < bytes_to_print; i++) {
+              if (memchr("|\\", buff[i], 2))
                 tmp[tmp_len++] = '\\';
               tmp[tmp_len++] = buff[i];
             }
@@ -314,7 +307,7 @@ void zsv_pretty_write_cell(unsigned char *buff, size_t bytes, struct zsv_pretty_
           data->write(buff, 1, bytes_to_print, data->write_arg);
         data->line.printed += used_width;
 
-        if(ellipsis) {
+        if (ellipsis) {
           data->write((unsigned char *)UTF8_ELLIPSIS, 1, strlen((const char *)UTF8_ELLIPSIS), data->write_arg);
           data->line.printed++;
           used_width++;
@@ -323,10 +316,9 @@ void zsv_pretty_write_cell(unsigned char *buff, size_t bytes, struct zsv_pretty_
         used_width = 0;
     }
 
-    if(data->markdown_pad
-       || (!data->markdown && !last_column)) {
+    if (data->markdown_pad || (!data->markdown && !last_column)) {
       size_t remaining = max_width - used_width;
-      while(remaining) {
+      while (remaining) {
         data->write((unsigned char *)" ", 1, 1, data->write_arg);
         data->line.printed++;
         --remaining;
@@ -335,45 +327,45 @@ void zsv_pretty_write_cell(unsigned char *buff, size_t bytes, struct zsv_pretty_
   }
 }
 
-#define zsv_pretty_output_col_spacer(data) do { \
-  if(data->line.printed < data->line.max) { \
-    data->write((unsigned char *)"|", 1, 1, data->write_arg);   \
-    data->line.printed++;                                       \
-  }                                                             \
-  } while(0)
+#define zsv_pretty_output_col_spacer(data)                                                                             \
+  do {                                                                                                                 \
+    if (data->line.printed < data->line.max) {                                                                         \
+      data->write((unsigned char *)"|", 1, 1, data->write_arg);                                                        \
+      data->line.printed++;                                                                                            \
+    }                                                                                                                  \
+  } while (0)
 
-static void zsv_pretty_output_row(struct zsv_pretty_data *data,
-                                    struct zsv_cached_row *r) {
+static void zsv_pretty_output_row(struct zsv_pretty_data *data, struct zsv_cached_row *r) {
   size_t columns_used = zsv_pretty_get_row_count(data, r);
   size_t columns_to_print = data->first_column_count > columns_used ? data->first_column_count : columns_used;
-  if(columns_used == 1) {
+  if (columns_used == 1) {
     struct zsv_cell cell = zsv_pretty_get_cell(data->parser, r, 0);
-    if(cell.len)
+    if (cell.len)
       zsv_pretty_write_cell(cell.str, cell.len, data, 0, 1);
   } else {
-    for(unsigned col_ix = 0; col_ix < columns_used; col_ix++) {
-      if(col_ix > 0)
+    for (unsigned col_ix = 0; col_ix < columns_used; col_ix++) {
+      if (col_ix > 0)
         zsv_pretty_output_col_spacer(data);
       else
         zsv_pretty_output_linestart(data);
       struct zsv_cell cell = zsv_pretty_get_cell(data->parser, r, col_ix);
-      zsv_pretty_write_cell(cell.str, cell.len, data, zsv_pretty_get_width(data, col_ix), col_ix + 1 == columns_to_print);
+      zsv_pretty_write_cell(cell.str, cell.len, data, zsv_pretty_get_width(data, col_ix),
+                            col_ix + 1 == columns_to_print);
     }
   }
 
   // pad the output with additional cells, if this row had fewer than the first row
-  if(!data->no_align && !data->markdown && !data->markdown_pad) {
-    if(data->first_column_count < 2)
+  if (!data->no_align && !data->markdown && !data->markdown_pad) {
+    if (data->first_column_count < 2)
       data->first_column_count = columns_used;
     else {
       unsigned char empty[2];
       empty[0] = '\0';
       empty[1] = '\0';
-      while(columns_used > 1 && columns_used < data->first_column_count) {
+      while (columns_used > 1 && columns_used < data->first_column_count) {
         zsv_pretty_output_col_spacer(data);
-        zsv_pretty_write_cell(empty, 0, data,
-                                zsv_pretty_get_width(data, columns_used),
-                                columns_used + 1 == columns_to_print);
+        zsv_pretty_write_cell(empty, 0, data, zsv_pretty_get_width(data, columns_used),
+                              columns_used + 1 == columns_to_print);
         columns_used++;
       }
     }
@@ -382,7 +374,7 @@ static void zsv_pretty_output_row(struct zsv_pretty_data *data,
 }
 
 static void zsv_pretty_output_cache(struct zsv_pretty_data *data) {
-  for(struct zsv_cached_row *c_row = data->cache.c_rows; c_row; c_row = c_row->next)
+  for (struct zsv_cached_row *c_row = data->cache.c_rows; c_row; c_row = c_row->next)
     zsv_pretty_output_row(data, c_row);
 }
 
@@ -394,8 +386,8 @@ static void zsv_pretty_clear_cache(struct zsv_pretty_data *data) {
 }
 
 static void set_min_col_widths(struct zsv_pretty_data *data, size_t used) {
-  for(unsigned i = 0; i < used; i++)
-    if(data->widths.values[i] < data->widths.min)
+  for (unsigned i = 0; i < used; i++)
+    if (data->widths.values[i] < data->widths.min)
       data->widths.values[i] = data->widths.min;
 }
 
@@ -403,7 +395,7 @@ static void zsv_pretty_reset_column_widths(struct zsv_pretty_data *data) {
   zsv_pretty_output_cache(data);
   zsv_pretty_clear_cache(data);
   data->cache.full = 0;
-  if(data->widths.used && data->widths.values) {
+  if (data->widths.used && data->widths.values) {
     memset(data->widths.values, 0, data->widths.used * sizeof(*data->widths.values));
     set_min_col_widths(data, data->widths.used);
   }
@@ -413,16 +405,16 @@ static void zsv_pretty_reset_column_widths(struct zsv_pretty_data *data) {
 
 static enum zsv_pretty_status zsv_pretty_add_to_cache(struct zsv_pretty_data *data) {
   enum zsv_pretty_status status = zsv_pretty_status_error;
-  if(data->cache.full)
+  if (data->cache.full)
     status = zsv_pretty_status_cache_full;
   else {
     struct zsv_cached_row *dupe = zsv_pretty_dupe_row(data->parser);
-    if(!dupe)
+    if (!dupe)
       status = zsv_pretty_status_memory;
     else {
       *data->cache.next = dupe;
       data->cache.next = &dupe->next;
-      if(++data->cache.count >= data->cache.max)
+      if (++data->cache.count >= data->cache.max)
         data->cache.full = 1;
       status = zsv_pretty_status_cache_updated;
     }
@@ -432,29 +424,28 @@ static enum zsv_pretty_status zsv_pretty_add_to_cache(struct zsv_pretty_data *da
 
 static enum zsv_pretty_status zsv_pretty_update_column_widths(struct zsv_pretty_data *data) {
   size_t columns_used = zsv_cell_count(data->parser);
-  if(columns_used > 1) {
-    if(columns_used > data->widths.allocated) {
+  if (columns_used > 1) {
+    if (columns_used > data->widths.allocated) {
       size_t *new_width_values = realloc(data->widths.values, columns_used * sizeof(*new_width_values));
-      if(!new_width_values)
+      if (!new_width_values)
         return zsv_pretty_status_memory;
       // zero out the newly-allocated memory
-      for(unsigned int j = data->widths.allocated; j < columns_used; j++)
+      for (unsigned int j = data->widths.allocated; j < columns_used; j++)
         new_width_values[j] = data->widths.min;
 
       data->widths.values = new_width_values;
       data->widths.allocated = columns_used;
     }
-    for(unsigned i = 0; i < columns_used; i++) {
+    for (unsigned i = 0; i < columns_used; i++) {
       // struct zsv_row_cell v = zsv_row_get_cell(r, i);
       struct zsv_cell cell = zsv_get_cell(data->parser, i);
       size_t cell_width;
       int utf8_err;
-      utf8_bytes_up_to_max_width_and_replace_newlines(cell.str, cell.len, data->line.max + 1,
-                                                      &cell_width, &utf8_err);
-      if(cell_width > data->widths.values[i] && data->widths.values[i] < data->widths.max)
+      utf8_bytes_up_to_max_width_and_replace_newlines(cell.str, cell.len, data->line.max + 1, &cell_width, &utf8_err);
+      if (cell_width > data->widths.values[i] && data->widths.values[i] < data->widths.max)
         data->widths.values[i] = cell_width > data->widths.max ? data->widths.max : cell_width;
     }
-    if(data->widths.used < columns_used)
+    if (data->widths.used < columns_used)
       data->widths.used = columns_used;
   }
   return zsv_pretty_status_ok;
@@ -473,21 +464,21 @@ static enum zsv_pretty_status zsv_pretty_update_column_widths(struct zsv_pretty_
 */
 static void zsv_pretty_row(void *ctx) {
   struct zsv_pretty_data *data = ctx;
-  if(data->err)
+  if (data->err)
     return;
 
   unsigned int columns_used = zsv_cell_count(data->parser);
-  if(columns_used < 2 && (zsv_pretty_get_cell(data->parser, NULL, 0).len == 0 || data->widths.used == 0)) {
+  if (columns_used < 2 && (zsv_pretty_get_cell(data->parser, NULL, 0).len == 0 || data->widths.used == 0)) {
     zsv_pretty_reset_column_widths(data);
     zsv_pretty_output_row(data, NULL);
   } else { // >= 2 columns
-    switch(zsv_pretty_add_to_cache(data)) {
+    switch (zsv_pretty_add_to_cache(data)) {
     case zsv_pretty_status_cache_updated: // row was added to cache
-      if(!data->ignore_header_lengths || data->cache.count > 1)
+      if (!data->ignore_header_lengths || data->cache.count > 1)
         zsv_pretty_update_column_widths(data);
       break;
     case zsv_pretty_status_cache_full: // row not added
-      if(data->cache.c_rows) {
+      if (data->cache.c_rows) {
         zsv_pretty_output_cache(data);
         zsv_pretty_clear_cache(data);
       }
@@ -498,66 +489,61 @@ static void zsv_pretty_row(void *ctx) {
     }
   }
 
-  if(++data->row_ix % 1000 == 0 && data->verbose)
+  if (++data->row_ix % 1000 == 0 && data->verbose)
     fprintf(stderr, "Processed %zu rows\n", data->row_ix);
 }
 
-const char *zsv_pretty_usage_msg[] =
-  {
-   APPNAME ": print one or more tables of data in fixed-width format",
-   "",
-   "Usage: " APPNAME " [filename] [--width n]",
-   "",
-   "Options:",
-   "  -o, --output <filename> : save output the the specified file",
-   "  -W, --width <n>: set the max line width to output. if not provided",
-   "                            will try to detect automatically",
-   "  -p, --rows:             : set the number of (preview) rows to calculated widths from",
-   "                            if not provided, defaults to 150",
-   "  -C, --max-col-width <n> : set the max column width. if not provided, defaults to 50",
-   "  -D, --min-col-width <n> : set the min column width. if not provided, defaults to 2",
-   "  -A, --no-align          : do not fill in additional cells if the first row has more columns than the current row",
-   "  -m, --markdown          : output the table in markdown format",
-   "  -M, --markdown-pad      : output the table in markdown format with padding",
-   "  -H, --ignore-header-lengths: ignore header lengths in determining column width",
-   NULL
-  };
+const char *zsv_pretty_usage_msg[] = {
+  APPNAME ": print one or more tables of data in fixed-width format",
+  "",
+  "Usage: " APPNAME " [options] <filename>",
+  "",
+  "Options:",
+  "  -o,--output <filename>     : save output the the specified file",
+  "  -W,--width <n>             : max line width to output, try to detect automatically if omitted",
+  "  -p,--rows <n>              : number of (preview) rows to calculated widths from if omitted (default: 150)",
+  "  -C,--max-col-width <n>     : max column width. if not provided, defaults to 50",
+  "  -D,--min-col-width <n>     : min column width. if not provided, defaults to 2",
+  "  -A,--no-align              : do not fill in additional cells if first row has more columns than current row",
+  "  -m,--markdown              : output table in markdown format",
+  "  -M,--markdown-pad          : output table in markdown format with padding",
+  "  -H,--ignore-header-lengths : ignore header lengths in determining column width",
+  NULL,
+};
 
 static void zsv_pretty_usage() {
-  for(int i = 0; zsv_pretty_usage_msg[i]; i++)
+  for (size_t i = 0; zsv_pretty_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_pretty_usage_msg[i]);
 }
 
 static void zsv_pretty_flush(struct zsv_pretty_data *data) {
-  if(data->parser)
+  if (data->parser)
     zsv_finish(data->parser);
-  if(data->cache.c_rows) {
+  if (data->cache.c_rows) {
     zsv_pretty_output_cache(data);
     zsv_pretty_clear_cache(data);
   }
 }
 
 static void zsv_pretty_destroy(struct zsv_pretty_data *data) {
-  if(data->parser) {
+  if (data->parser) {
     zsv_finish(data->parser);
     zsv_delete(data->parser);
   }
-//  zsv_row_destroy(data->row);
+  //  zsv_row_destroy(data->row);
   zsv_pretty_clear_cache(data);
 
-  if(data->widths.values)
+  if (data->widths.values)
     free(data->widths.values);
 
   free(data);
 }
 
-static struct zsv_pretty_data *zsv_pretty_init(struct zsv_pretty_opts *opts,
-                                               struct zsv_opts *parser_opts,
-                                               struct zsv_prop_handler *custom_prop_handler,
-                                               const char *input_path,
+static struct zsv_pretty_data *zsv_pretty_init(struct zsv_pretty_opts *opts, struct zsv_opts *parser_opts,
+                                               struct zsv_prop_handler *custom_prop_handler, const char *input_path,
                                                const char *opts_used) {
   struct zsv_pretty_data *data = calloc(1, sizeof(*data));
-  if(!data)
+  if (!data)
     return NULL;
 
   data->ignore_header_lengths = opts->ignore_header_lengths;
@@ -565,31 +551,31 @@ static struct zsv_pretty_data *zsv_pretty_init(struct zsv_pretty_opts *opts,
   data->markdown_pad = opts->markdown_pad;
   data->no_align = opts->no_align;
 
-  if(opts->line_width_max)
+  if (opts->line_width_max)
     data->line.max = opts->line_width_max;
-  else if(!(data->line.max = get_console_width()))
+  else if (!(data->line.max = get_console_width()))
     data->line.max = ZSV_PRETTY_DEFAULT_LINE_MAX_WIDTH;
 
   parser_opts->row_handler = zsv_pretty_row;
   parser_opts->ctx = data;
   zsv_new_with_properties(parser_opts, custom_prop_handler, input_path, opts_used, &data->parser);
 
-  data->write = (size_t (*)(const void *, size_t, size_t, void *))fwrite;
+  data->write = (size_t(*)(const void *, size_t, size_t, void *))fwrite;
   data->write_arg = opts->out ? opts->out : stdout;
 
   zsv_pretty_clear_cache(data);
 
-  if(opts->column_width_min)
+  if (opts->column_width_min)
     data->widths.min = opts->column_width_min;
   else
     data->widths.min = ZSV_PRETTY_DEFAULT_COLUMN_MIN_WIDTH;
 
-  if(opts->column_width_max)
+  if (opts->column_width_max)
     data->widths.max = opts->column_width_max;
   else
     data->widths.max = ZSV_PRETTY_DEFAULT_COLUMN_MAX_WIDTH;
 
-  if(opts->cache_max_rows)
+  if (opts->cache_max_rows)
     data->cache.max = opts->cache_max_rows;
   else
     data->cache.max = ZSV_PRETTY_DEFAULT_CACHE_MAX;
@@ -597,8 +583,9 @@ static struct zsv_pretty_data *zsv_pretty_init(struct zsv_pretty_opts *opts,
   return data;
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *parser_opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *parser_opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
     zsv_pretty_usage();
     return 0;
   }
@@ -607,44 +594,44 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *pa
   FILE *in = stdin;
   const char *input_path = NULL;
 
-  struct zsv_pretty_opts opts = { 0 };
+  struct zsv_pretty_opts opts = {0};
 
   opts.line_width_max = ZSV_PRETTY_DEFAULT_LINE_MAX_WIDTH;
   opts.column_width_min = ZSV_PRETTY_DEFAULT_COLUMN_MIN_WIDTH;
   opts.column_width_max = ZSV_PRETTY_DEFAULT_COLUMN_MAX_WIDTH;
   opts.cache_max_rows = ZSV_PRETTY_DEFAULT_CACHE_MAX;
 
-  const char *size_t_args[] = {"-W", "--width", "-C", "--max-col-width", "-D", "--min-col-width", "-p", "--rows", NULL };
-  size_t size_t_maximums[] = { 32000, 32000, 500, 500, 500, 500, 100000000, 100000000 };
-  for(int i = 1; !rc && i < argc; i++) {
-    if(*argv[i] == '-') {
-      if(!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
-        if(++i >= argc)
-          rc = zsv_printerr(1, "%s option requires a filename value", argv[i-1]);
-        else if(opts.out)
+  const char *size_t_args[] = {"-W", "--width", "-C", "--max-col-width", "-D", "--min-col-width", "-p", "--rows", NULL};
+  size_t size_t_maximums[] = {32000, 32000, 500, 500, 500, 500, 100000000, 100000000};
+  for (int i = 1; !rc && i < argc; i++) {
+    if (*argv[i] == '-') {
+      if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
+        if (++i >= argc)
+          rc = zsv_printerr(1, "%s option requires a filename value", argv[i - 1]);
+        else if (opts.out)
           rc = zsv_printerr(1, "Output specified more than once");
-        else if(!(opts.out = fopen(argv[i], "wb")))
+        else if (!(opts.out = fopen(argv[i], "wb")))
           rc = zsv_printerr(1, "Unable to open for writing: %s", argv[i]);
-      } else if(!strcmp(argv[i], "-m") || !strcmp(argv[i], "--markdown"))
+      } else if (!strcmp(argv[i], "-m") || !strcmp(argv[i], "--markdown"))
         opts.markdown = 1;
-      else if(!strcmp(argv[i], "-A") || !strcmp(argv[i], "--no-align"))
+      else if (!strcmp(argv[i], "-A") || !strcmp(argv[i], "--no-align"))
         opts.no_align = 1;
-      else if(!strcmp(argv[i], "-M") || !strcmp(argv[i], "--markdown-pad"))
+      else if (!strcmp(argv[i], "-M") || !strcmp(argv[i], "--markdown-pad"))
         opts.markdown_pad = 1;
-      else if(!strcmp(argv[i], "-H") || !strcmp(argv[i], "--ignore-header-lengths"))
+      else if (!strcmp(argv[i], "-H") || !strcmp(argv[i], "--ignore-header-lengths"))
         opts.ignore_header_lengths = 1;
       else {
         char got_opt = 0;
-        for(int j = 0; size_t_args[j]; j++) {
-          if(!strcmp(size_t_args[j], argv[i])) {
+        for (int j = 0; size_t_args[j]; j++) {
+          if (!strcmp(size_t_args[j], argv[i])) {
             got_opt = 1;
             i++;
-            if(i >= argc)
+            if (i >= argc)
               rc = zsv_printerr(1, "%s option requires a value", size_t_args[j]);
-            else if(atol(argv[i]) < 2 || (size_t)atol(argv[i]) > size_t_maximums[j])
+            else if (atol(argv[i]) < 2 || (size_t)atol(argv[i]) > size_t_maximums[j])
               rc = zsv_printerr(1, "%s value must be an integer between 2 and %zu", size_t_args[j], size_t_maximums[j]);
             else {
-              switch(j) {
+              switch (j) {
               case 0:
               case 1: // --width
                 opts.line_width_max = atol(argv[i]);
@@ -666,43 +653,42 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *pa
             break;
           }
         }
-        if(!got_opt)
+        if (!got_opt)
           rc = zsv_printerr(1, "Unrecognized option: %s", argv[i]);
       }
-    } else if(!(in = fopen(argv[i], "rb")))
+    } else if (!(in = fopen(argv[i], "rb")))
       rc = zsv_printerr(1, "Unable to open file %s for reading", argv[i]);
     else
       input_path = argv[i];
   }
 
 #ifdef NO_STDIN
-  if(in == stdin)
+  if (in == stdin)
     rc = zsv_printerr(1, "Please specify an input file");
 #endif
-  if(opts.column_width_min > opts.column_width_max || opts.column_width_min > opts.line_width_max)
+  if (opts.column_width_min > opts.column_width_max || opts.column_width_min > opts.line_width_max)
     rc = zsv_printerr(1, "Min column width cannot exceed max column width or max line width");
 
   parser_opts->stream = in;
   struct zsv_pretty_data *h = zsv_pretty_init(&opts, parser_opts, custom_prop_handler, input_path, opts_used);
-  if(!h)
+  if (!h)
     rc = 1;
   else {
     zsv_handle_ctrl_c_signal();
     rc = 0;
     enum zsv_status status;
-    while(zsv_parse_more(h->parser) == zsv_status_ok)
+    while (zsv_parse_more(h->parser) == zsv_status_ok)
       ;
 
-    while(!rc && !zsv_signal_interrupted
-          && (status = zsv_parse_more(h->parser)) == zsv_status_ok)
+    while (!rc && !zsv_signal_interrupted && (status = zsv_parse_more(h->parser)) == zsv_status_ok)
       ;
 
     zsv_pretty_flush(h);
     zsv_pretty_destroy(h);
   }
-  if(opts.out)
+  if (opts.out)
     fclose(opts.out);
-  if(in && in != stdin)
+  if (in && in != stdin)
     fclose(in);
 
   return rc;

--- a/app/pretty.c
+++ b/app/pretty.c
@@ -37,8 +37,7 @@ struct zsv_pretty_opts {
   unsigned char dummy : 4;
 };
 
-enum zsv_pretty_status
-{
+enum zsv_pretty_status {
   zsv_pretty_status_ok = 0,
   zsv_pretty_status_error,
   zsv_pretty_status_memory,

--- a/app/prop.c
+++ b/app/prop.c
@@ -498,7 +498,8 @@ static int merge_and_save_properties(const unsigned char *filepath, char save, c
   return err;
 }
 
-enum zsv_prop_mode {
+enum zsv_prop_mode
+{
   zsv_prop_mode_default = 0,
   zsv_prop_mode_list_files = 'l',
   zsv_prop_mode_clean = 'K',
@@ -658,7 +659,8 @@ static int zsv_prop_foreach_clean(struct zsv_foreach_dirent_handle *h, size_t de
   return err;
 }
 
-enum zsv_prop_foreach_copy_mode {
+enum zsv_prop_foreach_copy_mode
+{
   zsv_prop_foreach_copy_mode_check = 1,
   zsv_prop_foreach_copy_mode_copy
 };

--- a/app/prop.c
+++ b/app/prop.c
@@ -498,8 +498,7 @@ static int merge_and_save_properties(const unsigned char *filepath, char save, c
   return err;
 }
 
-enum zsv_prop_mode
-{
+enum zsv_prop_mode {
   zsv_prop_mode_default = 0,
   zsv_prop_mode_list_files = 'l',
   zsv_prop_mode_clean = 'K',
@@ -659,8 +658,7 @@ static int zsv_prop_foreach_clean(struct zsv_foreach_dirent_handle *h, size_t de
   return err;
 }
 
-enum zsv_prop_foreach_copy_mode
-{
+enum zsv_prop_foreach_copy_mode {
   zsv_prop_foreach_copy_mode_check = 1,
   zsv_prop_foreach_copy_mode_copy
 };

--- a/app/rm.c
+++ b/app/rm.c
@@ -28,27 +28,28 @@ const char *zsv_rm_usage_msg[] = {
   APPNAME ": remove a file and its related cache",
   "",
   "Usage: " APPNAME " [options] <filepath>",
-  "  where options may be:",
-  "    -v,--verbose: verbose output",
+  "",
+  "Options:",
+  "  -v,--verbose   : verbose output",
 #ifndef NO_STDIN
-  "    -f,--force  : do not prompt for confirmation",
+  "  -f,--force     : do not prompt for confirmation",
 #endif
-  "    -k,--keep   : do not remove related cache",
-  "    -C,--cache  : only remove related cache (not the file)",
-  NULL
+  "  -k,--keep      : do not remove related cache",
+  "  -C,--cache     : only remove related cache (not the file)",
+  NULL,
 };
 
 static int zsv_rm_usage(FILE *target) {
-  for(int j = 0; zsv_rm_usage_msg[j]; j++)
+  for (size_t j = 0; zsv_rm_usage_msg[j]; j++)
     fprintf(target, "%s\n", zsv_rm_usage_msg[j]);
   return target == stdout ? 0 : 1;
 }
 
 int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
   int err = 0;
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
     err = zsv_rm_usage(stdout);
-  else if(argc < 2)
+  else if (argc < 2)
     err = zsv_rm_usage(stderr);
   else {
     const char *filepath = NULL;
@@ -59,68 +60,65 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
     char remove_cache = 1;
     char remove_file = 1;
     char verbose = 0;
-    for(int i = 1; !err && i < argc; i++) {
+    for (int i = 1; !err && i < argc; i++) {
       const char *arg = argv[i];
-      if(*arg == '-') {
-        if(!strcmp(arg, "-v") || !strcmp(arg, "--verbose"))
+      if (*arg == '-') {
+        if (!strcmp(arg, "-v") || !strcmp(arg, "--verbose"))
           verbose = 1;
-        else if(!strcmp(arg, "-f") || !strcmp(arg, "--force"))
+        else if (!strcmp(arg, "-f") || !strcmp(arg, "--force"))
           force = 1;
-        else if(!strcmp(arg, "-k") || !strcmp(arg, "--keep"))
+        else if (!strcmp(arg, "-k") || !strcmp(arg, "--keep"))
           remove_cache = 0;
-        else if(!strcmp(arg, "-C") || !strcmp(arg, "--cache"))
+        else if (!strcmp(arg, "-C") || !strcmp(arg, "--cache"))
           remove_file = 0;
         else
           err = zsv_printerr(1, "Unrecognized option: %s", arg);
-      } else if(!filepath)
+      } else if (!filepath)
         filepath = arg;
       else
         err = zsv_printerr(1, "Unrecognized option: %s", arg);
     }
 
-    if(!err && !filepath)
+    if (!err && !filepath)
       err = zsv_rm_usage(stderr);
-    else if(remove_file == 0 && remove_cache == 0)
+    else if (remove_file == 0 && remove_cache == 0)
       err = fprintf(stderr, "Nothing to remove\n");
 
-    if(!err) {
+    if (!err) {
       char ok = 1;
 #ifndef NO_STDIN
-      if(!force) {
+      if (!force) {
         ok = 0;
-        if(!remove_file)
-          printf("Are you sure you want to remove the entire cache for the file %s?\n",
-                 filepath);
+        if (!remove_file)
+          printf("Are you sure you want to remove the entire cache for the file %s?\n", filepath);
         else
-          printf("Are you sure you want to remove the file %s%s?\n",
-                 filepath,
+          printf("Are you sure you want to remove the file %s%s?\n", filepath,
                  remove_cache ? " and all of its cache contents" : "");
         char buff[64];
-        if(fscanf(stdin, "%60s", buff)
-           && strchr("Yy", buff[0]))
+        if (fscanf(stdin, "%60s", buff) && strchr("Yy", buff[0]))
           ok = 1;
       }
 #endif
-      if(ok) {
-        if(remove_file) {
-          if(verbose)
+      if (ok) {
+        if (remove_file) {
+          if (verbose)
             fprintf(stderr, "Removing %s", filepath);
           err = unlink(filepath);
-          if(err) {
-            if(err == ENOENT && force)
+          if (err) {
+            if (err == ENOENT && force)
               err = 0;
             else
               perror(filepath);
           }
         }
-        if(!err) {
+        if (!err) {
           unsigned char *cache_dir = zsv_cache_path((const unsigned char *)filepath, NULL, 0);
-          if(!cache_dir)
+          if (!cache_dir)
             err = zsv_printerr(ENOMEM, "Out of memory!");
-          else if(zsv_dir_exists((const char *)cache_dir)) {
+          else if (zsv_dir_exists((const char *)cache_dir)) {
             err = zsv_remove_dir_recursive(cache_dir);
-            if(verbose) {
-              if(!err)
+            if (verbose) {
+              if (!err)
                 fprintf(stderr, "Removed cache %s", cache_dir);
             }
           }

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -32,7 +32,7 @@ struct zsv_select_search_str {
 };
 
 static void zsv_select_search_str_delete(struct zsv_select_search_str *ss) {
-  for(struct zsv_select_search_str *next; ss; ss = next) {
+  for (struct zsv_select_search_str *next; ss; ss = next) {
     next = ss->next;
     free(ss);
   }
@@ -60,7 +60,7 @@ struct zsv_select_data {
 
   struct {
     unsigned int ix; // index of the input column to be output
-    struct { // merge data: only used with --merge
+    struct {         // merge data: only used with --merge
       struct zsv_select_uint_list *indexes, **last_index;
     } merge;
   } *out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
@@ -99,23 +99,24 @@ struct zsv_select_data {
     size_t count;
   } fixed;
   */
-  unsigned char whitspace_clean_flags;
+  unsigned char whitespace_clean_flags;
 
-  unsigned char print_all_cols:1;
-  unsigned char use_header_indexes:1;
-  unsigned char no_trim_whitespace:1;
-  unsigned char cancelled:1;
-  unsigned char skip_this_row:1;
-  unsigned char verbose:1;
-  unsigned char clean_white:1;
-  unsigned char prepend_line_number:1;
+  unsigned char print_all_cols : 1;
+  unsigned char use_header_indexes : 1;
+  unsigned char no_trim_whitespace : 1;
+  unsigned char cancelled : 1;
+  unsigned char skip_this_row : 1;
+  unsigned char verbose : 1;
+  unsigned char clean_white : 1;
+  unsigned char prepend_line_number : 1;
 
-  unsigned char any_clean:1;
+  unsigned char any_clean : 1;
 #define ZSV_SELECT_DISTINCT_MERGE 2
-  unsigned char distinct:2; // 1 = ignore subsequent cols, ZSV_SELECT_DISTINCT_MERGE = merge subsequent cols (first non-null value)
+  unsigned char distinct : 2; // 1 = ignore subsequent cols, ZSV_SELECT_DISTINCT_MERGE = merge subsequent cols (first
+                              // non-null value)
 
-  unsigned char no_header:1;
-  unsigned char _:4;
+  unsigned char no_header : 1;
+  unsigned char _ : 4;
 };
 
 enum zsv_select_column_index_selection_type {
@@ -125,45 +126,48 @@ enum zsv_select_column_index_selection_type {
   zsv_select_column_index_selection_type_lower_bounded
 };
 
-static enum zsv_select_column_index_selection_type
-zsv_select_column_index_selection(const unsigned char *arg, unsigned *lo, unsigned *hi);
+static enum zsv_select_column_index_selection_type zsv_select_column_index_selection(const unsigned char *arg,
+                                                                                     unsigned *lo, unsigned *hi);
 
 static inline void zsv_select_add_exclusion(struct zsv_select_data *data, const char *name) {
-  if(data->exclusion_count < MAX_EXCLUSIONS)
+  if (data->exclusion_count < MAX_EXCLUSIONS)
     data->exclusions[data->exclusion_count++] = (const unsigned char *)name;
 }
 
 static inline unsigned char *zsv_select_get_header_name(struct zsv_select_data *data, unsigned in_ix) {
-  if(in_ix < data->header_name_count)
+  if (in_ix < data->header_name_count)
     return data->header_names[in_ix];
   return NULL;
 }
 
 static inline char zsv_select_excluded_current_header_name(struct zsv_select_data *data, unsigned in_ix) {
-  if(data->exclusion_count) {
+  if (data->exclusion_count) {
     unsigned char *header_name = zsv_select_get_header_name(data, in_ix);
-    if(data->use_header_indexes) {
-      for(unsigned int ix = 0; ix < data->exclusion_count; ix++) {
+    if (data->use_header_indexes) {
+      for (unsigned int ix = 0; ix < data->exclusion_count; ix++) {
         unsigned i, j;
-        switch(zsv_select_column_index_selection(data->exclusions[ix], &i, &j)) {
+        switch (zsv_select_column_index_selection(data->exclusions[ix], &i, &j)) {
         case zsv_select_column_index_selection_type_none:
           // not expected!
           break;
         case zsv_select_column_index_selection_type_single:
-          if(in_ix + 1 == i) return 1;
+          if (in_ix + 1 == i)
+            return 1;
           break;
         case zsv_select_column_index_selection_type_range:
-          if(i <= in_ix + 1 && in_ix + 1 <= j) return 1;
+          if (i <= in_ix + 1 && in_ix + 1 <= j)
+            return 1;
           break;
         case zsv_select_column_index_selection_type_lower_bounded:
-          if(i <= in_ix + 1) return 1;
+          if (i <= in_ix + 1)
+            return 1;
           break;
         }
       }
     } else {
-      if(header_name) {
-        for(unsigned int i = 0; i < data->exclusion_count; i++)
-          if(!zsv_stricmp(header_name, data->exclusions[i]))
+      if (header_name) {
+        for (unsigned int i = 0; i < data->exclusion_count; i++)
+          if (!zsv_stricmp(header_name, data->exclusions[i]))
             return 1;
       }
     }
@@ -173,10 +177,10 @@ static inline char zsv_select_excluded_current_header_name(struct zsv_select_dat
 
 // zsv_select_find_header(): return 1-based index, or 0 if not found
 static int zsv_select_find_header(struct zsv_select_data *data, const unsigned char *header_name) {
-  if(header_name) {
-    for(unsigned int i = 0; i < data->output_cols_count; i++) {
+  if (header_name) {
+    for (unsigned int i = 0; i < data->output_cols_count; i++) {
       unsigned char *prior_header_name = zsv_select_get_header_name(data, data->out2in[i].ix);
-      if(prior_header_name && !zsv_stricmp(header_name, prior_header_name))
+      if (prior_header_name && !zsv_stricmp(header_name, prior_header_name))
         return i + 1;
     }
   }
@@ -185,26 +189,26 @@ static int zsv_select_find_header(struct zsv_select_data *data, const unsigned c
 
 static int zsv_select_add_output_col(struct zsv_select_data *data, unsigned in_ix) {
   int err = 0;
-  if(data->output_cols_count < data->opts->max_columns) {
+  if (data->output_cols_count < data->opts->max_columns) {
     int found = zsv_select_find_header(data, zsv_select_get_header_name(data, in_ix));
-    if(data->distinct && found) {
-      if(data->distinct == ZSV_SELECT_DISTINCT_MERGE) {
+    if (data->distinct && found) {
+      if (data->distinct == ZSV_SELECT_DISTINCT_MERGE) {
         // add this index
         struct zsv_select_uint_list *ix = calloc(1, sizeof(*ix));
-        if(!ix)
+        if (!ix)
           err = zsv_printerr(1, "Out of memory!\n");
         else {
           ix->value = in_ix;
-          if(!data->out2in[found-1].merge.indexes)
-            data->out2in[found-1].merge.indexes = ix;
+          if (!data->out2in[found - 1].merge.indexes)
+            data->out2in[found - 1].merge.indexes = ix;
           else
-            *data->out2in[found-1].merge.last_index = ix;
-          data->out2in[found-1].merge.last_index = &ix->next;
+            *data->out2in[found - 1].merge.last_index = ix;
+          data->out2in[found - 1].merge.last_index = &ix->next;
         }
       }
       return err;
     }
-    if(zsv_select_excluded_current_header_name(data, in_ix))
+    if (zsv_select_excluded_current_header_name(data, in_ix))
       return err;
     data->out2in[data->output_cols_count++].ix = in_ix;
   }
@@ -212,15 +216,13 @@ static int zsv_select_add_output_col(struct zsv_select_data *data, unsigned in_i
 }
 
 // not very fast, but we don't need it to be
-static inline unsigned int str_array_ifind(const unsigned char *needle,
-                                           unsigned char *haystack[],
-                                           unsigned hay_count) {
-  for(unsigned int i = 0; i < hay_count; i++) {
-    if(!(needle && *needle) && !(haystack[i] && *haystack[i]))
+static inline unsigned int str_array_ifind(const unsigned char *needle, unsigned char *haystack[], unsigned hay_count) {
+  for (unsigned int i = 0; i < hay_count; i++) {
+    if (!(needle && *needle) && !(haystack[i] && *haystack[i]))
       return i + 1;
-    if(!(needle && *needle && haystack[i] && *haystack[i]))
+    if (!(needle && *needle && haystack[i] && *haystack[i]))
       continue;
-    if(!zsv_stricmp(needle, haystack[i]))
+    if (!zsv_stricmp(needle, haystack[i]))
       return i + 1;
   }
   return 0;
@@ -229,41 +231,41 @@ static inline unsigned int str_array_ifind(const unsigned char *needle,
 static int zsv_select_set_output_columns(struct zsv_select_data *data) {
   int err = 0;
   unsigned int header_name_count = data->header_name_count;
-  if(!data->col_argc) {
-    for(unsigned int i = 0; !err && i < header_name_count; i++)
+  if (!data->col_argc) {
+    for (unsigned int i = 0; !err && i < header_name_count; i++)
       err = zsv_select_add_output_col(data, i);
-  } else if(data->use_header_indexes) {
-    for(int arg_i = 0; !err && arg_i < data->col_argc; arg_i++) {
+  } else if (data->use_header_indexes) {
+    for (int arg_i = 0; !err && arg_i < data->col_argc; arg_i++) {
       const char *arg = data->col_argv[arg_i];
       unsigned i, j;
-      switch(zsv_select_column_index_selection((const unsigned char *)arg, &i, &j)) {
+      switch (zsv_select_column_index_selection((const unsigned char *)arg, &i, &j)) {
       case zsv_select_column_index_selection_type_none:
         zsv_printerr(1, "Invalid column index: %s", arg);
         err = -1;
         break;
       case zsv_select_column_index_selection_type_single:
-        err = zsv_select_add_output_col(data, i-1);
+        err = zsv_select_add_output_col(data, i - 1);
         break;
       case zsv_select_column_index_selection_type_range:
-        while(i <= j && i < data->opts->max_columns) {
-          err = zsv_select_add_output_col(data, i-1);
+        while (i <= j && i < data->opts->max_columns) {
+          err = zsv_select_add_output_col(data, i - 1);
           i++;
         }
         break;
       case zsv_select_column_index_selection_type_lower_bounded:
-        if(i) {
-          for(unsigned int k = i-1; !err && k < header_name_count; k++)
+        if (i) {
+          for (unsigned int k = i - 1; !err && k < header_name_count; k++)
             err = zsv_select_add_output_col(data, k);
         }
         break;
       }
     }
   } else { // using header names
-    for(int arg_i = 0; !err && arg_i < data->col_argc; arg_i++) {
+    for (int arg_i = 0; !err && arg_i < data->col_argc; arg_i++) {
       // find the location of the matching header name, if any
-      unsigned int in_pos = str_array_ifind((const unsigned char *)data->col_argv[arg_i],
-                                            data->header_names, header_name_count);
-      if(!in_pos) {
+      unsigned int in_pos =
+        str_array_ifind((const unsigned char *)data->col_argv[arg_i], data->header_names, header_name_count);
+      if (!in_pos) {
         fprintf(stderr, "Column %s not found\n", data->col_argv[arg_i]);
         err = -1;
       } else
@@ -284,24 +286,25 @@ static void zsv_select_add_search(struct zsv_select_data *data, const char *valu
 #ifndef NDEBUG
 __attribute__((always_inline)) static inline
 #endif
-unsigned char *zsv_select_cell_clean(struct zsv_select_data *data, unsigned char *utf8_value, char quoted, size_t *lenp) {
+  unsigned char *
+  zsv_select_cell_clean(struct zsv_select_data *data, unsigned char *utf8_value, char quoted, size_t *lenp) {
   size_t len = *lenp;
   // to do: option to replace or warn non-printable chars 0 - 31:
   // vectorized scan
   // replace or warn if found
 
-  if(UNLIKELY(!data->no_trim_whitespace))
+  if (UNLIKELY(!data->no_trim_whitespace))
     utf8_value = (unsigned char *)zsv_strtrim(utf8_value, &len);
 
-  if(UNLIKELY(data->clean_white))
-    len = zsv_strwhite(utf8_value, len, data->whitspace_clean_flags); // to do: zsv_clean
+  if (UNLIKELY(data->clean_white))
+    len = zsv_strwhite(utf8_value, len, data->whitespace_clean_flags); // to do: zsv_clean
 
-  if(UNLIKELY(data->embedded_lineend && quoted)) {
+  if (UNLIKELY(data->embedded_lineend && quoted)) {
     unsigned char *tmp;
-    const char *to_replace[] = { "\r\n", "\r", "\n" };
-    for(int i = 0; i < 3; i++) {
-      while((tmp = memmem(utf8_value, len, to_replace[i], strlen(to_replace[i])))) {
-        if(strlen(to_replace[i]) == 1)
+    const char *to_replace[] = {"\r\n", "\r", "\n"};
+    for (int i = 0; i < 3; i++) {
+      while ((tmp = memmem(utf8_value, len, to_replace[i], strlen(to_replace[i])))) {
+        if (strlen(to_replace[i]) == 1)
           *tmp = data->embedded_lineend;
         else {
           size_t right_len = utf8_value + len - tmp;
@@ -311,7 +314,7 @@ unsigned char *zsv_select_cell_clean(struct zsv_select_data *data, unsigned char
         }
       }
     }
-    if(data->no_trim_whitespace)
+    if (data->no_trim_whitespace)
       utf8_value = (unsigned char *)zsv_strtrim(utf8_value, &len);
   }
   *lenp = len;
@@ -319,51 +322,51 @@ unsigned char *zsv_select_cell_clean(struct zsv_select_data *data, unsigned char
 }
 
 static inline char zsv_select_row_search_hit(struct zsv_select_data *data, zsv_parser p) {
-  if(!data->search_strings)
+  if (!data->search_strings)
     return 1;
 
   unsigned int j = zsv_cell_count(p);
-  for(unsigned int i = 0; i < j; i++) {
+  for (unsigned int i = 0; i < j; i++) {
     struct zsv_cell cell = zsv_get_cell(p, i);
-    if(UNLIKELY(data->any_clean != 0))
+    if (UNLIKELY(data->any_clean != 0))
       cell.str = zsv_select_cell_clean(data, cell.str, cell.quoted, &cell.len);
-    if(cell.len) {
-      for(struct zsv_select_search_str *ss = data->search_strings; ss; ss = ss->next)
-        if(ss->value && *ss->value && memmem(cell.str, cell.len, ss->value, ss->len))
+    if (cell.len) {
+      for (struct zsv_select_search_str *ss = data->search_strings; ss; ss = ss->next)
+        if (ss->value && *ss->value && memmem(cell.str, cell.len, ss->value, ss->len))
           return 1;
     }
   }
   return 0;
 }
 
-static enum zsv_select_column_index_selection_type
-zsv_select_column_index_selection(const unsigned char *arg, unsigned *lo, unsigned *hi) {
+static enum zsv_select_column_index_selection_type zsv_select_column_index_selection(const unsigned char *arg,
+                                                                                     unsigned *lo, unsigned *hi) {
   enum zsv_select_column_index_selection_type result = zsv_select_column_index_selection_type_none;
 
   unsigned int i, j, k;
   int n = 0;
   k = sscanf((const char *)arg, "%u-%u%n", &i, &j, &n);
-  if(k == 2) {
-    if(n == (int)strlen((const char *)arg) && i > 0 && j >= i)
+  if (k == 2) {
+    if (n == (int)strlen((const char *)arg) && i > 0 && j >= i)
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if(k && n == (int)strlen((const char *)arg)) {
-      if(i > 0)
+    if (k && n == (int)strlen((const char *)arg)) {
+      if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if(k && n == (int)strlen((const char *)arg)) {
-        if(i > 0) {
+      if (k && n == (int)strlen((const char *)arg)) {
+        if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;
         }
       }
     }
   }
-  if(lo)
+  if (lo)
     *lo = i;
-  if(hi)
+  if (hi)
     *hi = j;
   return result;
 }
@@ -371,9 +374,9 @@ zsv_select_column_index_selection(const unsigned char *arg, unsigned *lo, unsign
 // zsv_select_check_exclusions_are_indexes(): return err
 static int zsv_select_check_exclusions_are_indexes(struct zsv_select_data *data) {
   int err = 0;
-  for(unsigned int e = 0; e < data->exclusion_count; e++) {
+  for (unsigned int e = 0; e < data->exclusion_count; e++) {
     const unsigned char *arg = data->exclusions[e];
-    if(zsv_select_column_index_selection(arg, NULL, NULL) == zsv_select_column_index_selection_type_none)
+    if (zsv_select_column_index_selection(arg, NULL, NULL) == zsv_select_column_index_selection_type_none)
       err = zsv_printerr(1, "Invalid column index: %s", arg);
   }
   return err;
@@ -387,15 +390,16 @@ static double demo_random_bw_1_and_100() {
 #else
   double max = 100.0;
   unsigned int n;
-# ifdef HAVE_RAND_S
+#ifdef HAVE_RAND_S
   unsigned int tries = 0;
-  while(rand_s(&n) && tries++ < 10);
-  return (double) n / ((double) UINT_MAX + 1) * max;
-# else
+  while (rand_s(&n) && tries++ < 10)
+    ;
+  return (double)n / ((double)UINT_MAX + 1) * max;
+#else
   unsigned int umax = ~0;
   n = rand();
-  return (double) n / ((double) (umax) + 1) * max;
-# endif
+  return (double)n / ((double)(umax) + 1) * max;
+#endif
 #endif
 }
 
@@ -403,26 +407,26 @@ static double demo_random_bw_1_and_100() {
 static void zsv_select_output_data_row(struct zsv_select_data *data, zsv_parser p) {
   unsigned int cnt = data->output_cols_count;
   char first = 1;
-  if(data->prepend_line_number) {
+  if (data->prepend_line_number) {
     zsv_writer_cell_zu(data->csv_writer, first, data->data_row_count);
     first = 0;
   }
 
   /* print data row */
-  for(unsigned int i = 0; i < cnt; i++) { // for each output column
+  for (unsigned int i = 0; i < cnt; i++) { // for each output column
     unsigned int in_ix = data->out2in[i].ix;
     struct zsv_cell cell = zsv_get_cell(p, in_ix);
-    if(UNLIKELY(data->any_clean != 0))
+    if (UNLIKELY(data->any_clean != 0))
       cell.str = zsv_select_cell_clean(data, cell.str, cell.quoted, &cell.len);
-    if(VERY_UNLIKELY(data->distinct == ZSV_SELECT_DISTINCT_MERGE)) {
-      if(UNLIKELY(cell.len == 0)) {
-        for(struct zsv_select_uint_list *ix = data->out2in[i].merge.indexes; ix; ix = ix->next) {
+    if (VERY_UNLIKELY(data->distinct == ZSV_SELECT_DISTINCT_MERGE)) {
+      if (UNLIKELY(cell.len == 0)) {
+        for (struct zsv_select_uint_list *ix = data->out2in[i].merge.indexes; ix; ix = ix->next) {
           unsigned int m_ix = ix->value;
           cell = zsv_get_cell(p, m_ix);
-          if(cell.len) {
-            if(UNLIKELY(data->any_clean != 0))
+          if (cell.len) {
+            if (UNLIKELY(data->any_clean != 0))
               cell.str = zsv_select_cell_clean(data, cell.str, cell.quoted, &cell.len);
-            if(cell.len)
+            if (cell.len)
               break;
           }
         }
@@ -436,46 +440,46 @@ static void zsv_select_output_data_row(struct zsv_select_data *data, zsv_parser 
 static void zsv_select_data_row(struct zsv_select_data *data, zsv_parser p) {
   data->data_row_count++;
 
-  if(UNLIKELY(zsv_cell_count(p) == 0 || data->cancelled))
+  if (UNLIKELY(zsv_cell_count(p) == 0 || data->cancelled))
     return;
 
   // check if we should skip this row
   data->skip_this_row = 0;
-  if(UNLIKELY(data->skip_data_rows)) {
+  if (UNLIKELY(data->skip_data_rows)) {
     data->skip_data_rows--;
     data->skip_this_row = 1;
-  } else if(UNLIKELY(data->sample_every_n || data->sample_pct)) {
+  } else if (UNLIKELY(data->sample_every_n || data->sample_pct)) {
     data->skip_this_row = 1;
-    if(data->sample_every_n && data->data_row_count % data->sample_every_n == 1)
+    if (data->sample_every_n && data->data_row_count % data->sample_every_n == 1)
       data->skip_this_row = 0;
-    if(data->sample_pct && demo_random_bw_1_and_100() <= data->sample_pct)
+    if (data->sample_pct && demo_random_bw_1_and_100() <= data->sample_pct)
       data->skip_this_row = 0;
   }
 
-  if(LIKELY(!data->skip_this_row)) {
+  if (LIKELY(!data->skip_this_row)) {
     // if we have a search filter, check that
     char skip = 0;
     skip = !zsv_select_row_search_hit(data, p);
-    if(!skip) {
+    if (!skip) {
 
       // print the data row
       zsv_select_output_data_row(data, p);
-      if(UNLIKELY(data->data_rows_limit > 0))
-        if(data->data_row_count + 1 >= data->data_rows_limit)
+      if (UNLIKELY(data->data_rows_limit > 0))
+        if (data->data_row_count + 1 >= data->data_rows_limit)
           data->cancelled = 1;
     }
   }
-  if(data->data_row_count % 25000 == 0 && data->verbose)
+  if (data->data_row_count % 25000 == 0 && data->verbose)
     fprintf(stderr, "Processed %zu rows\n", data->data_row_count);
 }
 
 static void zsv_select_print_header_row(struct zsv_select_data *data) {
-  if(data->no_header)
+  if (data->no_header)
     return;
   zsv_writer_cell_prepend(data->csv_writer, (const unsigned char *)data->prepend_header);
-  if(data->prepend_line_number)
+  if (data->prepend_line_number)
     zsv_writer_cell_s(data->csv_writer, 1, (const unsigned char *)"#", 0);
-  for(unsigned int i = 0; i < data->output_cols_count; i++) {
+  for (unsigned int i = 0; i < data->output_cols_count; i++) {
     unsigned char *header_name = zsv_select_get_header_name(data, data->out2in[i].ix);
     zsv_writer_cell_s(data->csv_writer, i == 0 && !data->prepend_line_number, header_name, 1);
   }
@@ -483,34 +487,34 @@ static void zsv_select_print_header_row(struct zsv_select_data *data) {
 }
 
 static void zsv_select_header_finish(struct zsv_select_data *data) {
-  if(zsv_select_set_output_columns(data))
+  if (zsv_select_set_output_columns(data))
     data->cancelled = 1;
   else
     zsv_select_print_header_row(data);
 }
 
 static void zsv_select_header_row(struct zsv_select_data *data, zsv_parser p) {
-  if(data->cancelled)
+  if (data->cancelled)
     return;
 
   unsigned int cols = zsv_cell_count(p);
   unsigned int max_header_ix = 0;
-  for(unsigned int i = 0; i < cols; i++) {
+  for (unsigned int i = 0; i < cols; i++) {
     struct zsv_cell cell = zsv_get_cell(p, i);
-    if(UNLIKELY(data->any_clean != 0))
+    if (UNLIKELY(data->any_clean != 0))
       cell.str = zsv_select_cell_clean(data, cell.str, cell.quoted, &cell.len);
-    if(i < data->opts->max_columns) {
+    if (i < data->opts->max_columns) {
       data->header_names[i] = zsv_memdup(cell.str, cell.len);
-      max_header_ix = i+1;
+      max_header_ix = i + 1;
     }
   }
 
   // in case we want to make this an option later
   char trim_trailing_columns = 1;
-  if(!trim_trailing_columns)
+  if (!trim_trailing_columns)
     max_header_ix = cols;
 
-  if(max_header_ix > data->header_name_count)
+  if (max_header_ix > data->header_name_count)
     data->header_name_count = max_header_ix;
 
   zsv_select_header_finish(data);
@@ -520,73 +524,77 @@ static void zsv_select_header_row(struct zsv_select_data *data, zsv_parser p) {
 #define ZSV_SELECT_MAX_COLS_DEFAULT_S "1024"
 
 const char *zsv_select_usage_msg[] = {
-  APPNAME ": streaming CSV parser",
+  APPNAME ": extracts and outputs specified columns",
   "",
   "Usage: " APPNAME " [filename] [options] [-- col_specifier [... col_specifier]]",
-  "  where col_specifier is a column name or, if the -n option is used,",
-  "   a column index (starting at 1) or index range in the form of n-m",
-  "  e.g. " APPNAME " -n myfile.csv -- 1 4-6 50 10",
-  "       " APPNAME " myfile.csv -- first_col fiftieth_column \"Tenth Column\"",
+  "       where col_specifier is a column name or, if the -n option is used,",
+  "       a column index (starting at 1) or index range in the form of n-m",
+  "       e.g. " APPNAME " -n file.csv -- 1 4-6 50 10",
+  "            " APPNAME " file.csv -- first_col fiftieth_column \"Tenth Column\"",
   "",
-  "Extracts and outputs specified columns. Outputs the input columns that are specified after",
-  "the '--' separator, or all columns if no '--' separator is provided",
+  "Note: Outputs the columns specified after '--' separator, or all columns if omitted.",
   "",
   "Options:",
-  "  -b, --with-bom : output with BOM",
-  /*
-  "  --fixed <offset1,offset2,offset3>: parse as fixed-width text; use given comma-separated list of positive integers for cell end indexes",
-  */
+  "  -b,--with-bom                : output with BOM",
+// "  --fixed <offset1,offset2,offset3>: parse as fixed-width text; use given comma-separated list of positive integers
+// for cell end indexes",
 #ifndef ZSV_CLI
-  "  -v, --verbose: verbose output",
+  "  -v, --verbose                : verbose output",
 #endif
-  "  -H,--head <n>               : (head) only process the first n rows of data from all rows (including header) in the input",
-  "  --no-header                 : do not output a header row",
-  "  --prepend-header <value>    : prepend each column header with the given text value",
-  "  -s, --search <value>: only output rows with at least one cell containing value",
-  // to do: " -s, --search /<pattern>/modifiers: search on regex pattern; modifiers include 'g' (global) and 'i' (case-insensitive)",
-  "  --sample-every <num of rows>: output a sample consisting of the first row, then every nth row",
-  "  --sample-pct   <percentage>: output a randomly-selected sample (32 bits of randomness) of n percent of the input rows",
-  "  -d, --header-row-span <n>: apply header depth (rowspan) of n",
-  "  --distinct: skip subsequent occurrences of columns with the same name",
-  "  --merge: merge subsequent occurrences of columns with the same name, outputting first non-null value",
-  // --rename: like distinct, but instead of removing cols with dupe names, renames them, trying _<n> for n up to max cols
-  "  -e <embedded lineend char>: char to replace embedded lineend. if none provided, embedded lineends are preserved",
-  "      If the provided string begins with 0x, it will be interpreted as the hex representation of a string",
-  "  -x <column>: exclude the indicated column. can be specified more than once",
-  "  -N, --line-number: prefix each row with the row number",
-  "  -n: provided column indexes are numbers corresponding to column positions (starting with 1), instead of names",
+  "  -H,--head <n>                : (head) only process the first n rows of input data (including header)",
+  "  --no-header                  : do not output header row",
+  "  --prepend-header <value>     : prepend each column header with the given text <value>",
+  "  -s, --search <value>         : only output rows with at least one cell containing <value>",
+  // TO DO: " -s, --search /<pattern>/modifiers: search on regex pattern; modifiers include 'g' (global) and 'i'
+  // (case-insensitive)",
+  "  --sample-every <num_of_rows> : output a sample consisting of the first row, then every nth row",
+  "  --sample-pct <percentage>    : output a randomly-selected sample (32 bits of randomness) of n%% of input rows",
+  "  -d,--header-row-span <n>     : apply header depth (rowspan) of n",
+  "  --distinct                   : skip subsequent occurrences of columns with the same name",
+  "  --merge                      : merge subsequent occurrences of columns with the same name",
+  "                                 outputting first non-null value",
+  // --rename: like distinct, but instead of removing cols with dupe names, renames them, trying _<n> for n up to max
+  // cols
+  "  -e <embedded_lineend_char>   : char to replace embedded lineend. If left empty, embedded lineends are preserved.",
+  "                                 If the provided string begins with 0x, it will be interpreted as the hex",
+  "                                 representation of a string.",
+  "  -x <column>                  : exclude the indicated column. can be specified more than once",
+  "  -N,--line-number             : prefix each row with the row number",
+  "  -n                           : provided column indexes are numbers corresponding to column positions",
+  "                                 (starting with 1), instead of names",
 #ifndef ZSV_CLI
-  "  -T: input is tab-delimited, instead of comma-delimited",
-  "  -O, --other-delim <delim>: input is delimited with the given char, instead of comma-delimited",
-  "                             Note: this option does not support quoted values with embedded delimiters",
+  "  -T                           : input is tab-delimited, instead of comma-delimited",
+  "  -O,--other-delim <delim>     : input is delimited with the given char",
+  "                                 Note: This option does not support quoted values with embedded delimiters.",
 #endif
-  "  -w, --whitespace-clean: normalize all whitespace to space or newline, single-char (non-consecutive) occurrences",
+  "  -w,--whitespace-clean        : normalize all whitespace to space or newline, single-char (non-consecutive)",
+  "                                 occurrences",
   "  --whitespace-clean-no-newline: clean whitespace and remove embedded newlines",
-  "  -W, --no-trim: do not trim whitespace",
+  "  -W,--no-trim                 : do not trim whitespace",
 #ifndef ZSV_CLI
-  "  -C <maximum_number_of_columns>: defaults to " ZSV_SELECT_MAX_COLS_DEFAULT_S,
-  "  -L, --max-row-size <n>: set the maximum memory used for a single row",
-  "                          defaults to " ZSV_ROW_MAX_SIZE_DEFAULT_S ", min " ZSV_ROW_MAX_SIZE_MIN_S ")",
+  "  -C <max_num_of_columns>      : defaults to " ZSV_SELECT_MAX_COLS_DEFAULT_S,
+  "  -L,--max-row-size <n>        : set the maximum memory used for a single row",
+  "                                 Default: " ZSV_ROW_MAX_SIZE_MIN_S " (min), " ZSV_ROW_MAX_SIZE_DEFAULT_S " (max)",
 #endif
-  "  -o <output filename>: name of file to save output to",
-  NULL
+  "  -o <filename>                : filename to save output to",
+  NULL,
 };
 
 static void zsv_select_usage() {
-  for(int i = 0; zsv_select_usage_msg[i]; i++)
+  for (size_t i = 0; zsv_select_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_select_usage_msg[i]);
 }
 
 static void zsv_select_cleanup(struct zsv_select_data *data) {
-  if(data->opts->stream && data->opts->stream != stdin)
+  if (data->opts->stream && data->opts->stream != stdin)
     fclose(data->opts->stream);
 
   zsv_writer_delete(data->csv_writer);
   zsv_select_search_str_delete(data->search_strings);
 
-  if(data->distinct == ZSV_SELECT_DISTINCT_MERGE) {
-    for(unsigned int i = 0; i < data->output_cols_count; i++) {
-      for(struct zsv_select_uint_list *next, *ix = data->out2in[i].merge.indexes; ix; ix = next) {
+  if (data->distinct == ZSV_SELECT_DISTINCT_MERGE) {
+    for (unsigned int i = 0; i < data->output_cols_count; i++) {
+      for (struct zsv_select_uint_list *next, *ix = data->out2in[i].merge.indexes; ix; ix = next) {
         next = ix->next;
         free(ix);
       }
@@ -594,31 +602,32 @@ static void zsv_select_cleanup(struct zsv_select_data *data) {
   }
   free(data->out2in);
 
-  for(unsigned int i = 0; i < data->header_name_count; i++)
+  for (unsigned int i = 0; i < data->header_name_count; i++)
     free(data->header_names[i]);
   free(data->header_names);
 
-/*  free(data->fixed.offsets); */
+  // free(data->fixed.offsets);
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
     zsv_select_usage();
     return zsv_status_ok;
   }
 
-  struct zsv_select_data data = { 0 };
+  struct zsv_select_data data = {0};
   data.opts = opts;
   const char *input_path = NULL;
   struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
   int col_index_arg_i = 0;
   enum zsv_status stat = zsv_status_ok;
-  for(int arg_i = 1; stat == zsv_status_ok && arg_i < argc; arg_i++) {
-    if(!strcmp(argv[arg_i], "--")) {
+  for (int arg_i = 1; stat == zsv_status_ok && arg_i < argc; arg_i++) {
+    if (!strcmp(argv[arg_i], "--")) {
       col_index_arg_i = arg_i + 1;
       break;
     }
-    if(!strcmp(argv[arg_i], "-b") || !strcmp(argv[arg_i], "--with-bom"))
+    if (!strcmp(argv[arg_i], "-b") || !strcmp(argv[arg_i], "--with-bom"))
       writer_opts.with_bom = 1;
     /*
     else if(!strcmp(argv[arg_i], "--fixed")) {
@@ -649,106 +658,108 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         }
       }
     } */
-    else if(!strcmp(argv[arg_i], "--distinct"))
+    else if (!strcmp(argv[arg_i], "--distinct"))
       data.distinct = 1;
-    else if(!strcmp(argv[arg_i], "--merge"))
+    else if (!strcmp(argv[arg_i], "--merge"))
       data.distinct = ZSV_SELECT_DISTINCT_MERGE;
-    else if(!strcmp(argv[arg_i], "-o") || !strcmp(argv[arg_i], "--output")) {
-      if(++arg_i >= argc)
-        stat = zsv_printerr(1, "%s option requires parameter", argv[arg_i-1]);
-      else if(writer_opts.stream && writer_opts.stream != stdout)
+    else if (!strcmp(argv[arg_i], "-o") || !strcmp(argv[arg_i], "--output")) {
+      if (++arg_i >= argc)
+        stat = zsv_printerr(1, "%s option requires parameter", argv[arg_i - 1]);
+      else if (writer_opts.stream && writer_opts.stream != stdout)
         stat = zsv_printerr(1, "Output file specified more than once");
-      else if(!(writer_opts.stream = fopen(argv[arg_i], "wb")))
+      else if (!(writer_opts.stream = fopen(argv[arg_i], "wb")))
         stat = zsv_printerr(1, "Unable to open for writing: %s", argv[arg_i]);
-      else if(data.opts->verbose)
+      else if (data.opts->verbose)
         fprintf(stderr, "Opened %s for write\n", argv[arg_i]);
-    } else if(!strcmp(argv[arg_i], "-N") || !strcmp(argv[arg_i], "--line-number")) {
+    } else if (!strcmp(argv[arg_i], "-N") || !strcmp(argv[arg_i], "--line-number")) {
       data.prepend_line_number = 1;
-    } else if(!strcmp(argv[arg_i], "-n"))
+    } else if (!strcmp(argv[arg_i], "-n"))
       data.use_header_indexes = 1;
-    else if(!strcmp(argv[arg_i], "-s") || !strcmp(argv[arg_i], "--search")) {
+    else if (!strcmp(argv[arg_i], "-s") || !strcmp(argv[arg_i], "--search")) {
       arg_i++;
-      if(arg_i < argc && strlen(argv[arg_i]))
+      if (arg_i < argc && strlen(argv[arg_i]))
         zsv_select_add_search(&data, argv[arg_i]);
       else
-        stat = zsv_printerr(1, "%s option requires a value", argv[arg_i-1]);
-    } else if(!strcmp(argv[arg_i], "-v") || !strcmp(argv[arg_i], "--verbose")) {
+        stat = zsv_printerr(1, "%s option requires a value", argv[arg_i - 1]);
+    } else if (!strcmp(argv[arg_i], "-v") || !strcmp(argv[arg_i], "--verbose")) {
       data.verbose = 1;
-    } else if(!strcmp(argv[arg_i], "-w") || !strcmp(argv[arg_i], "--whitespace-clean"))
+    } else if (!strcmp(argv[arg_i], "-w") || !strcmp(argv[arg_i], "--whitespace-clean"))
       data.clean_white = 1;
-    else if(!strcmp(argv[arg_i], "--whitespace-clean-no-newline")) {
+    else if (!strcmp(argv[arg_i], "--whitespace-clean-no-newline")) {
       data.clean_white = 1;
-      data.whitspace_clean_flags = 1;
-    } else if(!strcmp(argv[arg_i], "-W") || !strcmp(argv[arg_i], "--no-trim")) {
+      data.whitespace_clean_flags = 1;
+    } else if (!strcmp(argv[arg_i], "-W") || !strcmp(argv[arg_i], "--no-trim")) {
       data.no_trim_whitespace = 1;
-    } else if(!strcmp(argv[arg_i], "--sample-every")) {
+    } else if (!strcmp(argv[arg_i], "--sample-every")) {
       arg_i++;
-      if(!(arg_i < argc))
+      if (!(arg_i < argc))
         stat = zsv_printerr(1, "--sample-every option requires a value");
-      else if(atoi(argv[arg_i]) <= 0)
+      else if (atoi(argv[arg_i]) <= 0)
         stat = zsv_printerr(1, "--sample-every value should be an integer > 0");
       else
         data.sample_every_n = atoi(argv[arg_i]);
-    } else if(!strcmp(argv[arg_i], "--sample-pct")) {
+    } else if (!strcmp(argv[arg_i], "--sample-pct")) {
       arg_i++;
       double d;
-      if(!(arg_i < argc))
+      if (!(arg_i < argc))
         stat = zsv_printerr(1, "--sample-pct option requires a value");
-      else if(!(d = atof(argv[arg_i])) && d > 0 && d < 100)
-        stat = zsv_printerr(-1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5% of the data");
+      else if (!(d = atof(argv[arg_i])) && d > 0 && d < 100)
+        stat = zsv_printerr(
+          -1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5%% of the data");
       else
         data.sample_pct = d;
-    } else if(!strcmp(argv[arg_i], "--prepend-header")) {
-      if(!(arg_i + 1 < argc))
+    } else if (!strcmp(argv[arg_i], "--prepend-header")) {
+      if (!(arg_i + 1 < argc))
         stat = zsv_printerr(1, "%s option requires a value");
       else
         data.prepend_header = argv[++arg_i];
-    } else if(!strcmp(argv[arg_i], "--no-header")) {
+    } else if (!strcmp(argv[arg_i], "--no-header")) {
       data.no_header = 1;
-    } else if(!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
-      if(!(arg_i + 1 < argc && atoi(argv[arg_i+1]) >= 0))
-        stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i], arg_i + 1 < argc ? argv[arg_i+1] : "");
+    } else if (!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
+      if (!(arg_i + 1 < argc && atoi(argv[arg_i + 1]) >= 0))
+        stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i],
+                            arg_i + 1 < argc ? argv[arg_i + 1] : "");
       else
         data.data_rows_limit = atoi(argv[++arg_i]) + 1;
-    } else if(!strcmp(argv[arg_i], "-D") || !strcmp(argv[arg_i], "--skip-data")) {
+    } else if (!strcmp(argv[arg_i], "-D") || !strcmp(argv[arg_i], "--skip-data")) {
       ++arg_i;
-      if(!(arg_i < argc && atoi(argv[arg_i]) >= 0))
-        stat = zsv_printerr(1, "%s option value invalid: should be positive integer", argv[arg_i-1]);
+      if (!(arg_i < argc && atoi(argv[arg_i]) >= 0))
+        stat = zsv_printerr(1, "%s option value invalid: should be positive integer", argv[arg_i - 1]);
       else
         data.skip_data_rows = atoi(argv[arg_i]);
-    } else if(!strcmp(argv[arg_i], "-e")) {
+    } else if (!strcmp(argv[arg_i], "-e")) {
       ++arg_i;
-      if(data.embedded_lineend)
+      if (data.embedded_lineend)
         stat = zsv_printerr(1, "-e option specified more than once");
-      else if(strlen(argv[arg_i]) != 1)
+      else if (strlen(argv[arg_i]) != 1)
         stat = zsv_printerr(1, "-e option value must be a single character");
-      else if(arg_i < argc)
+      else if (arg_i < argc)
         data.embedded_lineend = *argv[arg_i];
       else
         stat = zsv_printerr(1, "-e option requires a value");
-    } else if(!strcmp(argv[arg_i], "-x")) {
+    } else if (!strcmp(argv[arg_i], "-x")) {
       arg_i++;
-      if(!(arg_i < argc))
-        stat = zsv_printerr(1, "%s option requires a value", argv[arg_i-1]);
+      if (!(arg_i < argc))
+        stat = zsv_printerr(1, "%s option requires a value", argv[arg_i - 1]);
       else
         zsv_select_add_exclusion(&data, argv[arg_i]);
-    } else if(*argv[arg_i] == '-')
+    } else if (*argv[arg_i] == '-')
       stat = zsv_printerr(1, "Unrecognized argument: %s", argv[arg_i]);
-    else if(data.opts->stream)
+    else if (data.opts->stream)
       stat = zsv_printerr(1, "Input file was specified, cannot also read: %s", argv[arg_i]);
-    else if(!(data.opts->stream = fopen(argv[arg_i], "rb")))
+    else if (!(data.opts->stream = fopen(argv[arg_i], "rb")))
       stat = zsv_printerr(1, "Could not open for reading: %s", argv[arg_i]);
     else
       input_path = argv[arg_i];
   }
 
-  if(data.sample_pct)
+  if (data.sample_pct)
     srand(time(0));
 
-  if(data.use_header_indexes && stat == zsv_status_ok)
+  if (data.use_header_indexes && stat == zsv_status_ok)
     stat = zsv_select_check_exclusions_are_indexes(&data);
 
-  if(!data.opts->stream) {
+  if (!data.opts->stream) {
 #ifdef NO_STDIN
     stat = zsv_printerr(1, "Please specify an input file");
 #else
@@ -756,8 +767,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #endif
   }
 
-  if(stat == zsv_status_ok) {
-    if(!col_index_arg_i)
+  if (stat == zsv_status_ok) {
+    if (!col_index_arg_i)
       data.col_argc = 0;
     else {
       data.col_argv = &argv[col_index_arg_i];
@@ -768,25 +779,17 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     assert(data.opts->max_columns > 0);
     data.out2in = calloc(data.opts->max_columns, sizeof(*data.out2in));
     data.csv_writer = zsv_writer_new(&writer_opts);
-    if(!(data.header_names && data.csv_writer))
+    if (!(data.header_names && data.csv_writer))
       stat = zsv_status_memory;
     else {
       zsv_parser parser;
-      if(zsv_new_with_properties(data.opts, custom_prop_handler, input_path, opts_used, &parser)
-         == zsv_status_ok) {
+      if (zsv_new_with_properties(data.opts, custom_prop_handler, input_path, opts_used, &parser) == zsv_status_ok) {
         // all done with
-        data.any_clean =
-          !data.no_trim_whitespace
-          || data.clean_white
-          || data.embedded_lineend;
+        data.any_clean = !data.no_trim_whitespace || data.clean_white || data.embedded_lineend;
 
-        // to do: support fixed input
-        /*
-        if(data.fixed.count && zsv_set_fixed_offsets(parser, data.fixed.count,
-                                                     data.fixed.offsets)
-           != zsv_status_ok)
-          data.cancelled = 1;
-          */
+        // TO DO: support fixed input
+        // if (data.fixed.count && zsv_set_fixed_offsets(parser, data.fixed.count, data.fixed.offsets) != zsv_status_ok)
+        //   data.cancelled = 1;
 
         // create a local csv writer buff quoted values
         unsigned char writer_buff[512];
@@ -795,16 +798,16 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         // process the input data
         zsv_handle_ctrl_c_signal();
         enum zsv_status status = zsv_next_row(parser);
-        if(status == zsv_status_row)
+        if (status == zsv_status_row)
           zsv_select_header_row(&data, parser);
-        while((status = zsv_next_row(parser)) == zsv_status_row)
+        while ((status = zsv_next_row(parser)) == zsv_status_row)
           zsv_select_data_row(&data, parser);
         zsv_delete(parser);
       }
     }
   }
   zsv_select_cleanup(&data);
-  if(writer_opts.stream && writer_opts.stream != stdout)
+  if (writer_opts.stream && writer_opts.stream != stdout)
     fclose(writer_opts.stream);
   return stat;
 }

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -119,8 +119,7 @@ struct zsv_select_data {
   unsigned char _ : 4;
 };
 
-enum zsv_select_column_index_selection_type
-{
+enum zsv_select_column_index_selection_type {
   zsv_select_column_index_selection_type_none = 0,
   zsv_select_column_index_selection_type_single,
   zsv_select_column_index_selection_type_range,

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -63,7 +63,7 @@ struct zsv_select_data {
     struct {         // merge data: only used with --merge
       struct zsv_select_uint_list *indexes, **last_index;
     } merge;
-  } *out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
+  } * out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
 
   unsigned int output_cols_count; // total count of output columns
 
@@ -119,7 +119,8 @@ struct zsv_select_data {
   unsigned char _ : 4;
 };
 
-enum zsv_select_column_index_selection_type {
+enum zsv_select_column_index_selection_type
+{
   zsv_select_column_index_selection_type_none = 0,
   zsv_select_column_index_selection_type_single,
   zsv_select_column_index_selection_type_range,

--- a/app/select.c
+++ b/app/select.c
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <assert.h>
 #ifdef _WIN32
-#define _CRT_RAND_S // for random number generator, used when sampling. must come before including stdlib.h
+#define _CRT_RAND_S /* for random number generator, used when sampling. must come before including stdlib.h */
 #endif
 #include <stdlib.h>
 #include <stdint.h>
@@ -32,7 +32,7 @@ struct zsv_select_search_str {
 };
 
 static void zsv_select_search_str_delete(struct zsv_select_search_str *ss) {
-  for(struct zsv_select_search_str *next; ss; ss = next) {
+  for (struct zsv_select_search_str *next; ss; ss = next) {
     next = ss->next;
     free(ss);
   }
@@ -66,7 +66,7 @@ struct zsv_select_data {
 
   struct {
     unsigned int ix; // index of the input column to be output
-    struct { // merge data: only used with --merge
+    struct {         // merge data: only used with --merge
       struct zsv_select_uint_list *indexes, **last_index;
     } merge;
   } *out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
@@ -101,23 +101,24 @@ struct zsv_select_data {
 
   struct fixed fixed;
 
-  unsigned char whitspace_clean_flags;
+  unsigned char whitespace_clean_flags;
 
-  unsigned char print_all_cols:1;
-  unsigned char use_header_indexes:1;
-  unsigned char no_trim_whitespace:1;
-  unsigned char cancelled:1;
-  unsigned char skip_this_row:1;
-  unsigned char verbose:1;
-  unsigned char clean_white:1;
-  unsigned char prepend_line_number:1;
+  unsigned char print_all_cols : 1;
+  unsigned char use_header_indexes : 1;
+  unsigned char no_trim_whitespace : 1;
+  unsigned char cancelled : 1;
+  unsigned char skip_this_row : 1;
+  unsigned char verbose : 1;
+  unsigned char clean_white : 1;
+  unsigned char prepend_line_number : 1;
 
-  unsigned char any_clean:1;
+  unsigned char any_clean : 1;
 #define ZSV_SELECT_DISTINCT_MERGE 2
-  unsigned char distinct:2; // 1 = ignore subsequent cols, ZSV_SELECT_DISTINCT_MERGE = merge subsequent cols (first non-null value)
-  unsigned char unescape:1;
-  unsigned char no_header:1; // --no-header
-  unsigned char _:3;
+  unsigned char distinct : 2; // 1 = ignore subsequent cols, ZSV_SELECT_DISTINCT_MERGE = merge subsequent cols (first
+                              // non-null value)
+  unsigned char unescape : 1;
+  unsigned char no_header : 1; // --no-header
+  unsigned char _ : 3;
 };
 
 enum zsv_select_column_index_selection_type {
@@ -127,45 +128,48 @@ enum zsv_select_column_index_selection_type {
   zsv_select_column_index_selection_type_lower_bounded
 };
 
-static enum zsv_select_column_index_selection_type
-zsv_select_column_index_selection(const unsigned char *arg, unsigned *lo, unsigned *hi);
+static enum zsv_select_column_index_selection_type zsv_select_column_index_selection(const unsigned char *arg,
+                                                                                     unsigned *lo, unsigned *hi);
 
 static inline void zsv_select_add_exclusion(struct zsv_select_data *data, const char *name) {
-  if(data->exclusion_count < MAX_EXCLUSIONS)
+  if (data->exclusion_count < MAX_EXCLUSIONS)
     data->exclusions[data->exclusion_count++] = (const unsigned char *)name;
 }
 
 static inline unsigned char *zsv_select_get_header_name(struct zsv_select_data *data, unsigned in_ix) {
-  if(in_ix < data->header_name_count)
+  if (in_ix < data->header_name_count)
     return data->header_names[in_ix];
   return NULL;
 }
 
 static inline char zsv_select_excluded_current_header_name(struct zsv_select_data *data, unsigned in_ix) {
-  if(data->exclusion_count) {
-    if(data->use_header_indexes) {
-      for(unsigned int ix = 0; ix < data->exclusion_count; ix++) {
+  if (data->exclusion_count) {
+    if (data->use_header_indexes) {
+      for (unsigned int ix = 0; ix < data->exclusion_count; ix++) {
         unsigned i, j;
-        switch(zsv_select_column_index_selection(data->exclusions[ix], &i, &j)) {
+        switch (zsv_select_column_index_selection(data->exclusions[ix], &i, &j)) {
         case zsv_select_column_index_selection_type_none:
           // not expected!
           break;
         case zsv_select_column_index_selection_type_single:
-          if(in_ix + 1 == i) return 1;
+          if (in_ix + 1 == i)
+            return 1;
           break;
         case zsv_select_column_index_selection_type_range:
-          if(i <= in_ix + 1 && in_ix + 1 <= j) return 1;
+          if (i <= in_ix + 1 && in_ix + 1 <= j)
+            return 1;
           break;
         case zsv_select_column_index_selection_type_lower_bounded:
-          if(i <= in_ix + 1) return 1;
+          if (i <= in_ix + 1)
+            return 1;
           break;
         }
       }
     } else {
       unsigned char *header_name = zsv_select_get_header_name(data, in_ix);
-      if(header_name) {
-        for(unsigned int i = 0; i < data->exclusion_count; i++)
-          if(!zsv_stricmp(header_name, data->exclusions[i]))
+      if (header_name) {
+        for (unsigned int i = 0; i < data->exclusion_count; i++)
+          if (!zsv_stricmp(header_name, data->exclusions[i]))
             return 1;
       }
     }
@@ -175,10 +179,10 @@ static inline char zsv_select_excluded_current_header_name(struct zsv_select_dat
 
 // zsv_select_find_header(): return 1-based index, or 0 if not found
 static int zsv_select_find_header(struct zsv_select_data *data, const unsigned char *header_name) {
-  if(header_name) {
-    for(unsigned int i = 0; i < data->output_cols_count; i++) {
+  if (header_name) {
+    for (unsigned int i = 0; i < data->output_cols_count; i++) {
       unsigned char *prior_header_name = zsv_select_get_header_name(data, data->out2in[i].ix);
-      if(prior_header_name && !zsv_stricmp(header_name, prior_header_name))
+      if (prior_header_name && !zsv_stricmp(header_name, prior_header_name))
         return i + 1;
     }
   }
@@ -187,26 +191,26 @@ static int zsv_select_find_header(struct zsv_select_data *data, const unsigned c
 
 static int zsv_select_add_output_col(struct zsv_select_data *data, unsigned in_ix) {
   int err = 0;
-  if(data->output_cols_count < data->opts->max_columns) {
+  if (data->output_cols_count < data->opts->max_columns) {
     int found = zsv_select_find_header(data, zsv_select_get_header_name(data, in_ix));
-    if(data->distinct && found) {
-      if(data->distinct == ZSV_SELECT_DISTINCT_MERGE) {
+    if (data->distinct && found) {
+      if (data->distinct == ZSV_SELECT_DISTINCT_MERGE) {
         // add this index
         struct zsv_select_uint_list *ix = calloc(1, sizeof(*ix));
-        if(!ix)
+        if (!ix)
           err = zsv_printerr(1, "Out of memory!\n");
         else {
           ix->value = in_ix;
-          if(!data->out2in[found-1].merge.indexes)
-            data->out2in[found-1].merge.indexes = ix;
+          if (!data->out2in[found - 1].merge.indexes)
+            data->out2in[found - 1].merge.indexes = ix;
           else
-            *data->out2in[found-1].merge.last_index = ix;
-          data->out2in[found-1].merge.last_index = &ix->next;
+            *data->out2in[found - 1].merge.last_index = ix;
+          data->out2in[found - 1].merge.last_index = &ix->next;
         }
       }
       return err;
     }
-    if(zsv_select_excluded_current_header_name(data, in_ix))
+    if (zsv_select_excluded_current_header_name(data, in_ix))
       return err;
     data->out2in[data->output_cols_count++].ix = in_ix;
   }
@@ -214,15 +218,13 @@ static int zsv_select_add_output_col(struct zsv_select_data *data, unsigned in_i
 }
 
 // not very fast, but we don't need it to be
-static inline unsigned int str_array_ifind(const unsigned char *needle,
-                                           unsigned char *haystack[],
-                                           unsigned hay_count) {
-  for(unsigned int i = 0; i < hay_count; i++) {
-    if(!(needle && *needle) && !(haystack[i] && *haystack[i]))
+static inline unsigned int str_array_ifind(const unsigned char *needle, unsigned char *haystack[], unsigned hay_count) {
+  for (unsigned int i = 0; i < hay_count; i++) {
+    if (!(needle && *needle) && !(haystack[i] && *haystack[i]))
       return i + 1;
-    if(!(needle && *needle && haystack[i] && *haystack[i]))
+    if (!(needle && *needle && haystack[i] && *haystack[i]))
       continue;
-    if(!zsv_stricmp(needle, haystack[i]))
+    if (!zsv_stricmp(needle, haystack[i]))
       return i + 1;
   }
   return 0;
@@ -231,41 +233,41 @@ static inline unsigned int str_array_ifind(const unsigned char *needle,
 static int zsv_select_set_output_columns(struct zsv_select_data *data) {
   int err = 0;
   unsigned int header_name_count = data->header_name_count;
-  if(!data->col_argc) {
-    for(unsigned int i = 0; !err && i < header_name_count; i++)
+  if (!data->col_argc) {
+    for (unsigned int i = 0; !err && i < header_name_count; i++)
       err = zsv_select_add_output_col(data, i);
-  } else if(data->use_header_indexes) {
-    for(int arg_i = 0; !err && arg_i < data->col_argc; arg_i++) {
+  } else if (data->use_header_indexes) {
+    for (int arg_i = 0; !err && arg_i < data->col_argc; arg_i++) {
       const char *arg = data->col_argv[arg_i];
       unsigned i, j;
-      switch(zsv_select_column_index_selection((const unsigned char *)arg, &i, &j)) {
+      switch (zsv_select_column_index_selection((const unsigned char *)arg, &i, &j)) {
       case zsv_select_column_index_selection_type_none:
         zsv_printerr(1, "Invalid column index: %s", arg);
         err = -1;
         break;
       case zsv_select_column_index_selection_type_single:
-        err = zsv_select_add_output_col(data, i-1);
+        err = zsv_select_add_output_col(data, i - 1);
         break;
       case zsv_select_column_index_selection_type_range:
-        while(i <= j && i < data->opts->max_columns) {
-          err = zsv_select_add_output_col(data, i-1);
+        while (i <= j && i < data->opts->max_columns) {
+          err = zsv_select_add_output_col(data, i - 1);
           i++;
         }
         break;
       case zsv_select_column_index_selection_type_lower_bounded:
-        if(i) {
-          for(unsigned int k = i-1; !err && k < header_name_count; k++)
+        if (i) {
+          for (unsigned int k = i - 1; !err && k < header_name_count; k++)
             err = zsv_select_add_output_col(data, k);
         }
         break;
       }
     }
   } else { // using header names
-    for(int arg_i = 0; !err && arg_i < data->col_argc; arg_i++) {
+    for (int arg_i = 0; !err && arg_i < data->col_argc; arg_i++) {
       // find the location of the matching header name, if any
-      unsigned int in_pos = str_array_ifind((const unsigned char *)data->col_argv[arg_i],
-                                            data->header_names, header_name_count);
-      if(!in_pos) {
+      unsigned int in_pos =
+        str_array_ifind((const unsigned char *)data->col_argv[arg_i], data->header_names, header_name_count);
+      if (!in_pos) {
         fprintf(stderr, "Column %s not found\n", data->col_argv[arg_i]);
         err = -1;
       } else
@@ -286,32 +288,33 @@ static void zsv_select_add_search(struct zsv_select_data *data, const char *valu
 #ifndef NDEBUG
 __attribute__((always_inline)) static inline
 #endif
-unsigned char *zsv_select_cell_clean(struct zsv_select_data *data, unsigned char *utf8_value, char *quoted, size_t *lenp) {
+  unsigned char *
+  zsv_select_cell_clean(struct zsv_select_data *data, unsigned char *utf8_value, char *quoted, size_t *lenp) {
 
   size_t len = *lenp;
   // to do: option to replace or warn non-printable chars 0 - 31:
   // vectorized scan
   // replace or warn if found
-  if(UNLIKELY(data->unescape)) {
+  if (UNLIKELY(data->unescape)) {
     size_t new_len = zsv_strunescape_backslash(utf8_value, len);
-    if(new_len != len) {
+    if (new_len != len) {
       *quoted = 1;
       len = new_len;
     }
   }
 
-  if(UNLIKELY(!data->no_trim_whitespace))
+  if (UNLIKELY(!data->no_trim_whitespace))
     utf8_value = (unsigned char *)zsv_strtrim(utf8_value, &len);
 
-  if(UNLIKELY(data->clean_white))
-    len = zsv_strwhite(utf8_value, len, data->whitspace_clean_flags); // to do: zsv_clean
+  if (UNLIKELY(data->clean_white))
+    len = zsv_strwhite(utf8_value, len, data->whitespace_clean_flags); // to do: zsv_clean
 
-  if(UNLIKELY(data->embedded_lineend && *quoted)) {
+  if (UNLIKELY(data->embedded_lineend && *quoted)) {
     unsigned char *tmp;
-    const char *to_replace[] = { "\r\n", "\r", "\n" };
-    for(int i = 0; i < 3; i++) {
-      while((tmp = memmem(utf8_value, len, to_replace[i], strlen(to_replace[i])))) {
-        if(strlen(to_replace[i]) == 1)
+    const char *to_replace[] = {"\r\n", "\r", "\n"};
+    for (int i = 0; i < 3; i++) {
+      while ((tmp = memmem(utf8_value, len, to_replace[i], strlen(to_replace[i])))) {
+        if (strlen(to_replace[i]) == 1)
           *tmp = data->embedded_lineend;
         else {
           size_t right_len = utf8_value + len - tmp;
@@ -321,7 +324,7 @@ unsigned char *zsv_select_cell_clean(struct zsv_select_data *data, unsigned char
         }
       }
     }
-    if(data->no_trim_whitespace)
+    if (data->no_trim_whitespace)
       utf8_value = (unsigned char *)zsv_strtrim(utf8_value, &len);
   }
   *lenp = len;
@@ -329,51 +332,51 @@ unsigned char *zsv_select_cell_clean(struct zsv_select_data *data, unsigned char
 }
 
 static inline char zsv_select_row_search_hit(struct zsv_select_data *data) {
-  if(!data->search_strings)
+  if (!data->search_strings)
     return 1;
 
   unsigned int j = zsv_cell_count(data->parser);
-  for(unsigned int i = 0; i < j; i++) {
+  for (unsigned int i = 0; i < j; i++) {
     struct zsv_cell cell = zsv_get_cell(data->parser, i);
-    if(UNLIKELY(data->any_clean != 0))
+    if (UNLIKELY(data->any_clean != 0))
       cell.str = zsv_select_cell_clean(data, cell.str, &cell.quoted, &cell.len);
-    if(cell.len) {
-      for(struct zsv_select_search_str *ss = data->search_strings; ss; ss = ss->next)
-        if(ss->value && *ss->value && memmem(cell.str, cell.len, ss->value, ss->len))
+    if (cell.len) {
+      for (struct zsv_select_search_str *ss = data->search_strings; ss; ss = ss->next)
+        if (ss->value && *ss->value && memmem(cell.str, cell.len, ss->value, ss->len))
           return 1;
     }
   }
   return 0;
 }
 
-static enum zsv_select_column_index_selection_type
-zsv_select_column_index_selection(const unsigned char *arg, unsigned *lo, unsigned *hi) {
+static enum zsv_select_column_index_selection_type zsv_select_column_index_selection(const unsigned char *arg,
+                                                                                     unsigned *lo, unsigned *hi) {
   enum zsv_select_column_index_selection_type result = zsv_select_column_index_selection_type_none;
 
   unsigned int i, j, k;
   int n = 0;
   k = sscanf((const char *)arg, "%u-%u%n", &i, &j, &n);
-  if(k == 2) {
-    if(n == (int)strlen((const char *)arg) && i > 0 && j >= i)
+  if (k == 2) {
+    if (n == (int)strlen((const char *)arg) && i > 0 && j >= i)
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if(k && n == (int)strlen((const char *)arg)) {
-      if(i > 0)
+    if (k && n == (int)strlen((const char *)arg)) {
+      if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if(k && n == (int)strlen((const char *)arg)) {
-        if(i > 0) {
+      if (k && n == (int)strlen((const char *)arg)) {
+        if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;
         }
       }
     }
   }
-  if(lo)
+  if (lo)
     *lo = i;
-  if(hi)
+  if (hi)
     *hi = j;
   return result;
 }
@@ -381,9 +384,9 @@ zsv_select_column_index_selection(const unsigned char *arg, unsigned *lo, unsign
 // zsv_select_check_exclusions_are_indexes(): return err
 static int zsv_select_check_exclusions_are_indexes(struct zsv_select_data *data) {
   int err = 0;
-  for(unsigned int e = 0; e < data->exclusion_count; e++) {
+  for (unsigned int e = 0; e < data->exclusion_count; e++) {
     const unsigned char *arg = data->exclusions[e];
-    if(zsv_select_column_index_selection(arg, NULL, NULL) == zsv_select_column_index_selection_type_none)
+    if (zsv_select_column_index_selection(arg, NULL, NULL) == zsv_select_column_index_selection_type_none)
       err = zsv_printerr(1, "Invalid column index: %s", arg);
   }
   return err;
@@ -397,15 +400,16 @@ static double demo_random_bw_1_and_100() {
 #else
   double max = 100.0;
   unsigned int n;
-# ifdef HAVE_RAND_S
+#ifdef HAVE_RAND_S
   unsigned int tries = 0;
-  while(rand_s(&n) && tries++ < 10);
-  return (double) n / ((double) UINT_MAX + 1) * max;
-# else
+  while (rand_s(&n) && tries++ < 10)
+    ;
+  return (double)n / ((double)UINT_MAX + 1) * max;
+#else
   unsigned int umax = ~0;
   n = rand();
-  return (double) n / ((double) (umax) + 1) * max;
-# endif
+  return (double)n / ((double)(umax) + 1) * max;
+#endif
 #endif
 }
 
@@ -413,26 +417,26 @@ static double demo_random_bw_1_and_100() {
 static void zsv_select_output_data_row(struct zsv_select_data *data) {
   unsigned int cnt = data->output_cols_count;
   char first = 1;
-  if(data->prepend_line_number) {
+  if (data->prepend_line_number) {
     zsv_writer_cell_zu(data->csv_writer, first, data->data_row_count);
     first = 0;
   }
 
   /* print data row */
-  for(unsigned int i = 0; i < cnt; i++) { // for each output column
+  for (unsigned int i = 0; i < cnt; i++) { // for each output column
     unsigned int in_ix = data->out2in[i].ix;
     struct zsv_cell cell = zsv_get_cell(data->parser, in_ix);
-    if(UNLIKELY(data->any_clean != 0))
+    if (UNLIKELY(data->any_clean != 0))
       cell.str = zsv_select_cell_clean(data, cell.str, &cell.quoted, &cell.len);
-    if(VERY_UNLIKELY(data->distinct == ZSV_SELECT_DISTINCT_MERGE)) {
-      if(UNLIKELY(cell.len == 0)) {
-        for(struct zsv_select_uint_list *ix = data->out2in[i].merge.indexes; ix; ix = ix->next) {
+    if (VERY_UNLIKELY(data->distinct == ZSV_SELECT_DISTINCT_MERGE)) {
+      if (UNLIKELY(cell.len == 0)) {
+        for (struct zsv_select_uint_list *ix = data->out2in[i].merge.indexes; ix; ix = ix->next) {
           unsigned int m_ix = ix->value;
           cell = zsv_get_cell(data->parser, m_ix);
-          if(cell.len) {
-            if(UNLIKELY(data->any_clean != 0))
+          if (cell.len) {
+            if (UNLIKELY(data->any_clean != 0))
               cell.str = zsv_select_cell_clean(data, cell.str, &cell.quoted, &cell.len);
-            if(cell.len)
+            if (cell.len)
               break;
           }
         }
@@ -447,46 +451,46 @@ static void zsv_select_data_row(void *ctx) {
   struct zsv_select_data *data = ctx;
   data->data_row_count++;
 
-  if(UNLIKELY(zsv_cell_count(data->parser) == 0 || data->cancelled))
+  if (UNLIKELY(zsv_cell_count(data->parser) == 0 || data->cancelled))
     return;
 
   // check if we should skip this row
   data->skip_this_row = 0;
-  if(UNLIKELY(data->skip_data_rows)) {
+  if (UNLIKELY(data->skip_data_rows)) {
     data->skip_data_rows--;
     data->skip_this_row = 1;
-  } else if(UNLIKELY(data->sample_every_n || data->sample_pct)) {
+  } else if (UNLIKELY(data->sample_every_n || data->sample_pct)) {
     data->skip_this_row = 1;
-    if(data->sample_every_n && data->data_row_count % data->sample_every_n == 1)
+    if (data->sample_every_n && data->data_row_count % data->sample_every_n == 1)
       data->skip_this_row = 0;
-    if(data->sample_pct && demo_random_bw_1_and_100() <= data->sample_pct)
+    if (data->sample_pct && demo_random_bw_1_and_100() <= data->sample_pct)
       data->skip_this_row = 0;
   }
 
-  if(LIKELY(!data->skip_this_row)) {
+  if (LIKELY(!data->skip_this_row)) {
     // if we have a search filter, check that
     char skip = 0;
     skip = !zsv_select_row_search_hit(data);
-    if(!skip) {
+    if (!skip) {
 
       // print the data row
       zsv_select_output_data_row(data);
-      if(UNLIKELY(data->data_rows_limit > 0))
-        if(data->data_row_count + 1 >= data->data_rows_limit)
+      if (UNLIKELY(data->data_rows_limit > 0))
+        if (data->data_row_count + 1 >= data->data_rows_limit)
           data->cancelled = 1;
     }
   }
-  if(data->data_row_count % 25000 == 0 && data->verbose)
+  if (data->data_row_count % 25000 == 0 && data->verbose)
     fprintf(stderr, "Processed %zu rows\n", data->data_row_count);
 }
 
 static void zsv_select_print_header_row(struct zsv_select_data *data) {
-  if(data->no_header)
+  if (data->no_header)
     return;
   zsv_writer_cell_prepend(data->csv_writer, (const unsigned char *)data->prepend_header);
-  if(data->prepend_line_number)
+  if (data->prepend_line_number)
     zsv_writer_cell_s(data->csv_writer, 1, (const unsigned char *)"#", 0);
-  for(unsigned int i = 0; i < data->output_cols_count; i++) {
+  for (unsigned int i = 0; i < data->output_cols_count; i++) {
     unsigned char *header_name = zsv_select_get_header_name(data, data->out2in[i].ix);
     zsv_writer_cell_s(data->csv_writer, i == 0 && !data->prepend_line_number, header_name, 1);
   }
@@ -494,7 +498,7 @@ static void zsv_select_print_header_row(struct zsv_select_data *data) {
 }
 
 static void zsv_select_header_finish(struct zsv_select_data *data) {
-  if(zsv_select_set_output_columns(data))
+  if (zsv_select_set_output_columns(data))
     data->cancelled = 1;
   else {
     zsv_select_print_header_row(data);
@@ -505,27 +509,27 @@ static void zsv_select_header_finish(struct zsv_select_data *data) {
 static void zsv_select_header_row(void *ctx) {
   struct zsv_select_data *data = ctx;
 
-  if(data->cancelled)
+  if (data->cancelled)
     return;
 
   unsigned int cols = zsv_cell_count(data->parser);
   unsigned int max_header_ix = 0;
-  for(unsigned int i = 0; i < cols; i++) {
+  for (unsigned int i = 0; i < cols; i++) {
     struct zsv_cell cell = zsv_get_cell(data->parser, i);
-    if(UNLIKELY(data->any_clean != 0))
+    if (UNLIKELY(data->any_clean != 0))
       cell.str = zsv_select_cell_clean(data, cell.str, &cell.quoted, &cell.len);
-    if(i < data->opts->max_columns) {
+    if (i < data->opts->max_columns) {
       data->header_names[i] = zsv_memdup(cell.str, cell.len);
-      max_header_ix = i+1;
+      max_header_ix = i + 1;
     }
   }
 
   // in case we want to make this an option later
   char trim_trailing_columns = 1;
-  if(!trim_trailing_columns)
+  if (!trim_trailing_columns)
     max_header_ix = cols;
 
-  if(max_header_ix > data->header_name_count)
+  if (max_header_ix > data->header_name_count)
     data->header_name_count = max_header_ix;
 
   zsv_select_header_finish(data);
@@ -535,76 +539,79 @@ static void zsv_select_header_row(void *ctx) {
 #define ZSV_SELECT_MAX_COLS_DEFAULT_S "1024"
 
 const char *zsv_select_usage_msg[] = {
-  APPNAME ": streaming CSV parser",
+  APPNAME ": extracts and outputs specified columns",
   "",
   "Usage: " APPNAME " [filename] [options] [-- col_specifier [... col_specifier]]",
-  "  where col_specifier is a column name or, if the -n option is used,",
-  "   a column index (starting at 1) or index range in the form of n-m",
-  "  e.g. " APPNAME " -n myfile.csv -- 1 4-6 50 10",
-  "       " APPNAME " myfile.csv -- first_col fiftieth_column \"Tenth Column\"",
+  "       where col_specifier is a column name or, if the -n option is used,",
+  "       a column index (starting at 1) or index range in the form of n-m",
+  "       e.g. " APPNAME " -n file.csv -- 1 4-6 50 10",
+  "            " APPNAME " file.csv -- first_col fiftieth_column \"Tenth Column\"",
   "",
-  "Extracts and outputs specified columns. Outputs the input columns that are specified after",
-  "the '--' separator, or all columns if no '--' separator is provided",
+  "Note: Outputs the columns specified after '--' separator, or all columns if omitted.",
   "",
   "Options:",
-  "  -b,--with-bom: output with BOM",
-  "  --fixed <offset1,offset2,..>: parse as fixed-width text; use given comma-separated list of positive integers for cell end indexes",
-  "  --fixed-auto                : parse as fixed-width text; derive widths from first row in input data (up to max 1MB size)",
-  "                                assumes ASCII whitespace; multi-byte whitespace is not counted as whitespace",
+  "  -b,--with-bom                : output with BOM",
+  "  --fixed <offset1,offset2,..> : parse as fixed-width text; use given CSV list of positive integers for",
+  "                                 cell and indexes",
+  "  --fixed-auto                 : parse as fixed-width text; derive widths from first row in input data (max 1MB)",
+  "                                 assumes ASCII whitespace; multi-byte whitespace is not counted as whitespace",
 #ifndef ZSV_CLI
-  "  -v,--verbose                : verbose output",
+  "  -v,--verbose                 : verbose output",
 #endif
-  "  -H,--head <n>               : (head) only process the first n rows of data from all rows (including header) in the input",
-  "  --no-header                 : do not output a header row",
-  "  --prepend-header <value>    : prepend each column header with the given text value",
-  "  -s,--search <value>         : only output rows with at least one cell containing value",
-  // to do: " -s,--search /<pattern>/modifiers: search on regex pattern; modifiers include 'g' (global) and 'i' (case-insensitive)",
-  "  --sample-every <num of rows>: output a sample consisting of the first row, then every nth row",
-  "  --sample-pct <percentage>   : output a randomly-selected sample (32 bits of randomness) of n percent of the input rows",
-  "  --distinct                  : skip subsequent occurrences of columns with the same name",
-  "  --merge                     : merge subsequent occurrences of columns with the same",
-  "                                name, outputting first non-null value",
-  // --rename: like distinct, but instead of removing cols with dupe names, renames them, trying _<n> for n up to max cols
-  "  -e <embedded lineend char>  : char to replace embedded lineend. if none provided, embedded lineends are preserved",
-  "      If the provided string begins with 0x, it will be interpreted as the hex representation of a string",
-  "  -x <column>                 : exclude the indicated column. can be specified more than once",
-  "  -N,--line-number            : prefix each row with the row number",
-  "  -n: provided column indexes are numbers corresponding to column positions (starting with 1), instead of names",
+  "  -H,--head <n>                : (head) only process the first n rows of input data (including header)",
+  "  --no-header                  : do not output header row",
+  "  --prepend-header <value>     : prepend each column header with the given text <value>",
+  "  -s,--search <value>          : only output rows with at least one cell containing <value>",
+  // TO DO: " -s,--search /<pattern>/modifiers: search on regex pattern; modifiers include 'g' (global) and 'i'
+  // (case-insensitive)",
+  "  --sample-every <num_of_rows> : output a sample consisting of the first row, then every nth row",
+  "  --sample-pct <percentage>    : output a randomly-selected sample (32 bits of randomness) of n%% of input rows",
+  "  --distinct                   : skip subsequent occurrences of columns with the same name",
+  "  --merge                      : merge subsequent occurrences of columns with the same name",
+  "                                 outputting first non-null value",
+  // --rename: like distinct, but instead of removing cols with dupe names, renames them, trying _<n> for n up to max
+  // cols
+  "  -e <embedded_lineend_char>   : char to replace embedded lineend. If left empty, embedded lineends are preserved.",
+  "                                 If the provided string begins with 0x, it will be interpreted as the hex",
+  "                                 representation of a string.",
+  "  -x <column>                  : exclude the indicated column. can be specified more than once",
+  "  -N,--line-number             : prefix each row with the row number",
+  "  -n                           : provided column indexes are numbers corresponding to column positions",
+  "                                 (starting with 1), instead of names",
 #ifndef ZSV_CLI
-  "  -T                          : input is tab-delimited, instead of comma-delimited",
-  "  -O,--other-delim <delim>    : input is delimited with the given char",
-  "                                Note: this option does not support quoted values",
-  "                                with embedded delimiters",
+  "  -T                           : input is tab-delimited, instead of comma-delimited",
+  "  -O,--other-delim <delim>     : input is delimited with the given char",
+  "                                 Note: This option does not support quoted values with embedded delimiters.",
 #endif
-  "  --unescape                  : escape any backslash-escaped input e.g. \\t, \\n, \\r",
-  "                                such as output from `2tsv`",
-  "  -w,--whitespace-clean       : normalize all whitespace to space or newline, single-char (non-consecutive) occurrences",
+  "  --unescape                   : escape any backslash-escaped input e.g. \\t, \\n, \\r such as output from `2tsv`",
+  "  -w,--whitespace-clean        : normalize all whitespace to space or newline, single-char (non-consecutive)",
+  "                                 occurrences",
   "  --whitespace-clean-no-newline: clean whitespace and remove embedded newlines",
-  "  -W,--no-trim: do not trim whitespace",
+  "  -W,--no-trim                 : do not trim whitespace",
 #ifndef ZSV_CLI
-  "  -C <maximum_number_of_columns>: defaults to " ZSV_SELECT_MAX_COLS_DEFAULT_S,
-  "  -L,--max-row-size <n>: set the maximum memory used for a single row",
-  "                          defaults to " ZSV_ROW_MAX_SIZE_DEFAULT_S ", min " ZSV_ROW_MAX_SIZE_MIN_S ")",
+  "  -C <max_num_of_columns>      : defaults to " ZSV_SELECT_MAX_COLS_DEFAULT_S,
+  "  -L,--max-row-size <n>        : set the maximum memory used for a single row",
+  "                                 Default: " ZSV_ROW_MAX_SIZE_MIN_S " (min), " ZSV_ROW_MAX_SIZE_DEFAULT_S " (max)",
 #endif
-  "  -o <output filename>: name of file to save output to",
-  NULL
+  "  -o <filename>                : filename to save output to",
+  NULL,
 };
 
 static void zsv_select_usage() {
-  for(int i = 0; zsv_select_usage_msg[i]; i++)
+  for (size_t i = 0; zsv_select_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_select_usage_msg[i]);
 }
 
 static void zsv_select_cleanup(struct zsv_select_data *data) {
-  if(data->opts->stream && data->opts->stream != stdin)
+  if (data->opts->stream && data->opts->stream != stdin)
     fclose(data->opts->stream);
 
   zsv_writer_delete(data->csv_writer);
   zsv_select_search_str_delete(data->search_strings);
 
-  if(data->distinct == ZSV_SELECT_DISTINCT_MERGE) {
-    for(unsigned int i = 0; i < data->output_cols_count; i++) {
-      for(struct zsv_select_uint_list *next, *ix = data->out2in[i].merge.indexes; ix; ix = next) {
+  if (data->distinct == ZSV_SELECT_DISTINCT_MERGE) {
+    for (unsigned int i = 0; i < data->output_cols_count; i++) {
+      for (struct zsv_select_uint_list *next, *ix = data->out2in[i].merge.indexes; ix; ix = next) {
         next = ix->next;
         free(ix);
       }
@@ -612,7 +619,7 @@ static void zsv_select_cleanup(struct zsv_select_data *data) {
   }
   free(data->out2in);
 
-  for(unsigned int i = 0; i < data->header_name_count; i++)
+  for (unsigned int i = 0; i < data->header_name_count; i++)
     free(data->header_names[i]);
   free(data->header_names);
 
@@ -631,22 +638,21 @@ static void zsv_select_cleanup(struct zsv_select_data *data) {
  * - from the merged line, find each instance of white followed by not-white,
  *   but ignore the first instance of it
  */
-static enum zsv_status auto_detect_fixed_column_sizes(struct fixed *fixed, struct zsv_opts *opts,
-                                                      unsigned char *buff, size_t buffsize, size_t *buff_used,
-                                                      char verbose) {
-  char only_first_line = 0; // to do: make this an option
+static enum zsv_status auto_detect_fixed_column_sizes(struct fixed *fixed, struct zsv_opts *opts, unsigned char *buff,
+                                                      size_t buffsize, size_t *buff_used, char verbose) {
+  char only_first_line = 0; // TO DO: make this an option
   enum zsv_status stat = zsv_status_ok;
 
   fixed->count = 0;
   char *line = calloc(buffsize, sizeof(*buff));
-  if(!line) {
+  if (!line) {
     stat = zsv_status_memory;
     goto auto_detect_fixed_column_sizes_exit;
   }
   memset(line, ' ', buffsize);
 
   *buff_used = fread(buff, 1, buffsize, opts->stream);
-  if(!*buff_used) {
+  if (!*buff_used) {
     stat = zsv_status_no_more_input;
     goto auto_detect_fixed_column_sizes_exit;
   }
@@ -656,13 +662,14 @@ static enum zsv_status auto_detect_fixed_column_sizes(struct fixed *fixed, struc
   char first = 1;
   char was_space = 1;
   char was_line_end = 0;
-  for(size_t i = 0; i < *buff_used && (!only_first_line || !line_end); i++, line_cursor = was_line_end ? 0 : line_cursor + 1) {
+  for (size_t i = 0; i < *buff_used && (!only_first_line || !line_end);
+       i++, line_cursor = was_line_end ? 0 : line_cursor + 1) {
     was_line_end = 0;
-    // to do: support multi-byte unicode chars?
-    switch(buff[i]) {
+    // TO DO: support multi-byte unicode chars?
+    switch (buff[i]) {
     case '\n':
     case '\r':
-      if(line_cursor > line_end)
+      if (line_cursor > line_end)
         line_end = line_cursor;
       was_line_end = 1;
       was_space = 1;
@@ -675,9 +682,9 @@ static enum zsv_status auto_detect_fixed_column_sizes(struct fixed *fixed, struc
       break;
     default:
       line[line_cursor] = 'x';
-      if(was_space) {
-        if(!line_end) { // only count columns for the first line
-          if(first)
+      if (was_space) {
+        if (!line_end) { // only count columns for the first line
+          if (first)
             first = 0;
           else
             fixed->count++;
@@ -686,21 +693,21 @@ static enum zsv_status auto_detect_fixed_column_sizes(struct fixed *fixed, struc
       was_space = 0;
     }
   }
-  if(!first)
+  if (!first)
     fixed->count++;
 
-  if(!line_end) {
+  if (!line_end) {
     stat = zsv_status_error;
     goto auto_detect_fixed_column_sizes_exit;
   }
 
-  if(verbose)
+  if (verbose)
     fprintf(stderr, "Calculating %zu columns from line:\n%.*s\n", fixed->count, (int)line_end, line);
 
   // allocate offsets
   free(fixed->offsets);
   fixed->offsets = malloc(fixed->count * sizeof(*fixed->offsets));
-  if(!fixed->offsets) {
+  if (!fixed->offsets) {
     stat = zsv_status_memory;
     goto auto_detect_fixed_column_sizes_exit;
   }
@@ -710,16 +717,16 @@ static enum zsv_status auto_detect_fixed_column_sizes(struct fixed *fixed, struc
   int count = 0;
   was_space = 1;
   first = 1;
-  if(verbose)
+  if (verbose)
     fprintf(stderr, "Running --fixed ");
   size_t i;
-  for(i = 0; i < line_end; i++) {
-    if(line[i] == 'x') {
-      if(was_space) {
-        if(first)
+  for (i = 0; i < line_end; i++) {
+    if (line[i] == 'x') {
+      if (was_space) {
+        if (first)
           first = 0;
         else {
-          if(verbose)
+          if (verbose)
             fprintf(stderr, "%s%zu", count ? "," : "", i);
           fixed->offsets[count++] = i;
         }
@@ -728,27 +735,28 @@ static enum zsv_status auto_detect_fixed_column_sizes(struct fixed *fixed, struc
     } else
       was_space = 1;
   }
-  if(!first) {
-    if(verbose)
+  if (!first) {
+    if (verbose)
       fprintf(stderr, "%s%zu", count ? "," : "", i);
     fixed->offsets[count++] = i;
   }
-  if(verbose)
+  if (verbose)
     fprintf(stderr, "\n");
 
- auto_detect_fixed_column_sizes_exit:
+auto_detect_fixed_column_sizes_exit:
   free(line);
   return stat;
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
     zsv_select_usage();
     return zsv_status_ok;
   }
 
   char fixed_auto = 0;
-  struct zsv_select_data data = { 0 };
+  struct zsv_select_data data = {0};
   data.opts = opts;
   const char *input_path = NULL;
   struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
@@ -757,144 +765,146 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   size_t preview_buff_len = 0;
 
   enum zsv_status stat = zsv_status_ok;
-  for(int arg_i = 1; stat == zsv_status_ok && arg_i < argc; arg_i++) {
-    if(!strcmp(argv[arg_i], "--")) {
+  for (int arg_i = 1; stat == zsv_status_ok && arg_i < argc; arg_i++) {
+    if (!strcmp(argv[arg_i], "--")) {
       col_index_arg_i = arg_i + 1;
       break;
     }
-    if(!strcmp(argv[arg_i], "-b") || !strcmp(argv[arg_i], "--with-bom"))
+    if (!strcmp(argv[arg_i], "-b") || !strcmp(argv[arg_i], "--with-bom"))
       writer_opts.with_bom = 1;
-    else if(!strcmp(argv[arg_i], "--fixed-auto"))
+    else if (!strcmp(argv[arg_i], "--fixed-auto"))
       fixed_auto = 1;
-    else if(!strcmp(argv[arg_i], "--fixed")) {
-      if(++arg_i >= argc)
-        stat = zsv_printerr(1, "%s option requires parameter", argv[arg_i-1]);
+    else if (!strcmp(argv[arg_i], "--fixed")) {
+      if (++arg_i >= argc)
+        stat = zsv_printerr(1, "%s option requires parameter", argv[arg_i - 1]);
       else { // parse offsets
         data.fixed.count = 1;
-        for(const char *s = argv[arg_i]; *s; s++)
-          if(*s == ',')
+        for (const char *s = argv[arg_i]; *s; s++)
+          if (*s == ',')
             data.fixed.count++;
         free(data.fixed.offsets);
         data.fixed.offsets = malloc(data.fixed.count * sizeof(*data.fixed.offsets));
         size_t count = 0;
         const char *start = argv[arg_i];
-        for(const char *end = argv[arg_i]; ; end++) {
-          if(*end == ',' || *end == '\0') {
-            if(!sscanf(start, "%zu,", &data.fixed.offsets[count++])) {
+        for (const char *end = argv[arg_i];; end++) {
+          if (*end == ',' || *end == '\0') {
+            if (!sscanf(start, "%zu,", &data.fixed.offsets[count++])) {
               stat = zsv_printerr(1, "Invalid offset: %.*s\n", end - start, start);
               break;
-            } else if(*end == '\0')
+            } else if (*end == '\0')
               break;
             else {
               start = end + 1;
-              if(*start == '\0')
+              if (*start == '\0')
                 break;
             }
           }
         }
       }
-    } else if(!strcmp(argv[arg_i], "--distinct"))
+    } else if (!strcmp(argv[arg_i], "--distinct"))
       data.distinct = 1;
-    else if(!strcmp(argv[arg_i], "--merge"))
+    else if (!strcmp(argv[arg_i], "--merge"))
       data.distinct = ZSV_SELECT_DISTINCT_MERGE;
-    else if(!strcmp(argv[arg_i], "-o") || !strcmp(argv[arg_i], "--output")) {
-      if(++arg_i >= argc)
-        stat = zsv_printerr(1, "%s option requires parameter", argv[arg_i-1]);
-      else if(writer_opts.stream && writer_opts.stream != stdout)
+    else if (!strcmp(argv[arg_i], "-o") || !strcmp(argv[arg_i], "--output")) {
+      if (++arg_i >= argc)
+        stat = zsv_printerr(1, "%s option requires parameter", argv[arg_i - 1]);
+      else if (writer_opts.stream && writer_opts.stream != stdout)
         stat = zsv_printerr(1, "Output file specified more than once");
-      else if(!(writer_opts.stream = fopen(argv[arg_i], "wb")))
+      else if (!(writer_opts.stream = fopen(argv[arg_i], "wb")))
         stat = zsv_printerr(1, "Unable to open for writing: %s", argv[arg_i]);
-      else if(data.opts->verbose)
+      else if (data.opts->verbose)
         fprintf(stderr, "Opened %s for write\n", argv[arg_i]);
-    } else if(!strcmp(argv[arg_i], "-N") || !strcmp(argv[arg_i], "--line-number")) {
+    } else if (!strcmp(argv[arg_i], "-N") || !strcmp(argv[arg_i], "--line-number")) {
       data.prepend_line_number = 1;
-    } else if(!strcmp(argv[arg_i], "-n"))
+    } else if (!strcmp(argv[arg_i], "-n"))
       data.use_header_indexes = 1;
-    else if(!strcmp(argv[arg_i], "-s") || !strcmp(argv[arg_i], "--search")) {
+    else if (!strcmp(argv[arg_i], "-s") || !strcmp(argv[arg_i], "--search")) {
       arg_i++;
-      if(arg_i < argc && strlen(argv[arg_i]))
+      if (arg_i < argc && strlen(argv[arg_i]))
         zsv_select_add_search(&data, argv[arg_i]);
       else
-        stat = zsv_printerr(1, "%s option requires a value", argv[arg_i-1]);
-    } else if(!strcmp(argv[arg_i], "-v") || !strcmp(argv[arg_i], "--verbose")) {
+        stat = zsv_printerr(1, "%s option requires a value", argv[arg_i - 1]);
+    } else if (!strcmp(argv[arg_i], "-v") || !strcmp(argv[arg_i], "--verbose")) {
       data.verbose = 1;
-    } else if(!strcmp(argv[arg_i], "--unescape")) {
+    } else if (!strcmp(argv[arg_i], "--unescape")) {
       data.unescape = 1;
-    } else if(!strcmp(argv[arg_i], "-w") || !strcmp(argv[arg_i], "--whitespace-clean"))
+    } else if (!strcmp(argv[arg_i], "-w") || !strcmp(argv[arg_i], "--whitespace-clean"))
       data.clean_white = 1;
-    else if(!strcmp(argv[arg_i], "--whitespace-clean-no-newline")) {
+    else if (!strcmp(argv[arg_i], "--whitespace-clean-no-newline")) {
       data.clean_white = 1;
-      data.whitspace_clean_flags = 1;
-    } else if(!strcmp(argv[arg_i], "-W") || !strcmp(argv[arg_i], "--no-trim")) {
+      data.whitespace_clean_flags = 1;
+    } else if (!strcmp(argv[arg_i], "-W") || !strcmp(argv[arg_i], "--no-trim")) {
       data.no_trim_whitespace = 1;
-    } else if(!strcmp(argv[arg_i], "--sample-every")) {
+    } else if (!strcmp(argv[arg_i], "--sample-every")) {
       arg_i++;
-      if(!(arg_i < argc))
+      if (!(arg_i < argc))
         stat = zsv_printerr(1, "--sample-every option requires a value");
-      else if(atoi(argv[arg_i]) <= 0)
+      else if (atoi(argv[arg_i]) <= 0)
         stat = zsv_printerr(1, "--sample-every value should be an integer > 0");
       else
         data.sample_every_n = atoi(argv[arg_i]); // TO DO: check for overflow
-    } else if(!strcmp(argv[arg_i], "--sample-pct")) {
+    } else if (!strcmp(argv[arg_i], "--sample-pct")) {
       arg_i++;
       double d;
-      if(!(arg_i < argc))
+      if (!(arg_i < argc))
         stat = zsv_printerr(1, "--sample-pct option requires a value");
-      else if(!(d = atof(argv[arg_i])) && d > 0 && d < 100)
-        stat = zsv_printerr(-1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5% of the data");
+      else if (!(d = atof(argv[arg_i])) && d > 0 && d < 100)
+        stat = zsv_printerr(
+          -1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5% of the data");
       else
         data.sample_pct = d;
-    } else if(!strcmp(argv[arg_i], "--prepend-header")) {
-      if(!(arg_i + 1 < argc))
+    } else if (!strcmp(argv[arg_i], "--prepend-header")) {
+      if (!(arg_i + 1 < argc))
         stat = zsv_printerr(1, "%s option requires a value");
       else
         data.prepend_header = argv[++arg_i];
-    } else if(!strcmp(argv[arg_i], "--no-header")) {
-        data.no_header = 1;
-    } else if(!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
-      if(!(arg_i + 1 < argc && atoi(argv[arg_i+1]) >= 0))
-        stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i], arg_i + 1 < argc ? argv[arg_i+1] : "");
+    } else if (!strcmp(argv[arg_i], "--no-header")) {
+      data.no_header = 1;
+    } else if (!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
+      if (!(arg_i + 1 < argc && atoi(argv[arg_i + 1]) >= 0))
+        stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i],
+                            arg_i + 1 < argc ? argv[arg_i + 1] : "");
       else
         data.data_rows_limit = atoi(argv[++arg_i]) + 1;
-    } else if(!strcmp(argv[arg_i], "-D") || !strcmp(argv[arg_i], "--skip-data")) {
+    } else if (!strcmp(argv[arg_i], "-D") || !strcmp(argv[arg_i], "--skip-data")) {
       ++arg_i;
-      if(!(arg_i < argc && atoi(argv[arg_i]) >= 0))
-        stat = zsv_printerr(1, "%s option value invalid: should be positive integer", argv[arg_i-1]);
+      if (!(arg_i < argc && atoi(argv[arg_i]) >= 0))
+        stat = zsv_printerr(1, "%s option value invalid: should be positive integer", argv[arg_i - 1]);
       else
         data.skip_data_rows = atoi(argv[arg_i]);
-    } else if(!strcmp(argv[arg_i], "-e")) {
+    } else if (!strcmp(argv[arg_i], "-e")) {
       ++arg_i;
-      if(data.embedded_lineend)
+      if (data.embedded_lineend)
         stat = zsv_printerr(1, "-e option specified more than once");
-      else if(strlen(argv[arg_i]) != 1)
+      else if (strlen(argv[arg_i]) != 1)
         stat = zsv_printerr(1, "-e option value must be a single character");
-      else if(arg_i < argc)
+      else if (arg_i < argc)
         data.embedded_lineend = *argv[arg_i];
       else
         stat = zsv_printerr(1, "-e option requires a value");
-    } else if(!strcmp(argv[arg_i], "-x")) {
+    } else if (!strcmp(argv[arg_i], "-x")) {
       arg_i++;
-      if(!(arg_i < argc))
-        stat = zsv_printerr(1, "%s option requires a value", argv[arg_i-1]);
+      if (!(arg_i < argc))
+        stat = zsv_printerr(1, "%s option requires a value", argv[arg_i - 1]);
       else
         zsv_select_add_exclusion(&data, argv[arg_i]);
-    } else if(*argv[arg_i] == '-')
+    } else if (*argv[arg_i] == '-')
       stat = zsv_printerr(1, "Unrecognized argument: %s", argv[arg_i]);
-    else if(data.opts->stream)
+    else if (data.opts->stream)
       stat = zsv_printerr(1, "Input file was specified, cannot also read: %s", argv[arg_i]);
-    else if(!(data.opts->stream = fopen(argv[arg_i], "rb")))
+    else if (!(data.opts->stream = fopen(argv[arg_i], "rb")))
       stat = zsv_printerr(1, "Could not open for reading: %s", argv[arg_i]);
     else
       input_path = argv[arg_i];
   }
 
-  if(data.sample_pct)
+  if (data.sample_pct)
     srand(time(0));
 
-  if(data.use_header_indexes && stat == zsv_status_ok)
+  if (data.use_header_indexes && stat == zsv_status_ok)
     stat = zsv_select_check_exclusions_are_indexes(&data);
 
-  if(!data.opts->stream) {
+  if (!data.opts->stream) {
 #ifdef NO_STDIN
     stat = zsv_printerr(1, "Please specify an input file");
 #else
@@ -902,23 +912,24 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #endif
   }
 
-  if(stat == zsv_status_ok && fixed_auto) {
-    if(data.fixed.offsets)
+  if (stat == zsv_status_ok && fixed_auto) {
+    if (data.fixed.offsets)
       stat = zsv_printerr(zsv_status_error, "Please specify either --fixed-auto or --fixed, but not both");
-    else if(data.opts->insert_header_row)
+    else if (data.opts->insert_header_row)
       stat = zsv_printerr(zsv_status_error, "--fixed-auto can not be specified together with --header-row");
     else {
-      size_t buffsize = 1024*256; // read the first
+      size_t buffsize = 1024 * 256; // read the first
       preview_buff = calloc(buffsize, sizeof(*preview_buff));
-      if(!preview_buff)
+      if (!preview_buff)
         stat = zsv_printerr(zsv_status_memory, "Out of memory!");
       else
-        stat = auto_detect_fixed_column_sizes(&data.fixed, data.opts, preview_buff, buffsize, &preview_buff_len, opts->verbose);
+        stat = auto_detect_fixed_column_sizes(&data.fixed, data.opts, preview_buff, buffsize, &preview_buff_len,
+                                              opts->verbose);
     }
   }
 
-  if(stat == zsv_status_ok) {
-    if(!col_index_arg_i)
+  if (stat == zsv_status_ok) {
+    if (!col_index_arg_i)
       data.col_argc = 0;
     else {
       data.col_argv = &argv[col_index_arg_i];
@@ -929,24 +940,20 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     assert(data.opts->max_columns > 0);
     data.out2in = calloc(data.opts->max_columns, sizeof(*data.out2in));
     data.csv_writer = zsv_writer_new(&writer_opts);
-    if(!(data.header_names && data.csv_writer))
+    if (!(data.header_names && data.csv_writer))
       stat = zsv_status_memory;
     else {
       data.opts->row_handler = zsv_select_header_row;
       data.opts->ctx = &data;
-      if(zsv_new_with_properties(data.opts, custom_prop_handler, input_path, opts_used, &data.parser)
-         == zsv_status_ok) {
+      if (zsv_new_with_properties(data.opts, custom_prop_handler, input_path, opts_used, &data.parser) ==
+          zsv_status_ok) {
         // all done with
-        data.any_clean =
-          !data.no_trim_whitespace
-          || data.clean_white
-          || data.embedded_lineend
-          || data.unescape;;
+        data.any_clean = !data.no_trim_whitespace || data.clean_white || data.embedded_lineend || data.unescape;
+        ;
 
         // set to fixed if applicable
-        if(data.fixed.count && zsv_set_fixed_offsets(data.parser, data.fixed.count,
-                                                     data.fixed.offsets)
-           != zsv_status_ok)
+        if (data.fixed.count &&
+            zsv_set_fixed_offsets(data.parser, data.fixed.count, data.fixed.offsets) != zsv_status_ok)
           data.cancelled = 1;
 
         // create a local csv writer buff quoted values
@@ -956,13 +963,12 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         // process the input data
         zsv_handle_ctrl_c_signal();
         enum zsv_status status = zsv_status_ok;
-        if(preview_buff && preview_buff_len)
+        if (preview_buff && preview_buff_len)
           status = zsv_parse_bytes(data.parser, preview_buff, preview_buff_len);
 
-        while(status == zsv_status_ok
-              && !zsv_signal_interrupted && !data.cancelled)
+        while (status == zsv_status_ok && !zsv_signal_interrupted && !data.cancelled)
           status = zsv_parse_more(data.parser);
-        if(status == zsv_status_no_more_input)
+        if (status == zsv_status_no_more_input)
           status = zsv_finish(data.parser);
         zsv_delete(data.parser);
       }
@@ -970,7 +976,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   }
   free(preview_buff);
   zsv_select_cleanup(&data);
-  if(writer_opts.stream && writer_opts.stream != stdout)
+  if (writer_opts.stream && writer_opts.stream != stdout)
     fclose(writer_opts.stream);
   return stat;
 }

--- a/app/select.c
+++ b/app/select.c
@@ -121,8 +121,7 @@ struct zsv_select_data {
   unsigned char _ : 3;
 };
 
-enum zsv_select_column_index_selection_type
-{
+enum zsv_select_column_index_selection_type {
   zsv_select_column_index_selection_type_none = 0,
   zsv_select_column_index_selection_type_single,
   zsv_select_column_index_selection_type_range,

--- a/app/select.c
+++ b/app/select.c
@@ -69,7 +69,7 @@ struct zsv_select_data {
     struct {         // merge data: only used with --merge
       struct zsv_select_uint_list *indexes, **last_index;
     } merge;
-  } *out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
+  } * out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
 
   unsigned int output_cols_count; // total count of output columns
 
@@ -121,7 +121,8 @@ struct zsv_select_data {
   unsigned char _ : 3;
 };
 
-enum zsv_select_column_index_selection_type {
+enum zsv_select_column_index_selection_type
+{
   zsv_select_column_index_selection_type_none = 0,
   zsv_select_column_index_selection_type_single,
   zsv_select_column_index_selection_type_range,

--- a/app/serialize.c
+++ b/app/serialize.c
@@ -48,67 +48,64 @@ struct serialize_data {
     const char *value;
     unsigned char *value_lc; // only used if case_insensitive is set
     size_t len;
-    unsigned char case_insensitive:1;
-    unsigned char entire:1;
-    unsigned _:6;
+    unsigned char case_insensitive : 1;
+    unsigned char entire : 1;
+    unsigned _ : 6;
   } filter;
-  unsigned char use_column_position:1;
-  unsigned char _:7;
+  unsigned char use_column_position : 1;
+  unsigned char _ : 7;
 };
 
-static void serialize_write_tuple(struct serialize_data *data,
-                                  const unsigned char *id, size_t id_len, char id_quoted,
-                                  const unsigned char *colname, size_t colname_len,
-                                  const unsigned char *s, size_t len, char quoted) {
+static void serialize_write_tuple(struct serialize_data *data, const unsigned char *id, size_t id_len, char id_quoted,
+                                  const unsigned char *colname, size_t colname_len, const unsigned char *s, size_t len,
+                                  char quoted) {
   // write row ID, column name, cell value
   zsv_writer_cell(data->csv_writer, 1, id, id_len, id_quoted);
   zsv_writer_cell(data->csv_writer, 0, colname, colname_len, 0);
   zsv_writer_cell(data->csv_writer, 0, s, len, quoted);
 
   // to do: write additional column headers
-  for(struct serialize_additional_column *col = data->additional_columns; col; col = col->next) {
-    if(col->position_plus_1) {
+  for (struct serialize_additional_column *col = data->additional_columns; col; col = col->next) {
+    if (col->position_plus_1) {
       struct zsv_cell c = zsv_get_cell(data->parser, col->position_plus_1 - 1);
       zsv_writer_cell(data->csv_writer, 0, c.str, c.len, c.quoted);
     }
   }
 }
 
-static inline void serialize_cell(struct serialize_data *data,
-                                  struct zsv_cell id, unsigned i) {
+static inline void serialize_cell(struct serialize_data *data, struct zsv_cell id, unsigned i) {
   struct zsv_cell cell = zsv_get_cell(data->parser, i);
   char skip = 0;
-  if(data->filter.value) {
-    if(data->filter.case_insensitive) {
-      if(data->filter.entire) {
+  if (data->filter.value) {
+    if (data->filter.case_insensitive) {
+      if (data->filter.entire) {
         int err = 0;
         skip = zsv_strincmp(cell.str, cell.len, (const unsigned char *)data->filter.value, data->filter.len);
-        if(err) {
+        if (err) {
           skip = 1;
           fprintf(stderr, "Ignoring invalid utf8: %.*s\n", (int)cell.len, cell.str);
         }
       } else { // case-insensitive, not-entire-cell. skip if not contains
-        if(data->filter.value_lc) {
+        if (data->filter.value_lc) {
           size_t len = cell.len;
           unsigned char *tmp = zsv_strtolowercase(cell.str, &len);
-          if(tmp) {
+          if (tmp) {
             skip = !zsv_strstr(tmp, data->filter.value_lc);
             free(tmp);
           }
         }
       }
     } else {
-      if(data->filter.entire) // case-sensitive, exact / entire-cell. skip if not equal
+      if (data->filter.entire) // case-sensitive, exact / entire-cell. skip if not equal
         skip = !(cell.len == data->filter.len && !memcmp(cell.str, data->filter.value, cell.len));
       else // case-sensitive, not-entire-cell. skip if not contains
         skip = !memmem(cell.str, cell.len, data->filter.value, data->filter.len);
     }
   }
 
-  if(!skip)
+  if (!skip)
     // write tuple
-    serialize_write_tuple(data, id.str, id.len, id.quoted,
-                          data->header_names[i].str, data->header_names[i].len,
+    serialize_write_tuple(data, id.str, id.len, id.quoted, data->header_names[i].str, data->header_names[i].len,
                           cell.str, cell.len, cell.quoted);
 }
 
@@ -117,82 +114,78 @@ static void serialize_row(void *hook);
 static void serialize_header(void *hook) {
   struct serialize_data *data = hook;
   zsv_set_row_handler(data->parser, serialize_row);
-  if(data->err_msg)
+  if (data->err_msg)
     return;
 
   data->col_count = zsv_cell_count(data->parser);
-  if(!data->col_count)
+  if (!data->col_count)
     asprintf(&data->err_msg, "No columns read in first row; aborting\n");
   else {
     // write header
     struct zsv_cell idCell = zsv_get_cell(data->parser, data->id_column_position);
-    if(idCell.len == 0) {
+    if (idCell.len == 0) {
       idCell.str = (unsigned char *)"(Blank)";
       idCell.len = strlen((const char *)idCell.str);
     }
     // if we have additional columns, find them and output their header names
-    if(data->additional_columns) {
-      for(struct serialize_additional_column *c = data->additional_columns;
-          c && !data->err_msg; c = c->next) {
-        for(unsigned i = 0; i < data->col_count && !data->err_msg; i++) {
+    if (data->additional_columns) {
+      for (struct serialize_additional_column *c = data->additional_columns; c && !data->err_msg; c = c->next) {
+        for (unsigned i = 0; i < data->col_count && !data->err_msg; i++) {
           struct zsv_cell tmp = zsv_get_cell(data->parser, i);
 
-          if(!zsv_strincmp(tmp.str, tmp.len, c->name, c->len)) {
+          if (!zsv_strincmp(tmp.str, tmp.len, c->name, c->len)) {
             // found
             c->position_plus_1 = i + 1;
             break;
           }
         }
-        if(!c->position_plus_1)
+        if (!c->position_plus_1)
           asprintf(&data->err_msg, "Column '%s' not found\n", (char *)c->name);
       }
     }
-    if(!data->err_msg) {
+    if (!data->err_msg) {
       data->header_names = calloc(data->col_count, sizeof(*data->header_names));
-      if(!data->header_names)
+      if (!data->header_names)
         asprintf(&data->err_msg, "Out of memory!");
     }
 
-    for(unsigned i = 1; i < data->col_count && !data->err_msg; i++) {
-      struct zsv_cell cell  = zsv_get_cell(data->parser, i);
+    for (unsigned i = 1; i < data->col_count && !data->err_msg; i++) {
+      struct zsv_cell cell = zsv_get_cell(data->parser, i);
       // save the column header name
-      if(data->use_column_position)
+      if (data->use_column_position)
         asprintf((char **)&data->header_names[i].str, "%u", i);
       else {
         struct zsv_cell c = zsv_get_cell(data->parser, i);
-        if(i == 0 && c.len == 0)
+        if (i == 0 && c.len == 0)
           data->header_names[i].str = (unsigned char *)strdup("(Blank)");
         else
           data->header_names[i].str = zsv_writer_str_to_csv(cell.str, cell.len);
       }
 
-      if(data->header_names[i].str)
+      if (data->header_names[i].str)
         data->header_names[i].len = strlen((const char *)data->header_names[i].str);
-      else if(cell.len)
+      else if (cell.len)
         asprintf(&data->err_msg, "Out of memory!");
     }
 
-    if(!data->err_msg) {
+    if (!data->err_msg) {
       // print the output table header
-      serialize_write_tuple(data, idCell.str, idCell.len, idCell.quoted,
-                            (const unsigned char *)"Column", strlen("Column"),
-                            (const unsigned char *)"Value", strlen("Value"), 0);
+      serialize_write_tuple(data, idCell.str, idCell.len, idCell.quoted, (const unsigned char *)"Column",
+                            strlen("Column"), (const unsigned char *)"Value", strlen("Value"), 0);
 
-      if(data->use_column_position) {
+      if (data->use_column_position) {
         // process the header row as if it was a data row
         // output ID cell
         struct zsv_cell cell = zsv_get_cell(data->parser, data->id_column_position);
-        serialize_write_tuple(data, (const unsigned char *)"Header", strlen("Header"), 0,
-                              (const unsigned char *)"0", 1,
+        serialize_write_tuple(data, (const unsigned char *)"Header", strlen("Header"), 0, (const unsigned char *)"0", 1,
                               cell.str, cell.len, cell.quoted);
 
         // output other cells
-        for(unsigned i = 0; i < data->col_count; i++) {
-          if(i != data->id_column_position) {
+        for (unsigned i = 0; i < data->col_count; i++) {
+          if (i != data->id_column_position) {
             cell = zsv_get_cell(data->parser, i);
-            serialize_write_tuple(data, (const unsigned char *)"Header", strlen("Header"), 0,
-                                  data->header_names[i].str, data->header_names[i].len,
-                                  cell.str, cell.len, cell.quoted);
+            serialize_write_tuple(data, (const unsigned char *)"Header", strlen("Header"), 0, data->header_names[i].str,
+                                  data->header_names[i].len, cell.str, cell.len, cell.quoted);
           }
         }
       }
@@ -202,41 +195,39 @@ static void serialize_header(void *hook) {
 
 static void serialize_row(void *hook) {
   struct serialize_data *data = hook;
-  if(data->err_msg)
+  if (data->err_msg)
     return;
 
   // get the row id
   struct zsv_cell id = zsv_get_cell(data->parser, data->id_column_position);
 
   unsigned j = zsv_cell_count(data->parser);
-  for(unsigned i = 0; i < j && i < data->col_count; i++)
-    if(i != data->id_column_position)
+  for (unsigned i = 0; i < j && i < data->col_count; i++)
+    if (i != data->id_column_position)
       serialize_cell(data, id, i);
 }
 
-const char *serialize_usage_msg[] =
-  {
-   APPNAME ": Serialize a CSV file into Row/Colname/Value triplets",
-   "",
-   "Usage: " APPNAME " [<filename>]",
-   "Serializes a CSV file",
-   "",
-   "Options:",
-   "  -b                     : output with BOM",
-   "  -f,--filter <value>    : only output cells with text that contains the given value",
-   "  -e,--entire            : match the entire cell's content (only applicable with -f)",
-   "  -i,--case-insensitive  : use case-insensitive match for the filter value",
-   "  --id-column <n>        : the 1-based position of the column to use as the identifer (default=1, max=2000)",
-   "  -p,--position          : output column position instead of name; the second column",
-   "                           will be position 1, and the first row will be treated as a",
-   "                           normal data row",
-   "  -a,--add <column name> : add additional columns to output. may be specified",
-   "                           multiple times for multiple additional columns",
-   NULL
-  };
+const char *serialize_usage_msg[] = {
+  APPNAME ": serialize a CSV file into row/column/value triplets",
+  "",
+  "Usage: " APPNAME " [<filename>]",
+  "",
+  "Options:",
+  "  -b                     : output with BOM",
+  "  -f,--filter <value>    : only output cells with text that contains the given value",
+  "  -e,--entire            : match the entire cell's content (only applicable with -f)",
+  "  -i,--case-insensitive  : use case-insensitive match for the filter value",
+  "  --id-column <n>        : the 1-based position of the column to use as the identifier (default=1, max=2000)",
+  "  -p,--position          : output column position instead of name; the second column",
+  "                           will be position 1, and the first row will be treated as a",
+  "                           normal data row",
+  "  -a,--add <column name> : add additional columns to output. may be specified",
+  "                           multiple times for multiple additional columns",
+  NULL,
+};
 
 static int serialize_usage() {
-  for(int i = 0; serialize_usage_msg[i]; i++)
+  for (size_t i = 0; serialize_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", serialize_usage_msg[i]);
   return 1;
 }
@@ -247,16 +238,16 @@ static void serialize_cleanup(struct serialize_data *data) {
   free(data->filter.value_lc);
   free(data->err_msg);
 
-  if(data->header_names) {
-    for(unsigned int i = 0; i < data->col_count; i++)
+  if (data->header_names) {
+    for (unsigned int i = 0; i < data->col_count; i++)
       free(data->header_names[i].str);
     free(data->header_names);
   }
 
-  if(data->in && data->in != stdin)
+  if (data->in && data->in != stdin)
     fclose(data->in);
 
-  for(struct serialize_additional_column *next, *c = data->additional_columns; c; c = next) {
+  for (struct serialize_additional_column *next, *c = data->additional_columns; c; c = next) {
     next = c->next;
     free(c->name);
     free(c);
@@ -265,10 +256,10 @@ static void serialize_cleanup(struct serialize_data *data) {
 
 static int serialize_append_additional_column(struct serialize_data *data, const char *name) {
   struct serialize_additional_column *c = calloc(1, sizeof(*c));
-  if(c) {
-    if((c->name = (unsigned char *)strdup(name))) {
+  if (c) {
+    if ((c->name = (unsigned char *)strdup(name))) {
       c->len = strlen((char *)c->name);
-      if(!data->additional_columns)
+      if (!data->additional_columns)
         data->additional_columns = c;
       else
         *data->additional_columns_next = c;
@@ -280,65 +271,63 @@ static int serialize_append_additional_column(struct serialize_data *data, const
   return 1;
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
     serialize_usage();
     return 0;
   } else {
     struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
-    struct serialize_data data = { 0 };
+    struct serialize_data data = {0};
     int err = 0;
-    for(int arg_i = 1; !err && arg_i < argc; arg_i++) {
+    for (int arg_i = 1; !err && arg_i < argc; arg_i++) {
       const char *arg = argv[arg_i];
-      if(!strcmp(arg, "-f") || !strcmp(arg, "--filter")) {
-        if(arg_i + 1 < argc)
+      if (!strcmp(arg, "-f") || !strcmp(arg, "--filter")) {
+        if (arg_i + 1 < argc)
           data.filter.value = argv[++arg_i];
         else {
           fprintf(stderr, "filter option requires a value\n");
           err = 1;
         }
-      } else if(!strcmp(arg, "-a") || !strcmp(arg, "--add")) {
-        if(arg_i + 1 < argc)
+      } else if (!strcmp(arg, "-a") || !strcmp(arg, "--add")) {
+        if (arg_i + 1 < argc)
           err = serialize_append_additional_column(&data, argv[++arg_i]);
         else {
           fprintf(stderr, "%s option requires a value\n", argv[arg_i]);
           err = 1;
         }
-      } else if(!strcmp(arg, "-i") || !strcmp(arg, "--case-insensitive"))
+      } else if (!strcmp(arg, "-i") || !strcmp(arg, "--case-insensitive"))
         data.filter.case_insensitive = 1;
-      else if(!strcmp(arg, "--id-column")) {
-        if(arg_i + 1 < argc && atoi(argv[arg_i+1]) > 0 && atoi(argv[arg_i+1]) <= 2000)
+      else if (!strcmp(arg, "--id-column")) {
+        if (arg_i + 1 < argc && atoi(argv[arg_i + 1]) > 0 && atoi(argv[arg_i + 1]) <= 2000)
           data.id_column_position = atoi(argv[++arg_i]) - 1;
         else {
           fprintf(stderr, "%s option requires a value between 1 and 2000\n", argv[arg_i]);
           err = 1;
         }
-      }
-      else if(!strcmp(arg, "-p") || !strcmp(arg, "--position"))
+      } else if (!strcmp(arg, "-p") || !strcmp(arg, "--position"))
         data.use_column_position = 1;
-      else if(!strcmp(arg, "-e") || !strcmp(arg, "--entire"))
+      else if (!strcmp(arg, "-e") || !strcmp(arg, "--entire"))
         data.filter.entire = 1;
-      else if(!strcmp(argv[arg_i], "-b"))
+      else if (!strcmp(argv[arg_i], "-b"))
         writer_opts.with_bom = 1;
-      else if(data.in) {
+      else if (data.in) {
         err = 1;
         fprintf(stderr, "Input file specified twice, or unrecognized argument: %s\n", argv[arg_i]);
-      } else if(!(data.in = fopen(argv[arg_i], "rb"))) {
+      } else if (!(data.in = fopen(argv[arg_i], "rb"))) {
         err = 1;
         fprintf(stderr, "Could not open for reading: %s\n", argv[arg_i]);
       } else
         data.input_path = argv[arg_i];
     }
 
-    if(data.filter.value) {
+    if (data.filter.value) {
       data.filter.len = strlen(data.filter.value);
-      if(data.filter.case_insensitive)
-        data.filter.value_lc =
-          zsv_strtolowercase((const unsigned char *)data.filter.value,
-                               &data.filter.len);
+      if (data.filter.case_insensitive)
+        data.filter.value_lc = zsv_strtolowercase((const unsigned char *)data.filter.value, &data.filter.len);
     }
 
-    if(!data.in) {
+    if (!data.in) {
 #ifdef NO_STDIN
       fprintf(stderr, "Please specify an input file\n");
       err = 1;
@@ -347,7 +336,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #endif
     }
 
-    if(err) {
+    if (err) {
       serialize_cleanup(&data);
       return 1;
     }
@@ -358,8 +347,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
     opts->ctx = &data;
     data.csv_writer = zsv_writer_new(&writer_opts);
-    if(zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &data.parser) != zsv_status_ok
-       || !data.csv_writer) {
+    if (zsv_new_with_properties(opts, custom_prop_handler, input_path, opts_used, &data.parser) != zsv_status_ok ||
+        !data.csv_writer) {
       serialize_cleanup(&data);
       return 1;
     }
@@ -370,11 +359,10 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
     // process the input data
     zsv_handle_ctrl_c_signal();
-    enum zsv_status status;
-    while(!zsv_signal_interrupted && (status = zsv_parse_more(data.parser)) == zsv_status_ok)
+    while (!zsv_signal_interrupted && zsv_parse_more(data.parser) == zsv_status_ok)
       ;
 
-    if(data.err_msg)
+    if (data.err_msg)
       fprintf(stderr, "Error: %s\n", data.err_msg);
     zsv_finish(data.parser);
     zsv_delete(data.parser);

--- a/app/sql.c
+++ b/app/sql.c
@@ -30,38 +30,37 @@ struct string_list {
 };
 #endif
 
-const char *zsv_sql_usage_msg[] =
-  {
-   APPNAME ": run ad hoc sql on a CSV file",
-   "          or join multiple CSV files on one or more common column(s)",
-   "",
+const char *zsv_sql_usage_msg[] = {
+  APPNAME ": run ad hoc sql on a CSV file",
+  "          or join multiple CSV files on one or more common column(s)",
+  "",
 #ifdef NO_STDIN
-   "Usage: " APPNAME " <filename> [filename ...] <sql | @file.sql>",
+  "Usage: " APPNAME " <filename> [filename ...] <sql | @file.sql>",
 #else
-   "Usage: " APPNAME " [filename, or - for stdin] [filename ...] <sql | @file.sql | --join-indexes <N,...>>",
+  "Usage: " APPNAME " [filename, or - for stdin] [filename ...] <sql | @file.sql | --join-indexes <N,...>>",
 #endif
-   "  e.g. " APPNAME " myfile.csv \"select * from data\"",
-   "  e.g. " APPNAME " myfile.csv myfile2.csv \"select * from data inner join data2\"",
-   "  e.g. " APPNAME " myfile.csv myfile2.csv --join-indexes 1,2",
-   "",
-   "Loads your CSV file into a table named 'data', then runs your sql, which must start with 'select '.",
-   "If multiple files are specified, tables will be named data, data2, data3, ...",
-   "",
-   "Options:",
-   "  --join-indexes <n1...>: specify one or more column names to join multiple files by",
-   "     each n is treated as an index in the first input file that determines a column",
-   "     of the join. For example, if joining two files that, respectively, have columns",
-   "     A,B,C,D and X,B,C,A,Y then `--join-indexes 1,3` will join on columns A and C.",
-   "     When using this option, do not include an sql statement",
-   "  -b: output with BOM",
-   "  -C, --max-cols <n>    : change the maximum allowable columns. must be > 0 and < 2000",
-   "  -o <output filename>  : name of file to save output to",
-   "  --memory              : use in-memory instead of temporary db (see https://www.sqlite.org/inmemorydb.html)",
-   NULL
+  "  e.g. " APPNAME " file.csv \"select * from data\"",
+  "  e.g. " APPNAME " file1.csv file2.csv \"select * from data inner join data2\"",
+  "  e.g. " APPNAME " file1.csv file2.csv --join-indexes 1,2",
+  "",
+  "Loads your CSV file into a table named 'data', then runs your sql, which must start with 'select '.",
+  "If multiple files are specified, tables will be named data, data2, data3, ...",
+  "",
+  "Options:",
+  "  --join-indexes <n1...>: specify one or more column names to join multiple files by",
+  "                          each n is treated as an index in the first input file that determines a column",
+  "                          of the join. For example, if joining two files that, respectively, have columns",
+  "                          A,B,C,D and X,B,C,A,Y then `--join-indexes 1,3` will join on columns A and C.",
+  "                          When using this option, do not include an sql statement",
+  "  -b                    : output with BOM",
+  "  -C,--max-cols <n>     : change the maximum allowable columns. must be > 0 and < 2000",
+  "  -o <filename>         : filename to save output to",
+  "  --memory              : use in-memory instead of temporary db (see https://www.sqlite.org/inmemorydb.html)",
+  NULL,
 };
 
 static int zsv_sql_usage(FILE *f) {
-  for(int i = 0; zsv_sql_usage_msg[i]; i++)
+  for (size_t i = 0; zsv_sql_usage_msg[i]; i++)
     fprintf(f, "%s\n", zsv_sql_usage_msg[i]);
   return f == stderr ? 1 : 0;
 }
@@ -69,11 +68,11 @@ static int zsv_sql_usage(FILE *f) {
 struct zsv_sql_data {
   FILE *in;
   struct string_list *more_input_filenames;
-  char *sql_dynamic; // will hold contents of sql file, if any
+  char *sql_dynamic;  // will hold contents of sql file, if any
   char *join_indexes; // will hold contents of join_indexes arg, prefixed and suffixed with a comma
   struct string_list *join_column_names;
-  unsigned char in_memory:1;
-  unsigned char _:7;
+  unsigned char in_memory : 1;
+  unsigned char _ : 7;
 };
 
 static void zsv_sql_finalize(struct zsv_sql_data *data) {
@@ -81,22 +80,22 @@ static void zsv_sql_finalize(struct zsv_sql_data *data) {
 }
 
 static void zsv_sql_cleanup(struct zsv_sql_data *data) {
-  if(data->in && data->in != stdin)
+  if (data->in && data->in != stdin)
     fclose(data->in);
   free(data->sql_dynamic);
   free(data->join_indexes);
-  if(data->join_column_names) {
+  if (data->join_column_names) {
     struct string_list *next;
-    for(struct string_list *tmp = data->join_column_names; tmp; tmp = next) {
+    for (struct string_list *tmp = data->join_column_names; tmp; tmp = next) {
       next = tmp->next;
       free(tmp->value);
       free(tmp);
     }
   }
 
-  if(data->more_input_filenames) {
+  if (data->more_input_filenames) {
     struct string_list *next;
-    for(struct string_list *tmp = data->more_input_filenames; tmp; tmp = next) {
+    for (struct string_list *tmp = data->more_input_filenames; tmp; tmp = next) {
       next = tmp->next;
       free(tmp);
     }
@@ -104,26 +103,26 @@ static void zsv_sql_cleanup(struct zsv_sql_data *data) {
   (void)data;
 }
 
-static int create_virtual_csv_table(const char *fname, sqlite3 *db,
-                                    const char *opts_used,
-                                    int max_columns, char **err_msg,
-                                    int table_ix) {
+static int create_virtual_csv_table(const char *fname, sqlite3 *db, const char *opts_used, int max_columns,
+                                    char **err_msg, int table_ix) {
   // TO DO: set customizable maximum number of columns to prevent
   // runaway in case no line ends found
   char *sql = NULL;
   char table_name_suffix[64];
 
-  if(table_ix == 0)
+  if (table_ix == 0)
     *table_name_suffix = '\0';
-  else if(table_ix < 0 || table_ix > 1000)
+  else if (table_ix < 0 || table_ix > 1000)
     return -1;
   else
     snprintf(table_name_suffix, sizeof(table_name_suffix), "%i", table_ix + 1);
 
-  if(max_columns)
-    sql = sqlite3_mprintf("CREATE VIRTUAL TABLE data%s USING csv(filename=%Q,options_used=%Q,max_columns=%i)", table_name_suffix, fname, opts_used, max_columns);
+  if (max_columns)
+    sql = sqlite3_mprintf("CREATE VIRTUAL TABLE data%s USING csv(filename=%Q,options_used=%Q,max_columns=%i)",
+                          table_name_suffix, fname, opts_used, max_columns);
   else
-    sql = sqlite3_mprintf("CREATE VIRTUAL TABLE data%s USING csv(filename=%Q,options_used=%Q)", table_name_suffix, fname, opts_used);
+    sql = sqlite3_mprintf("CREATE VIRTUAL TABLE data%s USING csv(filename=%Q,options_used=%Q)", table_name_suffix,
+                          fname, opts_used);
 
   int rc = sqlite3_exec(db, sql, NULL, NULL, err_msg);
   sqlite3_free(sql);
@@ -131,13 +130,12 @@ static int create_virtual_csv_table(const char *fname, sqlite3 *db,
 }
 
 static char is_select_sql(const char *s) {
-  return strlen(s) > strlen("select ")
-    && !zsv_strincmp((const unsigned char *)"select ", strlen("select "),
-                     (const unsigned char *)s, strlen("select ")
-                     );
+  return strlen(s) > strlen("select ") && !zsv_strincmp((const unsigned char *)"select ", strlen("select "),
+                                                        (const unsigned char *)s, strlen("select "));
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
   /**
    * We need to pass the following data to the sqlite3 virtual table code:
    * a. zsv parser options indicated in the cmd line
@@ -153,11 +151,11 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
    * module calls zsv_get_default_opts()
    */
   int err = 0;
-  if(argc < 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))
+  if (argc < 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))
     err = zsv_sql_usage(argc < 2 ? stderr : stdout);
   else {
-    struct zsv_sql_data data = { 0 };
-    int max_cols = 0; // to do: remove this; use parser_opts.max_columns
+    struct zsv_sql_data data = {0};
+    int max_cols = 0; // TO DO: remove this; use parser_opts.max_columns
     const char *input_filename = NULL;
     const char *my_sql = NULL;
     struct string_list **next_input_filename = &data.more_input_filenames;
@@ -168,102 +166,105 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
     // set parser opts that the sql module will get via zsv_get_default_opts()
     zsv_set_default_opts(*opts);
-    if(custom_prop_handler) zsv_set_default_custom_prop_handler(*custom_prop_handler);
+    if (custom_prop_handler)
+      zsv_set_default_custom_prop_handler(*custom_prop_handler);
 
     struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
     int err = 0;
-    for(int arg_i = 1; !err && arg_i < argc; arg_i++) {
+    for (int arg_i = 1; !err && arg_i < argc; arg_i++) {
       const char *arg = argv[arg_i];
-      if(!strcmp(arg, "--join-indexes")) {
-        if(data.join_indexes) {
+      if (!strcmp(arg, "--join-indexes")) {
+        if (data.join_indexes) {
           fprintf(stderr, "%s specified more than once\n", arg);
           err = 1;
-        } else if(!(++arg_i < argc)) {
+        } else if (!(++arg_i < argc)) {
           fprintf(stderr, "%s option requires a value\n", arg);
           err = 1;
         } else {
           arg = argv[arg_i];
           int have = 0;
-          for(const char *s = arg; *s; s++) {
-            if(*s == ',')
+          for (const char *s = arg; *s; s++) {
+            if (*s == ',')
               ;
-            else if((*s >= '0' && *s <= '9'))
+            else if ((*s >= '0' && *s <= '9'))
               have = 1;
             else
               err = 1;
           }
-          if(!have || err)
-            fprintf(stderr, "Invalid --join-indexes value (%s): must be a comma-separated"
-                    " list of indexes with no spaces or other characters\n", arg), err = 1;
+          if (!have || err)
+            fprintf(stderr,
+                    "Invalid --join-indexes value (%s): must be a comma-separated"
+                    " list of indexes with no spaces or other characters\n",
+                    arg),
+              err = 1;
           else {
             asprintf(&data.join_indexes, ",%s,", arg);
-            if(data.join_indexes && strstr(data.join_indexes, ",0,"))
+            if (data.join_indexes && strstr(data.join_indexes, ",0,"))
               fprintf(stderr, "--join-indexes index values must be greater than zero\n"), err = 1;
           }
         }
-      } else if(!my_sql
-                && ((*arg == '@' && arg[1]) || is_select_sql(arg))) {
-        if(is_select_sql(arg))
+      } else if (!my_sql && ((*arg == '@' && arg[1]) || is_select_sql(arg))) {
+        if (is_select_sql(arg))
           my_sql = arg;
         else {
           struct stat st;
-          if(stat(arg+1, &st) == 0 && st.st_size > 0) {
-            FILE *f = fopen(arg+1, "rb");
-            if(f) {
+          if (stat(arg + 1, &st) == 0 && st.st_size > 0) {
+            FILE *f = fopen(arg + 1, "rb");
+            if (f) {
               data.sql_dynamic = malloc(st.st_size + 1);
-              if(data.sql_dynamic) {
+              if (data.sql_dynamic) {
                 fread(data.sql_dynamic, 1, st.st_size, f);
                 data.sql_dynamic[st.st_size] = '\0';
-                if(is_select_sql(data.sql_dynamic))
+                if (is_select_sql(data.sql_dynamic))
                   my_sql = (const char *)data.sql_dynamic;
                 else {
-                  fprintf(stderr, "File %s contents must be a sql SELECT statement\n", arg+1);
+                  fprintf(stderr, "File %s contents must be a sql SELECT statement\n", arg + 1);
                   err = 1;
                 }
               }
               fclose(f);
             }
           }
-          if(!data.sql_dynamic && !err) {
-            fprintf(stderr, "File %s empty or not readable\n", arg+1);
+          if (!data.sql_dynamic && !err) {
+            fprintf(stderr, "File %s empty or not readable\n", arg + 1);
             err = 1;
           }
         }
-      } else if(!strcmp(arg, "-o") || !strcmp(arg, "--output")) {
-        if(!(++arg_i < argc)) {
+      } else if (!strcmp(arg, "-o") || !strcmp(arg, "--output")) {
+        if (!(++arg_i < argc)) {
           fprintf(stderr, "option %s requires a filename\n", arg);
           err = 1;
-        } else if(!(writer_opts.stream = fopen(argv[arg_i], "wb"))) {
+        } else if (!(writer_opts.stream = fopen(argv[arg_i], "wb"))) {
           fprintf(stderr, "Could not open for writing: %s\n", argv[arg_i]);
           err = 1;
         }
-      } else if(!strcmp(arg, "--memory"))
+      } else if (!strcmp(arg, "--memory"))
         data.in_memory = 1;
-      else if(!strcmp(arg, "-b"))
+      else if (!strcmp(arg, "-b"))
         writer_opts.with_bom = 1;
-      else if(!strcmp(arg, "-C") || !strcmp(arg, "--max-cols")) {
-        if(arg_i+1 < argc && atoi(argv[arg_i+1]) > 0 && atoi(argv[arg_i+1]) <= 2000)
+      else if (!strcmp(arg, "-C") || !strcmp(arg, "--max-cols")) {
+        if (arg_i + 1 < argc && atoi(argv[arg_i + 1]) > 0 && atoi(argv[arg_i + 1]) <= 2000)
           max_cols = atoi(argv[++arg_i]);
         else {
           fprintf(stderr, "maximum columns value not provided or not between 0 and 2000\n");
           err = 1;
         }
-      } else if(*arg != '-') {
-        if(!input_filename) {
+      } else if (*arg != '-') {
+        if (!input_filename) {
           input_filename = arg;
-          if(!(data.in = fopen(arg, "rb"))) {
+          if (!(data.in = fopen(arg, "rb"))) {
             fprintf(stderr, "Unable to open for reading: %s\n", arg);
             err = 1;
           }
         } else { // another input file
           FILE *tmp_f;
-          if(!(tmp_f = fopen(arg, "rb"))) {
+          if (!(tmp_f = fopen(arg, "rb"))) {
             fprintf(stderr, "Unable to open %s for reading\n", arg);
             err = 1;
           } else {
             fclose(tmp_f);
             struct string_list *tmp = calloc(1, sizeof(**next_input_filename));
-            if(!tmp)
+            if (!tmp)
               fprintf(stderr, "Out of memory!\n");
             else {
               tmp->value = (char *)arg;
@@ -278,7 +279,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       }
     }
 
-    if(!data.in || !input_filename) {
+    if (!data.in || !input_filename) {
 #ifdef NO_STDIN
       fprintf(stderr, "Please specify an input file\n");
       err = 1;
@@ -287,53 +288,53 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #endif
     }
 
-    if(!my_sql && !data.join_indexes) {
+    if (!my_sql && !data.join_indexes) {
       fprintf(stderr, "No sql command specified\n");
       err = 1;
     }
 
-    if(err) {
+    if (err) {
       zsv_sql_cleanup(&data);
-      if(custom_prop_handler) {
+      if (custom_prop_handler) {
         zsv_set_default_opts(original_default_opts); // restore default options
         zsv_set_default_custom_prop_handler(original_default_custom_prop_handler);
       }
       return 1;
     }
 
-    if(data.in != stdin) {
+    if (data.in != stdin) {
       fclose(data.in);
       data.in = NULL;
     }
 
     FILE *f = NULL;
     char *tmpfn = NULL;
-    if(input_filename) {
+    if (input_filename) {
       f = fopen(input_filename, "rb");
-      if(!f)
+      if (!f)
         fprintf(stderr, "Unable to open %s for reading\n", input_filename);
     } else
       f = stdin;
 
-    if(f == stdin) {
+    if (f == stdin) {
       tmpfn = zsv_get_temp_filename("zsv_sql_XXXXXXXX");
-      if(!tmpfn) {
+      if (!tmpfn) {
         fprintf(stderr, "Unable to create temp file name\n");
       } else {
         FILE *tmpf = fopen(tmpfn, "wb");
-        if(!tmpf)
+        if (!tmpf)
           fprintf(stderr, "Unable to open temp file %s\n", tmpfn);
         else {
           char rbuff[1024];
           size_t bytes_read;
-          while((bytes_read = fread(rbuff, 1, sizeof(rbuff), stdin)))
+          while ((bytes_read = fread(rbuff, 1, sizeof(rbuff), stdin)))
             fwrite(rbuff, 1, bytes_read, tmpf);
           f = tmpf;
         }
       }
     }
 
-    if(f) {
+    if (f) {
       fclose(f); // to do: don't open in the first place
       f = NULL;
 
@@ -346,60 +347,61 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
       char *err_msg = NULL;
       const char *db_url = data.in_memory ? "file::memory:" : "";
-      if((rc = sqlite3_open_v2(db_url, &db, SQLITE_OPEN_URI | SQLITE_OPEN_READWRITE, NULL)) == SQLITE_OK
-         && db
-         && (rc = sqlite3_create_module(db, "csv", &CsvModule, 0) == SQLITE_OK)
-         && (rc = create_virtual_csv_table(tmpfn ? tmpfn : input_filename, db, opts_used, max_cols, &err_msg, 0)) == SQLITE_OK
-         ) {
+      if ((rc = sqlite3_open_v2(db_url, &db, SQLITE_OPEN_URI | SQLITE_OPEN_READWRITE, NULL)) == SQLITE_OK && db &&
+          (rc = sqlite3_create_module(db, "csv", &CsvModule, 0) == SQLITE_OK) &&
+          (rc = create_virtual_csv_table(tmpfn ? tmpfn : input_filename, db, opts_used, max_cols, &err_msg, 0)) ==
+            SQLITE_OK) {
         int i = 1;
-        for(struct string_list *sl = data.more_input_filenames; sl; sl = sl->next)
-          if(create_virtual_csv_table(sl->value, db, opts_used, max_cols, &err_msg, i++) != SQLITE_OK)
+        for (struct string_list *sl = data.more_input_filenames; sl; sl = sl->next)
+          if (create_virtual_csv_table(sl->value, db, opts_used, max_cols, &err_msg, i++) != SQLITE_OK)
             rc = SQLITE_ERROR;
       }
 
-      if(data.join_indexes) { // get column names, and construct the sql
+      if (data.join_indexes) { // get column names, and construct the sql
         // sql template:
-        // select t1.*, t2.*, t3.* from t1 left join (select * from t2 group by a) t2 left join (select * from t3 group by a) t3 using(a);
+        // select t1.*, t2.*, t3.* from t1 left join (select * from t2 group by a) t2 left join (select * from t3 group
+        // by a) t3 using(a);
         sqlite3_stmt *stmt = NULL;
         const char *prefix_search = NULL;
         const char *prefix_end = NULL;
-        if(my_sql) {
+        if (my_sql) {
           prefix_search = " from data ";
           prefix_end = strstr(my_sql, prefix_search);
-          if(!prefix_end) {
+          if (!prefix_end) {
             prefix_search = " from data";
             prefix_end = strstr(my_sql, prefix_search);
-            if(prefix_end && (prefix_end + strlen(prefix_search) != my_sql + strlen(my_sql)))
+            if (prefix_end && (prefix_end + strlen(prefix_search) != my_sql + strlen(my_sql)))
               prefix_end = NULL;
           }
-          if(!prefix_end || !prefix_search) {
+          if (!prefix_end || !prefix_search) {
             err = 1;
             fprintf(stderr, "Invalid sql: must contain 'from data'");
           }
         }
 
-        if(!err) {
+        if (!err) {
           rc = sqlite3_prepare_v2(db, "select * from data", -1, &stmt, NULL);
-          if(rc != SQLITE_OK) {
+          if (rc != SQLITE_OK) {
             fprintf(stderr, "%s:\n  %s\n (or bad CSV/utf8 input)\n\n", sqlite3_errstr(err), "select * from data");
             err = 1;
           }
         }
-        if(!err) {
+        if (!err) {
           struct string_list **next_joined_column_name = &data.join_column_names;
           int col_count = sqlite3_column_count(stmt);
-          for(char *ix_str = data.join_indexes; !err && ix_str && *ix_str && *(++ix_str); ix_str = strchr(ix_str + 1, ',')) {
+          for (char *ix_str = data.join_indexes; !err && ix_str && *ix_str && *(++ix_str);
+               ix_str = strchr(ix_str + 1, ',')) {
             unsigned int next_ix;
-            if(sscanf(ix_str, "%u,", &next_ix)) {
-              if(next_ix == 0)
+            if (sscanf(ix_str, "%u,", &next_ix)) {
+              if (next_ix == 0)
                 fprintf(stderr, "--join-indexes index must be greater than zero\n");
-              else if(next_ix > (unsigned)col_count)
+              else if (next_ix > (unsigned)col_count)
                 fprintf(stderr, "Column %u out of range; input has only %i columns\n", next_ix, col_count), err = 1;
-              else if(!sqlite3_column_name(stmt, next_ix - 1))
+              else if (!sqlite3_column_name(stmt, next_ix - 1))
                 fprintf(stderr, "Column %u unexpectedly missing name\n", next_ix);
               else {
                 struct string_list *tmp = calloc(1, sizeof(**next_joined_column_name));
-                if(!tmp)
+                if (!tmp)
                   fprintf(stderr, "Out of memory!\n"), err = 1;
                 else {
                   tmp->value = strdup(sqlite3_column_name(stmt, next_ix - 1));
@@ -410,9 +412,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
             }
           }
 
-          if(!data.more_input_filenames)
+          if (!data.more_input_filenames)
             fprintf(stderr, "--join-indexes requires more than one input\n"), err = 1;
-          else if(!err) { // now build the join select
+          else if (!err) { // now build the join select
             sqlite3_str *select_clause = sqlite3_str_new(db);
             sqlite3_str *from_clause = sqlite3_str_new(db);
             sqlite3_str *group_by_clause = sqlite3_str_new(db);
@@ -420,61 +422,58 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
             sqlite3_str_appendf(select_clause, "data.*");
             sqlite3_str_appendf(from_clause, "data");
 
-            for(struct string_list *sl = data.join_column_names; sl; sl = sl->next) {
-              if(sl != data.join_column_names)
+            for (struct string_list *sl = data.join_column_names; sl; sl = sl->next) {
+              if (sl != data.join_column_names)
                 sqlite3_str_appendf(group_by_clause, ",");
               sqlite3_str_appendf(group_by_clause, "\"%w\"", sl->value);
             }
 
             int i = 2;
-            for(struct string_list *sl = data.more_input_filenames; sl; sl = sl->next, i++) {
+            for (struct string_list *sl = data.more_input_filenames; sl; sl = sl->next, i++) {
               sqlite3_str_appendf(select_clause, ", data%i.*", i);
               // left join (select * from t2 group by a) t2 using(x,...)
               sqlite3_str_appendf(from_clause, " left join (select * from data%i group by %s) data%i", i,
                                   sqlite3_str_value(group_by_clause), i);
-              sqlite3_str_appendf(from_clause, " using (%s)",
-                                  sqlite3_str_value(group_by_clause));
+              sqlite3_str_appendf(from_clause, " using (%s)", sqlite3_str_value(group_by_clause));
             }
 
-            if(!prefix_end || !prefix_search)
-              asprintf(&data.sql_dynamic, "select %s from %s",
-                       sqlite3_str_value(select_clause), sqlite3_str_value(from_clause));
+            if (!prefix_end || !prefix_search)
+              asprintf(&data.sql_dynamic, "select %s from %s", sqlite3_str_value(select_clause),
+                       sqlite3_str_value(from_clause));
             else {
               asprintf(&data.sql_dynamic, "%.*s from %s%s%s", (int)(prefix_end - my_sql), my_sql,
-                       sqlite3_str_value(from_clause),
-                       strlen(prefix_end + strlen(prefix_search)) ? " " : "",
-                       strlen(prefix_end + strlen(prefix_search)) ?
-                       prefix_end + strlen(prefix_search) : "");
+                       sqlite3_str_value(from_clause), strlen(prefix_end + strlen(prefix_search)) ? " " : "",
+                       strlen(prefix_end + strlen(prefix_search)) ? prefix_end + strlen(prefix_search) : "");
             }
 
             my_sql = data.sql_dynamic;
-            if(opts->verbose)
+            if (opts->verbose)
               fprintf(stderr, "Join sql:\n%s\n", my_sql);
             sqlite3_free(sqlite3_str_finish(select_clause));
             sqlite3_free(sqlite3_str_finish(from_clause));
             sqlite3_free(sqlite3_str_finish(group_by_clause));
           }
         }
-        if(stmt)
+        if (stmt)
           sqlite3_finalize(stmt);
       }
 
-      if(rc == SQLITE_OK && !err && my_sql) {
+      if (rc == SQLITE_OK && !err && my_sql) {
         sqlite3_stmt *stmt;
         err = sqlite3_prepare_v2(db, my_sql, -1, &stmt, NULL);
-        if(err != SQLITE_OK)
+        if (err != SQLITE_OK)
           fprintf(stderr, "%s:\n  %s\n (or bad CSV/utf8 input)\n\n", sqlite3_errstr(err), my_sql);
         else {
           int col_count = sqlite3_column_count(stmt);
 
           // write header row
-          for(int i = 0; i < col_count; i++) {
+          for (int i = 0; i < col_count; i++) {
             const char *colname = sqlite3_column_name(stmt, i);
             zsv_writer_cell(cw, !i, (const unsigned char *)colname, colname ? strlen(colname) : 0, 1);
           }
 
-          while(sqlite3_step(stmt) == SQLITE_ROW) {
-            for(int i = 0; i < col_count; i++) {
+          while (sqlite3_step(stmt) == SQLITE_ROW) {
+            for (int i = 0; i < col_count; i++) {
               const unsigned char *text = sqlite3_column_text(stmt, i);
               int len = text ? sqlite3_column_bytes(stmt, i) : 0;
               zsv_writer_cell(cw, !i, text, len, 1);
@@ -484,32 +483,33 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         }
       }
       err = 1;
-      if(err_msg) {
+      if (err_msg) {
         fprintf(stderr, "Error: %s\n", err_msg);
         sqlite3_free(err_msg);
-      } else if(!db)
+      } else if (!db)
         fprintf(stderr, "Error (unable to open db, code %i): %s\n", rc, sqlite3_errstr(rc));
-      else if(rc)
+      else if (rc)
         fprintf(stderr, "Error (code %i): %s\n", rc, sqlite3_errstr(rc));
       else
         err = 0;
 
-      if(db)
+      if (db)
         sqlite3_close(db);
 
       zsv_writer_delete(cw);
     }
-    if(f)
+    if (f)
       fclose(f);
     zsv_sql_finalize(&data);
     zsv_sql_cleanup(&data);
 
-    if(tmpfn) {
+    if (tmpfn) {
       unlink(tmpfn);
       free(tmpfn);
     }
     zsv_set_default_opts(original_default_opts); // restore default options
-    if(custom_prop_handler) zsv_set_default_custom_prop_handler(original_default_custom_prop_handler);
+    if (custom_prop_handler)
+      zsv_set_default_custom_prop_handler(original_default_custom_prop_handler);
   }
   return err;
 }

--- a/app/stack.c
+++ b/app/stack.c
@@ -17,22 +17,21 @@
 #include <zsv/utils/mem.h>
 #include <zsv/utils/string.h>
 
-const char *zsv_stack_usage_msg[] =
-  {
-   APPNAME ": stack one or more csv files vertically, aligning columns with the same name",
-   "",
-   "Usage: " APPNAME " [options] filename [filename...]",
-   "",
-   "Options:",
-   "  -o <filename>: output file",
-   "  -b: output with BOM",
-   "  -q: always add double-quotes",
-   "  -T: input is tab-delimited, instead of comma-delimited",
-   NULL
-  };
+const char *zsv_stack_usage_msg[] = {
+  APPNAME ": stack one or more csv files vertically, aligning columns with the same name",
+  "",
+  "Usage: " APPNAME " [options] filename [filename...]",
+  "",
+  "Options:",
+  "  -o <filename>: output file",
+  "  -b           : output with BOM",
+  "  -q           : always add double-quotes",
+  "  -T           : input is tab-delimited, instead of comma-delimited",
+  NULL,
+};
 
 static int zsv_stack_usage() {
-  for(int i = 0; zsv_stack_usage_msg[i]; i++)
+  for (size_t i = 0; zsv_stack_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_stack_usage_msg[i]);
   return 0;
 }
@@ -48,20 +47,20 @@ typedef struct zsv_stack_colname {
   unsigned int raw_col_ix_plus_1;
 } zsv_stack_colname;
 
-static struct zsv_stack_colname *zsv_stack_colname_init(struct zsv_stack_colname *e,
-                                                            const unsigned char *name, size_t len) {
+static struct zsv_stack_colname *zsv_stack_colname_init(struct zsv_stack_colname *e, const unsigned char *name,
+                                                        size_t len) {
   memset(e, 0, sizeof(*e));
-  if(len)
+  if (len)
     e->name = zsv_strtolowercase(name, &len);
   else
-    e->name = calloc(1,2);
+    e->name = calloc(1, 2);
   return e;
 }
 
 static void zsv_stack_colname_free(struct zsv_stack_colname *e) {
-  if(e->name)
+  if (e->name)
     free(e->name);
-  if(e->orig_name)
+  if (e->orig_name)
     free(e->orig_name);
 }
 
@@ -78,10 +77,10 @@ SGLIB_DEFINE_RBTREE_PROTOTYPES(zsv_stack_colname, left, right, color, zsv_stack_
 SGLIB_DEFINE_RBTREE_FUNCTIONS(zsv_stack_colname, left, right, color, zsv_stack_colname_cmp);
 
 static void zsv_stack_colname_tree_delete(zsv_stack_colname **tree) {
-  if(tree && *tree) {
+  if (tree && *tree) {
     struct sglib_zsv_stack_colname_iterator it;
     struct zsv_stack_colname *e;
-    for(e=sglib_zsv_stack_colname_it_init(&it,*tree); e; e=sglib_zsv_stack_colname_it_next(&it))
+    for (e = sglib_zsv_stack_colname_it_init(&it, *tree); e; e = sglib_zsv_stack_colname_it_next(&it))
       zsv_stack_colname_delete(e);
     *tree = NULL;
   }
@@ -99,8 +98,8 @@ struct zsv_stack_input_file {
   size_t output_column_map_size;
   size_t header_row_end_offset; // location in buff at which the data row begins
   struct zsv_stack_data *ctx;
-  unsigned char headers_done:1;
-  unsigned char _:7;
+  unsigned char headers_done : 1;
+  unsigned char _ : 7;
 };
 
 struct zsv_stack_data {
@@ -118,13 +117,11 @@ struct zsv_stack_data {
   zsv_csv_writer csv_writer;
 };
 
-static struct zsv_stack_input_file **
-zsv_stack_input_file_add(const char *filename,
-                           struct zsv_stack_input_file **target,
-                           unsigned *count, FILE *f,
-                           struct zsv_stack_data *ctx) {
+static struct zsv_stack_input_file **zsv_stack_input_file_add(const char *filename,
+                                                              struct zsv_stack_input_file **target, unsigned *count,
+                                                              FILE *f, struct zsv_stack_data *ctx) {
   struct zsv_stack_input_file *e = calloc(1, sizeof(*e));
-  if(e) {
+  if (e) {
     e->f = f;
     e->fname = filename;
     e->ctx = ctx;
@@ -136,11 +133,11 @@ zsv_stack_input_file_add(const char *filename,
 }
 
 static void zsv_stack_input_files_delete(struct zsv_stack_input_file *list) {
-  for(struct zsv_stack_input_file *next, *e = list; e; e = next) {
+  for (struct zsv_stack_input_file *next, *e = list; e; e = next) {
     next = e->next;
-    if(e->f)
+    if (e->f)
       fclose(e->f);
-    if(e->output_column_map)
+    if (e->output_column_map)
       free(e->output_column_map);
     zsv_delete(e->parser);
     free(e);
@@ -153,22 +150,19 @@ static void zsv_stack_cleanup(struct zsv_stack_data *data) {
   zsv_writer_delete(data->csv_writer);
 }
 
-static struct zsv_stack_colname *
-zsv_stack_colname_get_or_add(const unsigned char *name,
-                               size_t name_len,
-                               struct zsv_stack_colname **tree,
-                               int *added) {
+static struct zsv_stack_colname *zsv_stack_colname_get_or_add(const unsigned char *name, size_t name_len,
+                                                              struct zsv_stack_colname **tree, int *added) {
   struct zsv_stack_colname e;
   zsv_stack_colname_init(&e, name, name_len);
   struct zsv_stack_colname *found = sglib_zsv_stack_colname_find_member(*tree, &e);
-  if(found)
+  if (found)
     zsv_stack_colname_free(&e);
   else {
     found = calloc(1, sizeof(*found));
-    if(found) {
+    if (found) {
       *added = 1;
       *found = e;
-      if(name)
+      if (name)
         found->orig_name = name ? zsv_memdup(name, name_len) : calloc(1, 2);
       sglib_zsv_stack_colname_add(tree, found);
     }
@@ -177,20 +171,15 @@ zsv_stack_colname_get_or_add(const unsigned char *name,
 }
 
 // zsv_stack_consolidate_header(): return global position
-static unsigned zsv_stack_consolidate_header(struct zsv_stack_data *d,
-                                               const unsigned char *name,
-                                               size_t name_len) {
+static unsigned zsv_stack_consolidate_header(struct zsv_stack_data *d, const unsigned char *name, size_t name_len) {
   int added = 0;
-  zsv_stack_colname *c =
-    zsv_stack_colname_get_or_add(name, name_len,
-                                   &d->colnames,
-                                   &added);
-  if(!c)
+  zsv_stack_colname *c = zsv_stack_colname_get_or_add(name, name_len, &d->colnames, &added);
+  if (!c)
     d->err = 1;
   else {
-    if(added) {
+    if (added) {
       c->global_position = ++d->colnames_count;
-      if(d->last_colname)
+      if (d->last_colname)
         d->last_colname->next = c;
       else
         d->first_colname = c;
@@ -211,8 +200,7 @@ static void zsv_stack_header_cell_wrapper(void *ctx, unsigned char *restrict utf
 
 static void zsv_stack_header_row(void *ctx) {
   struct zsv_stack_input_file *input = ctx;
-  if(!input->headers_done
-     && !zsv_row_is_blank(input->parser)) { // skip any blank leading rows
+  if (!input->headers_done && !zsv_row_is_blank(input->parser)) { // skip any blank leading rows
     input->headers_done = 1;
     zsv_abort(input->parser);
   }
@@ -220,16 +208,15 @@ static void zsv_stack_header_row(void *ctx) {
 
 static void zsv_stack_data_row(void *ctx) {
   struct zsv_stack_input_file *input = ctx;
-  if(!input->headers_done) {
+  if (!input->headers_done) {
     input->headers_done = 1;
     return;
   }
-  if(!zsv_row_is_blank(input->parser)) {
+  if (!zsv_row_is_blank(input->parser)) {
     size_t colnames_count = input->ctx->colnames_count;
-    for(unsigned i = 0; i < colnames_count; i++) {
+    for (unsigned i = 0; i < colnames_count; i++) {
       size_t raw_ix_plus_1;
-      if(i < input->output_column_map_size &&
-         ((raw_ix_plus_1 = input->output_column_map[i]))) {
+      if (i < input->output_column_map_size && ((raw_ix_plus_1 = input->output_column_map[i]))) {
         struct zsv_cell cell = zsv_get_cell(input->parser, raw_ix_plus_1 - 1);
         zsv_writer_cell(input->ctx->csv_writer, !i, cell.str, cell.len, cell.quoted);
       } else
@@ -238,34 +225,35 @@ static void zsv_stack_data_row(void *ctx) {
   }
 }
 
-int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
+int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
+                               struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
   int err = 0;
-  if(argc < 2) {
+  if (argc < 2) {
     zsv_stack_usage();
     return 1;
   }
 
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
     return zsv_stack_usage();
 
   struct zsv_opts saved_opts = *opts;
-  struct zsv_stack_data data = { 0 };
+  struct zsv_stack_data data = {0};
   char delimiter = 0; // defaults to csv
   struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
   writer_opts.stream = stdout;
 
-  for(int arg_i = 1; !data.err && arg_i < argc; arg_i++) {
+  for (int arg_i = 1; !data.err && arg_i < argc; arg_i++) {
     const char *arg = argv[arg_i];
-    if(!strcmp(arg, "-b"))
+    if (!strcmp(arg, "-b"))
       writer_opts.with_bom = 1;
-    else if(!strcmp(arg, "-T"))
+    else if (!strcmp(arg, "-T"))
       delimiter = '\t';
-    else if(!strcmp(arg, "-o")) {
+    else if (!strcmp(arg, "-o")) {
       arg_i++;
-      if(arg_i >= argc)
+      if (arg_i >= argc)
         fprintf(stderr, "-o option: no filename specified\n");
       else {
-        if(!(writer_opts.stream = fopen(argv[arg_i], "wb"))){
+        if (!(writer_opts.stream = fopen(argv[arg_i], "wb"))) {
           data.err = 1;
           fprintf(stderr, "Unable to open file for writing: %s\n", argv[arg_i]);
         }
@@ -273,21 +261,21 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     }
   }
 
-  if(!(data.csv_writer = zsv_writer_new(&writer_opts)))
+  if (!(data.csv_writer = zsv_writer_new(&writer_opts)))
     data.err = 1;
 
-  if(!data.err) {
+  if (!data.err) {
     struct zsv_stack_input_file **next_input = &data.inputs;
-    for(int arg_i = 1; !data.err && arg_i < argc; arg_i++) {
+    for (int arg_i = 1; !data.err && arg_i < argc; arg_i++) {
       const char *arg = argv[arg_i];
-      if(*arg == '-') {
-        if(!strcmp(arg, "-o"))
+      if (*arg == '-') {
+        if (!strcmp(arg, "-o"))
           arg_i++;
         continue;
       }
 
       FILE *f = fopen(arg, "rb");
-      if(!f) {
+      if (!f) {
         fprintf(stderr, "Could not open file for reading: %s\n", arg);
         data.err = 1;
       } else
@@ -297,7 +285,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
   // collect all header names so we can line them up
   unsigned i = 0;
-  for(struct zsv_stack_input_file *input = data.inputs; !data.err && input; input = input->next, i++) {
+  for (struct zsv_stack_input_file *input = data.inputs; !data.err && input; input = input->next, i++) {
     *opts = saved_opts;
     opts->row_handler = zsv_stack_header_row;
     opts->ctx = input;
@@ -305,15 +293,12 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
     // to do: max_cell_size
     opts->stream = input->f;
-    if(zsv_new_with_properties(opts, custom_prop_handler, input->fname, opts_used, &input->parser)
-       != zsv_status_ok)
+    if (zsv_new_with_properties(opts, custom_prop_handler, input->fname, opts_used, &input->parser) != zsv_status_ok)
       data.err = 1;
     else {
       zsv_handle_ctrl_c_signal();
       enum zsv_status status;
-      while(!data.err
-            && !input->headers_done
-            && (status = zsv_parse_more(input->parser)) == zsv_status_ok)
+      while (!data.err && !input->headers_done && (status = zsv_parse_more(input->parser)) == zsv_status_ok)
         ;
     }
   }
@@ -325,23 +310,22 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   // first, get maximum size of consolidated cols, which is just the sum of the column count
   // of all inputs
   size_t max_columns_count = 0;
-  for(struct zsv_stack_input_file *input = data.inputs; !data.err && input; input = input->next)
+  for (struct zsv_stack_input_file *input = data.inputs; !data.err && input; input = input->next)
     max_columns_count += zsv_cell_count(input->parser); // zsv_row_cells_count(input->row);
 
   // next, for each input, align the input columns with the output columns
-  for(struct zsv_stack_input_file *input = data.inputs; input && !data.err; input = input->next) {
-    if(max_columns_count) {
-      if(!(input->output_column_map = calloc(max_columns_count,
-                                             sizeof(*input->output_column_map))))
+  for (struct zsv_stack_input_file *input = data.inputs; input && !data.err; input = input->next) {
+    if (max_columns_count) {
+      if (!(input->output_column_map = calloc(max_columns_count, sizeof(*input->output_column_map))))
         data.err = 1;
       else {
         input->output_column_map_size = max_columns_count;
         // assign column indexes to global columns
         size_t cols_used = zsv_cell_count(input->parser);
-        for(unsigned col_ix = 0; col_ix < cols_used; col_ix++) {
+        for (unsigned col_ix = 0; col_ix < cols_used; col_ix++) {
           struct zsv_cell cell = zsv_get_cell(input->parser, col_ix);
           size_t output_ix = zsv_stack_consolidate_header(&data, cell.str, cell.len);
-          if(output_ix)
+          if (output_ix)
             input->output_column_map[output_ix - 1] = col_ix + 1;
         }
       }
@@ -351,44 +335,42 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   }
 
   // not necessary, but free up unused memory by resizing each input's output_column_map
-  for(struct zsv_stack_input_file *input = data.inputs; input && !data.err; input = input->next) {
-    if(!data.colnames_count) {
-      if(input->output_column_map) {
+  for (struct zsv_stack_input_file *input = data.inputs; input && !data.err; input = input->next) {
+    if (!data.colnames_count) {
+      if (input->output_column_map) {
         free(input->output_column_map);
         input->output_column_map = NULL;
       }
     } else {
       size_t *resized = realloc(input->output_column_map, data.colnames_count * sizeof(*resized));
-      if(resized)
+      if (resized)
         input->output_column_map = resized;
     }
   }
 
   // print headers
-  for(struct zsv_stack_colname *e = data.first_colname; !data.err && e; e = e->next) {
+  for (struct zsv_stack_colname *e = data.first_colname; !data.err && e; e = e->next) {
     const unsigned char *name = e->orig_name ? e->orig_name : e->name ? e->name : (const unsigned char *)"";
     zsv_writer_cell(data.csv_writer, e == data.first_colname, name, strlen((const char *)name), 1);
   }
 
   // process data
-  for(struct zsv_stack_input_file *input = data.inputs; input && !data.err; input = input->next, i++) {
-    if(input->headers_done) {
+  for (struct zsv_stack_input_file *input = data.inputs; input && !data.err; input = input->next, i++) {
+    if (input->headers_done) {
       *opts = saved_opts;
       opts->row_handler = zsv_stack_data_row;
       opts->ctx = input;
-      if(delimiter == '\t')
+      if (delimiter == '\t')
         opts->delimiter = delimiter;
 
       rewind(input->f);
       input->headers_done = 0;
       opts->stream = input->f;
-      if(zsv_new_with_properties(opts, custom_prop_handler, input->fname, opts_used, &input->parser)
-         != zsv_status_ok)
+      if (zsv_new_with_properties(opts, custom_prop_handler, input->fname, opts_used, &input->parser) != zsv_status_ok)
         data.err = 1;
       else {
         enum zsv_status status = zsv_status_ok;
-        while(status == zsv_status_ok && !data.err
-              && (status = zsv_parse_more(input->parser)) == zsv_status_ok)
+        while (status == zsv_status_ok && !data.err && (status = zsv_parse_more(input->parser)) == zsv_status_ok)
           ;
         zsv_finish(input->parser);
         zsv_delete(input->parser);
@@ -399,7 +381,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   err = data.err;
   zsv_stack_cleanup(&data);
 
-  if(writer_opts.stream && writer_opts.stream != stdout)
+  if (writer_opts.stream && writer_opts.stream != stdout)
     fclose(writer_opts.stream);
 
   return err;

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -168,9 +168,9 @@ test-cli: ${CLI}
 	@${TEST_INIT}
 	@[ "${CLI}" = "" ] && echo 1>&2 'test-cli: missing CLI env var' && exit 1 || exit 0
 	@$< help select 2>&1 > ${TMP_DIR}/$@.out
-	@[ "`head -1 ${TMP_DIR}/$@.out`" = "select: streaming CSV parser" ] && [ $$(( `cat ${TMP_DIR}/$@.out | wc -l` )) = "36" ] && ${TEST_PASS} || ${TEST_FAIL}
+	@[ "`head -1 ${TMP_DIR}/$@.out`" = "select: extracts and outputs specified columns" ] && [ $$(( `cat ${TMP_DIR}/$@.out | wc -l` )) = "38" ] && ${TEST_PASS} || ${TEST_FAIL}
 	@$< help count 2>&1 > ${TMP_DIR}/$@.out
-	@[ "`head -1 ${TMP_DIR}/$@.out`" = "Usage: count [options]" ] && [ $$(( `cat ${TMP_DIR}/$@.out | wc -l` )) = "5" ] && ${TEST_PASS} || ${TEST_FAIL}
+	@[ "`head -1 ${TMP_DIR}/$@.out`" = "Usage: count [options]" ] && [ $$(( `cat ${TMP_DIR}/$@.out | wc -l` )) = "6" ] && ${TEST_PASS} || ${TEST_FAIL}
 
 test-1-count test-1-count-pull: test-1-% : ${BUILD_DIR}/bin/zsv_%${EXE} worldcitiespop_mil.csv
 	@${TEST_INIT}

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -485,7 +485,7 @@ test-2json: test-%: ${BUILD_DIR}/bin/zsv_%${EXE} ${BUILD_DIR}/bin/zsv_2db${EXE} 
 
 test-2json-help: test-%-help: ${BUILD_DIR}/bin/zsv_%${EXE}
 	@${TEST_INIT}
-	@[ "`$< -h | wc -l`" -gt 17 ] && ${TEST_PASS} || ${TEST_FAIL} # check output nonempty
+	@[ "`$< -h | wc -l`" -gt 15 ] && ${TEST_PASS} || ${TEST_FAIL} # check output nonempty
 	@$< -h >/dev/null && ${TEST_PASS} || ${TEST_FAIL} # check exit code
 
 test-desc: test-%: ${BUILD_DIR}/bin/zsv_%${EXE}

--- a/app/utils/arg.c
+++ b/app/utils/arg.c
@@ -120,7 +120,7 @@ void zsv_set_default_completed_callback(zsv_completed_callback cb, void *ctx) {
  *     -q,--no-quote
  *     -R,--skip-head <n>: skip specified number of initial rows
  *     -d,--header-row-span <n> : apply header depth (rowspan) of n
- *     -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed UTF8
+ *     -u,--malformed-utf8-replacement <string>: replacement string (can be empty) in case of malformed UTF8
  * input (default for "desc" command is '?') -S,--keep-blank-headers  : disable default behavior of ignoring leading
  * blank rows -0,--header-row <header> : insert the provided CSV as the first row (in position 0) e.g. --header-row
  * 'col1,col2,\"my col 3\"'", -v,--verbose

--- a/app/utils/arg.c
+++ b/app/utils/arg.c
@@ -20,11 +20,11 @@
  * user customizations need multithreading support
  */
 #ifndef ZSVTLS
-# ifndef NO_THREADING
-#  define ZSVTLS _Thread_local
-# else
-#  define ZSVTLS
-# endif
+#ifndef NO_THREADING
+#define ZSVTLS _Thread_local
+#else
+#define ZSVTLS
+#endif
 #endif
 /*
  * global zsv_default_opts for convenience funcs zsv_get_default_opts() and zsv_set_default_opts()
@@ -37,20 +37,21 @@
  */
 static struct zsv_opts *zsv_with_default_opts(char mode) {
   ZSVTLS static char zsv_default_opts_initd = 0;
-  ZSVTLS static struct zsv_opts zsv_default_opts = { 0 };
+  ZSVTLS static struct zsv_opts zsv_default_opts = {0};
 
-  switch(mode) {
+  switch (mode) {
   case 'c': // clear
     memset(&zsv_default_opts, 0, sizeof(zsv_default_opts));
     zsv_default_opts_initd = 0;
     break;
   case 'g': // get
-    if(!zsv_default_opts_initd) {
+    if (!zsv_default_opts_initd) {
       zsv_default_opts_initd = 1;
       zsv_default_opts.max_row_size = ZSV_ROW_MAX_SIZE_DEFAULT;
       zsv_default_opts.max_columns = ZSV_MAX_COLS_DEFAULT;
     } else {
-      zsv_default_opts.max_row_size = zsv_default_opts.max_row_size ? zsv_default_opts.max_row_size : ZSV_ROW_MAX_SIZE_DEFAULT;
+      zsv_default_opts.max_row_size =
+        zsv_default_opts.max_row_size ? zsv_default_opts.max_row_size : ZSV_ROW_MAX_SIZE_DEFAULT;
       zsv_default_opts.max_columns = zsv_default_opts.max_columns ? zsv_default_opts.max_columns : ZSV_MAX_COLS_DEFAULT;
     }
     break;
@@ -73,20 +74,21 @@ void zsv_set_default_opts(struct zsv_opts opts) {
   *zsv_with_default_opts(0) = opts;
 }
 
-
 /**
  * str_array_index_of: return index in list, or size of list if not found
  */
 static inline int str_array_index_of(const char *list[], const char *s) {
   int i;
-  for(i = 0; list[i] && strcmp(list[i], s); i++) ;
+  for (i = 0; list[i] && strcmp(list[i], s); i++)
+    ;
   return i;
 }
 
 #ifdef ZSV_EXTRAS
 
 ZSV_EXPORT
-void zsv_set_default_progress_callback(zsv_progress_callback cb, void *ctx, size_t rows_interval, unsigned int seconds_interval) {
+void zsv_set_default_progress_callback(zsv_progress_callback cb, void *ctx, size_t rows_interval,
+                                       unsigned int seconds_interval) {
   struct zsv_opts opts = zsv_get_default_opts();
   opts.progress.callback = cb;
   opts.progress.ctx = ctx;
@@ -104,6 +106,7 @@ void zsv_set_default_completed_callback(zsv_completed_callback cb, void *ctx) {
 }
 
 #endif
+
 /**
  * Convert common command-line arguments to zsv_opts
  * Return new argc/argv values with processed args stripped out
@@ -117,12 +120,10 @@ void zsv_set_default_completed_callback(zsv_completed_callback cb, void *ctx) {
  *     -q,--no-quote
  *     -R,--skip-head <n>: skip specified number of initial rows
  *     -d,--header-row-span <n> : apply header depth (rowspan) of n
- *     -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed UTF8 input
- *       (default for "desc" commamnd is '?')
- *     -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows
- *     -0,--header-row <header> : insert the provided CSV as the first row (in position 0)
- *                                e.g. --header-row 'col1,col2,\"my col 3\"'",
- *     -v,--verbose
+ *     -u,--malformed-utf8-replacement <replacement_string>: replacement string (can be empty) in case of malformed UTF8
+ * input (default for "desc" command is '?') -S,--keep-blank-headers  : disable default behavior of ignoring leading
+ * blank rows -0,--header-row <header> : insert the provided CSV as the first row (in position 0) e.g. --header-row
+ * 'col1,col2,\"my col 3\"'", -v,--verbose
  *
  * @param  argc      count of args to process
  * @param  argv      args to process
@@ -138,11 +139,8 @@ void zsv_set_default_completed_callback(zsv_completed_callback cb, void *ctx) {
  * @return           zero on success, non-zero on error
  */
 ZSV_EXPORT
-enum zsv_status zsv_args_to_opts(int argc, const char *argv[],
-                                 int *argc_out, const char **argv_out,
-                                 struct zsv_opts *opts_out,
-                                 char *opts_used
-                                 ) {
+enum zsv_status zsv_args_to_opts(int argc, const char *argv[], int *argc_out, const char **argv_out,
+                                 struct zsv_opts *opts_out, char *opts_used) {
 #ifdef ZSV_EXTRAS
   static const char *short_args = "BcrtOqvRdSu0L";
 #else
@@ -150,7 +148,7 @@ enum zsv_status zsv_args_to_opts(int argc, const char *argv[],
 #endif
   assert(strlen(short_args) < ZSV_OPTS_SIZE_MAX);
 
-  static const char *long_args[] = { //
+  static const char *long_args[] = {
     "buff-size",
     "max-column-count",
     "max-row-size",
@@ -166,30 +164,30 @@ enum zsv_status zsv_args_to_opts(int argc, const char *argv[],
 #ifdef ZSV_EXTRAS
     "limit-rows",
 #endif
-    NULL
+    NULL,
   };
 
   *opts_out = zsv_get_default_opts();
   int options_start = 1; // skip this many args before we start looking for options
   int err = 0;
   int new_argc = 0;
-  for(; new_argc < options_start && new_argc < argc; new_argc++)
+  for (; new_argc < options_start && new_argc < argc; new_argc++)
     argv_out[new_argc] = argv[new_argc];
-  if(opts_used) {
-    memset(opts_used, ' ', ZSV_OPTS_SIZE_MAX-1);
-    opts_used[ZSV_OPTS_SIZE_MAX-1] = '\0';
+  if (opts_used) {
+    memset(opts_used, ' ', ZSV_OPTS_SIZE_MAX - 1);
+    opts_used[ZSV_OPTS_SIZE_MAX - 1] = '\0';
   }
 
-  for(int i = options_start; !err && i < argc; i++) {
+  for (int i = options_start; !err && i < argc; i++) {
     char arg = 0;
-    if(*argv[i] != '-') { /* pass this option through */
+    if (*argv[i] != '-') { /* pass this option through */
       argv_out[new_argc++] = argv[i];
       continue;
     }
     unsigned found_ix = 0;
-    if(argv[i][1] != '-') {
+    if (argv[i][1] != '-') {
       char *strchr_result;
-      if(!argv[i][2] && (strchr_result = strchr(short_args, argv[i][1]))) {
+      if (!argv[i][2] && (strchr_result = strchr(short_args, argv[i][1]))) {
         arg = argv[i][1];
         found_ix = strchr_result - short_args;
       }
@@ -199,7 +197,7 @@ enum zsv_status zsv_args_to_opts(int argc, const char *argv[],
     }
 
     char processed = 1;
-    switch(arg) {
+    switch (arg) {
     case 't':
       opts_out->delimiter = '\t';
       break;
@@ -223,72 +221,73 @@ enum zsv_status zsv_args_to_opts(int argc, const char *argv[],
     case 'd':
     case 'u':
     case '0':
-      if(++i >= argc)
-        err = fprintf(stderr, "Error: option %s requires a value\n", argv[i-1]);
+      if (++i >= argc)
+        err = fprintf(stderr, "Error: option %s requires a value\n", argv[i - 1]);
       else {
         const char *val = argv[i];
-        if(arg == 'O') {
-          if(strlen(val) != 1 || *val == 0)
+        if (arg == 'O') {
+          if (strlen(val) != 1 || *val == 0)
             err = fprintf(stderr, "Error: delimiter '%s' may only be a single ascii character", val);
-          else if(strchr("\n\r\"", *val))
+          else if (strchr("\n\r\"", *val))
             err = fprintf(stderr, "Error: column delimiter may not be '\\n', '\\r' or '\"'\n");
-        else
-          opts_out->delimiter = *val;
-        } else if(arg == 'u') {
-          if(!strcmp(val, "none"))
+          else
+            opts_out->delimiter = *val;
+        } else if (arg == 'u') {
+          if (!strcmp(val, "none"))
             opts_out->malformed_utf8_replace = ZSV_MALFORMED_UTF8_DO_NOT_REPLACE;
-          else if(!*val)
+          else if (!*val)
             opts_out->malformed_utf8_replace = ZSV_MALFORMED_UTF8_REMOVE;
-          else if(strlen(val) > 2 || *val < 0)
-            err = fprintf(stderr, "Error: %s value must be a single-byte UTF8 char, empty string or 'none'\n", argv[i-1]);
+          else if (strlen(val) > 2 || *val < 0)
+            err =
+              fprintf(stderr, "Error: %s value must be a single-byte UTF8 char, empty string or 'none'\n", argv[i - 1]);
           else
             opts_out->malformed_utf8_replace = *val;
-        } else if(arg == '0') {
-          if(*val == 0)
+        } else if (arg == '0') {
+          if (*val == 0)
             err = fprintf(stderr, "Invalid empty Inserted header row\n");
           else
             opts_out->insert_header_row = argv[i];
         } else {
           /* arg = 'B', 'c', 'r', 'R', 'd', or 'L' (ZSV_EXTRAS only) */
           long n = atol(val);
-          if(n < 0)
+          if (n < 0)
             err = fprintf(stderr, "Error: option %s value may not be less than zero (got %li\n", val, n);
 #ifdef ZSV_EXTRAS
-          else if(arg == 'L') {
-            if(n < 1)
+          else if (arg == 'L') {
+            if (n < 1)
               err = fprintf(stderr, "Error: max rows may not be less than 1 (got %s)\n", val);
             else
               opts_out->max_rows = n;
           } else
 #endif
-            if(arg == 'B') {
-              if(n < ZSV_MIN_SCANNER_BUFFSIZE)
-                err = fprintf(stderr, "Error: buff size may not be less than %u (got %s)\n",
-                              ZSV_MIN_SCANNER_BUFFSIZE, val);
-              else
-                opts_out->buffsize = n;
-            } else if(arg == 'c') {
-              if(n < 8)
-                err = fprintf(stderr, "Error: max column count may not be less than 8 (got %s)\n", val);
-              else
-                opts_out->max_columns = n;
-            } else if(arg == 'r') {
-              if(n < ZSV_ROW_MAX_SIZE_MIN)
-                err = fprintf(stderr, "Error: max row size size may not be less than %u (got %s)\n",
-                              ZSV_ROW_MAX_SIZE_MIN, val);
-              else
-                opts_out->max_row_size = n;
-            } else if(arg == 'd') {
-              if(n < 8 && n >= 0)
-                opts_out->header_span = n;
-              else
-                err = fprintf(stderr, "Error: header_span must be an integer between 0 and 8\n");
-            } else if(arg == 'R') {
-              if(n >= 0)
-                opts_out->rows_to_ignore = n;
-              else
-                err = fprintf(stderr, "Error: rows_to_skip must be >= 0\n");
-            }
+            if (arg == 'B') {
+            if (n < ZSV_MIN_SCANNER_BUFFSIZE)
+              err =
+                fprintf(stderr, "Error: buff size may not be less than %u (got %s)\n", ZSV_MIN_SCANNER_BUFFSIZE, val);
+            else
+              opts_out->buffsize = n;
+          } else if (arg == 'c') {
+            if (n < 8)
+              err = fprintf(stderr, "Error: max column count may not be less than 8 (got %s)\n", val);
+            else
+              opts_out->max_columns = n;
+          } else if (arg == 'r') {
+            if (n < ZSV_ROW_MAX_SIZE_MIN)
+              err = fprintf(stderr, "Error: max row size size may not be less than %u (got %s)\n", ZSV_ROW_MAX_SIZE_MIN,
+                            val);
+            else
+              opts_out->max_row_size = n;
+          } else if (arg == 'd') {
+            if (n < 8 && n >= 0)
+              opts_out->header_span = n;
+            else
+              err = fprintf(stderr, "Error: header_span must be an integer between 0 and 8\n");
+          } else if (arg == 'R') {
+            if (n >= 0)
+              opts_out->rows_to_ignore = n;
+            else
+              err = fprintf(stderr, "Error: rows_to_skip must be >= 0\n");
+          }
         }
       }
       break;
@@ -297,7 +296,7 @@ enum zsv_status zsv_args_to_opts(int argc, const char *argv[],
       argv_out[new_argc++] = argv[i];
       break;
     }
-    if(processed && opts_used)
+    if (processed && opts_used)
       opts_used[found_ix] = arg;
   }
 
@@ -306,8 +305,8 @@ enum zsv_status zsv_args_to_opts(int argc, const char *argv[],
 }
 
 const char *zsv_next_arg(int arg_i, int argc, const char *argv[], int *err) {
-  if(!(arg_i < argc && strlen(argv[arg_i]) > 0)) {
-    fprintf(stderr, "%s option value invalid: should be non-empty string\n", argv[arg_i-1]);
+  if (!(arg_i < argc && strlen(argv[arg_i]) > 0)) {
+    fprintf(stderr, "%s option value invalid: should be non-empty string\n", argv[arg_i - 1]);
     *err = 1;
     return NULL;
   }

--- a/app/utils/cache.c
+++ b/app/utils/cache.c
@@ -17,7 +17,7 @@
 #include <zsv/utils/file.h>
 
 static const char *zsv_cache_type_name(enum zsv_cache_type t) {
-  switch(t) {
+  switch (t) {
   case zsv_cache_type_property:
     return ZSV_CACHE_PROPERTIES_NAME;
   case zsv_cache_type_tag:
@@ -27,14 +27,13 @@ static const char *zsv_cache_type_name(enum zsv_cache_type t) {
   }
 }
 
-unsigned char *zsv_cache_filepath(const unsigned char *data_filepath,
-                                  enum zsv_cache_type type, char create_dir,
+unsigned char *zsv_cache_filepath(const unsigned char *data_filepath, enum zsv_cache_type type, char create_dir,
                                   char temp_file) {
-  if(!data_filepath || !*data_filepath)
+  if (!data_filepath || !*data_filepath)
     return NULL;
 
   const char *cache_filename_base = zsv_cache_type_name(type);
-  if(!cache_filename_base) {
+  if (!cache_filename_base) {
     zsv_printerr(ENOMEM, "Out of memory!");
     return NULL;
   }
@@ -43,7 +42,7 @@ unsigned char *zsv_cache_filepath(const unsigned char *data_filepath,
   asprintf((char **)&cache_filename, "%s.json%s", cache_filename_base, temp_file ? ZSV_TEMPFILE_SUFFIX : "");
 
   unsigned char *s = cache_filename ? zsv_cache_path(data_filepath, cache_filename, 0) : NULL;
-  if(s && create_dir) {
+  if (s && create_dir) {
     char *last_slash_s = (char *)strrchr((void *)s, FILESLASH);
     int err = 0;
 
@@ -51,9 +50,9 @@ unsigned char *zsv_cache_filepath(const unsigned char *data_filepath,
     *last_slash_s = '\0';
 
     // ensure the parent dir exists
-    if(!zsv_dir_exists((char *)s))
+    if (!zsv_dir_exists((char *)s))
       err = zsv_mkdirs((char *)s, 0);
-    if(err) {
+    if (err) {
       fprintf(stderr, "Unable to create cache directory %s\n", s);
       free(s);
       s = NULL;
@@ -68,25 +67,25 @@ unsigned char *zsv_cache_filepath(const unsigned char *data_filepath,
 /*
  * print cache file to stdout
  */
-int zsv_cache_print(const unsigned char *filepath, enum zsv_cache_type ctype,
-                    const unsigned char *default_value) {
+int zsv_cache_print(const unsigned char *filepath, enum zsv_cache_type ctype, const unsigned char *default_value) {
   int err = 0;
   // to do: parse the json rather than just blindly regurgitating the file
   unsigned char *cache_fn = zsv_cache_filepath(filepath, ctype, 0, 0);
-  if(cache_fn) {
+  if (cache_fn) {
     FILE *f;
-    if(zsv_file_readable((char *)cache_fn, &err, &f)) {
+    if (zsv_file_readable((char *)cache_fn, &err, &f)) {
       char buff[1024];
       size_t bytes;
-      while((bytes = fread(buff, 1, sizeof(buff), f)))
+      while ((bytes = fread(buff, 1, sizeof(buff), f)))
         fwrite(buff, 1, bytes, stdout);
       fclose(f);
-    } else if(err == ENOENT) {
-      if(default_value)
+    } else if (err == ENOENT) {
+      if (default_value)
         printf("%s\n", default_value);
     } else {
       perror((const char *)cache_fn);
-      if(!err) err = 1;
+      if (!err)
+        err = 1;
     }
   }
   free(cache_fn);
@@ -100,13 +99,13 @@ int zsv_cache_print(const unsigned char *filepath, enum zsv_cache_type ctype,
 int zsv_cache_remove(const unsigned char *filepath, enum zsv_cache_type ctype) {
   int err = 0;
   unsigned char *fn = zsv_cache_filepath(filepath, ctype, 0, 0);
-  if(!fn)
+  if (!fn)
     err = ENOMEM;
-  else if(zsv_file_readable((const char *)fn, &err, NULL)) {
+  else if (zsv_file_readable((const char *)fn, &err, NULL)) {
     err = unlink((const char *)fn);
-    if(err)
+    if (err)
       perror((const char *)fn);
-  } else if(err == ENOENT)
+  } else if (err == ENOENT)
     err = 0; // file d.n. exist, nothing to do
   else
     perror((const char *)fn);
@@ -114,29 +113,22 @@ int zsv_cache_remove(const unsigned char *filepath, enum zsv_cache_type ctype) {
   return err;
 }
 
-
 /*
  * modify a JSON cache file, write to tmp file, then replace the cache file
  */
-int zsv_modify_cache_file(const unsigned char *filepath,
-                          enum zsv_cache_type ctype,
-                          const unsigned char *json_value1,
-                          const unsigned char *json_value2,
-                          const unsigned char *filter
-                          ) {
-  unsigned char *cache_fn = zsv_cache_filepath((const unsigned char *)filepath,
-                                               ctype, 0, 0);
-  unsigned char *cache_tmp_fn = zsv_cache_filepath((const unsigned char *)filepath,
-                                                   ctype, 1, 1);
+int zsv_modify_cache_file(const unsigned char *filepath, enum zsv_cache_type ctype, const unsigned char *json_value1,
+                          const unsigned char *json_value2, const unsigned char *filter) {
+  unsigned char *cache_fn = zsv_cache_filepath((const unsigned char *)filepath, ctype, 0, 0);
+  unsigned char *cache_tmp_fn = zsv_cache_filepath((const unsigned char *)filepath, ctype, 1, 1);
   FILE *cache_data = NULL;
-  if(!(cache_fn && cache_tmp_fn))
+  if (!(cache_fn && cache_tmp_fn))
     return zsv_printerr(ENOMEM, "Out of memory!");
 
   cache_data = fopen((void *)cache_fn, "rb");
   int err = 0;
-  if(!cache_data) {
+  if (!cache_data) {
     err = errno;
-    if(err == ENOENT)
+    if (err == ENOENT)
       err = 0;
     else { // file exists but could not be opened
       perror((const char *)cache_fn);
@@ -144,10 +136,10 @@ int zsv_modify_cache_file(const unsigned char *filepath,
     }
   }
 
-  if(cache_data) {
+  if (cache_data) {
     // check that we have at least 1 byte of data
     fseek(cache_data, 1, SEEK_SET);
-    if(!ftell(cache_data)) { // empty file; will use default value of "{}"
+    if (!ftell(cache_data)) { // empty file; will use default value of "{}"
       fclose(cache_data);
       cache_data = NULL;
     } else
@@ -156,48 +148,47 @@ int zsv_modify_cache_file(const unsigned char *filepath,
 
   // jq filter to apply to [current_properties, id, value]
   FILE *tmp = fopen((const char *)cache_tmp_fn, "wb");
-  if(!tmp) {
-    if(!(err = errno)) err = 1;
+  if (!tmp) {
+    if (!(err = errno))
+      err = 1;
     perror((const char *)cache_tmp_fn);
   } else {
-    struct jv_to_json_ctx ctx = { 0 };
+    struct jv_to_json_ctx ctx = {0};
     ctx.write1 = zsv_jq_fwrite1;
     ctx.ctx = tmp;
     ctx.flags = JV_PRINT_PRETTY | JV_PRINT_SPACE1;
     enum zsv_jq_status jqstat;
     void *jqh = zsv_jq_new(filter, jv_to_json_func, &ctx, &jqstat);
-    if(jqstat || !jqh)
-      err = zsv_printerr(-1 ,"Unable to initialize jq filter");
-    else if(!(jqstat = zsv_jq_parse(jqh, "[", 1))) {
-      if(cache_data)
+    if (jqstat || !jqh)
+      err = zsv_printerr(-1, "Unable to initialize jq filter");
+    else if (!(jqstat = zsv_jq_parse(jqh, "[", 1))) {
+      if (cache_data)
         jqstat = zsv_jq_parse_file(jqh, cache_data);
       else
         jqstat = zsv_jq_parse(jqh, "{}", 2);
-      if(!jqstat
-         && !(jqstat = zsv_jq_parse(jqh, ",", 1))
-         && !(jqstat = zsv_jq_parse(jqh, json_value1, strlen((void *)json_value1)))
-         && !(jqstat = zsv_jq_parse(jqh, ",", 1))
-         && !(jqstat = zsv_jq_parse(jqh, json_value2, strlen((void *)json_value2)))
-         && !(jqstat = zsv_jq_parse(jqh, "]", 1))
-         && !(jqstat = zsv_jq_finish(jqh))) {
+      if (!jqstat && !(jqstat = zsv_jq_parse(jqh, ",", 1)) &&
+          !(jqstat = zsv_jq_parse(jqh, json_value1, strlen((void *)json_value1))) &&
+          !(jqstat = zsv_jq_parse(jqh, ",", 1)) &&
+          !(jqstat = zsv_jq_parse(jqh, json_value2, strlen((void *)json_value2))) &&
+          !(jqstat = zsv_jq_parse(jqh, "]", 1)) && !(jqstat = zsv_jq_finish(jqh))) {
         ;
       }
     }
     zsv_jq_delete(jqh);
 
-    if(cache_data) {
+    if (cache_data) {
       fclose(cache_data);
       cache_data = NULL;
     }
     fclose(tmp);
 
-    if(!jqstat && zsv_replace_file(cache_tmp_fn, cache_fn)) {
+    if (!jqstat && zsv_replace_file(cache_tmp_fn, cache_fn)) {
       err = zsv_printerr(-1, "Unable to save %s: ", cache_fn);
       zsv_perror(NULL);
     }
   }
 
-  if(cache_data)
+  if (cache_data)
     fclose(cache_data);
   free(cache_fn);
   free(cache_tmp_fn);
@@ -208,28 +199,26 @@ int zsv_modify_cache_file(const unsigned char *filepath,
  * Returns the folder or file path to the cache for a given data file
  * Caller must free the returned result
  */
-unsigned char *zsv_cache_path(const unsigned char *data_filepath,
-                              const unsigned char *cache_filename, char temp_file) {
-  if(!data_filepath)
+unsigned char *zsv_cache_path(const unsigned char *data_filepath, const unsigned char *cache_filename, char temp_file) {
+  if (!data_filepath)
     return NULL;
   const unsigned char *last_slash = (void *)strrchr((void *)data_filepath, '/');
   const unsigned char *last_backslash = (void *)strrchr((void *)data_filepath, '\\');
-  const unsigned char *dir_end = (!last_slash && !last_backslash ? NULL :
-                                  last_backslash > last_slash ? last_backslash :
-                                  last_slash);
+  const unsigned char *dir_end = (!last_slash && !last_backslash ? NULL
+                                  : last_backslash > last_slash  ? last_backslash
+                                                                 : last_slash);
   char *s = NULL;
   char *filename_suffix = NULL;
-  if(cache_filename)
-    asprintf(&filename_suffix, "%c%s%s", FILESLASH, cache_filename,
-             temp_file ? ZSV_TEMPFILE_SUFFIX : "");
+  if (cache_filename)
+    asprintf(&filename_suffix, "%c%s%s", FILESLASH, cache_filename, temp_file ? ZSV_TEMPFILE_SUFFIX : "");
 
-  if(!dir_end) // file is in current dir
-    asprintf(&s, ZSV_CACHE_DIR"%c%s%s", FILESLASH, data_filepath, filename_suffix ? filename_suffix : "");
-  else if(dir_end[1]) {
-    asprintf(&s, "%.*s%c"ZSV_CACHE_DIR"%c%s%s", (int)(dir_end - data_filepath),
-             data_filepath, FILESLASH, FILESLASH, dir_end + 1, filename_suffix ? filename_suffix : "");
-    for(int i = 0; s && s[i]; i++)
-      if(s[i] != FILESLASH && (s[i] == '/' || s[i] == '\\'))
+  if (!dir_end) // file is in current dir
+    asprintf(&s, ZSV_CACHE_DIR "%c%s%s", FILESLASH, data_filepath, filename_suffix ? filename_suffix : "");
+  else if (dir_end[1]) {
+    asprintf(&s, "%.*s%c" ZSV_CACHE_DIR "%c%s%s", (int)(dir_end - data_filepath), data_filepath, FILESLASH, FILESLASH,
+             dir_end + 1, filename_suffix ? filename_suffix : "");
+    for (int i = 0; s && s[i]; i++)
+      if (s[i] != FILESLASH && (s[i] == '/' || s[i] == '\\'))
         s[i] = FILESLASH;
   }
   free(filename_suffix);

--- a/app/utils/clock.c
+++ b/app/utils/clock.c
@@ -13,52 +13,45 @@ clock_t zsv_clock_in;
 clock_t zsv_clock_out;
 int i_tmp;
 
-size_t
-zsv_fread_clock(void *restrict ptr, size_t size, size_t nitems,
-                FILE *restrict stream) {
+size_t zsv_fread_clock(void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream) {
   clock_t clock_tmp = clock();
   size_t sz = fread(ptr, size, nitems, stream);
   zsv_clock_in += clock() - clock_tmp;
   return sz;
 }
 
-size_t
-zsv_fwrite_clock(const void *restrict ptr, size_t size, size_t nitems,
-                 FILE *restrict stream) {
+size_t zsv_fwrite_clock(const void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream) {
   clock_t clock_tmp = clock();
   size_t sz = fwrite(ptr, size, nitems, stream);
   zsv_clock_out += clock() - clock_tmp;
   return sz;
 }
 
-int
-zsv_fflush_clock(FILE *stream) {
+int zsv_fflush_clock(FILE *stream) {
   clock_t clock_tmp = clock();
   int i = fflush(stream);
   zsv_clock_out += clock() - clock_tmp;
   return i;
 }
 
-void
-zsv_clocks_begin() {
+void zsv_clocks_begin() {
   zsv_clock_in = zsv_clock_out = 0;
   zsv_clock_begin = clock();
 }
 
-void
-zsv_clocks_end() {
+void zsv_clocks_end() {
   clock_t clock_end = clock();
   clock_t clock_total = clock_end - zsv_clock_begin;
   clock_t clock_other = clock_total - zsv_clock_in - zsv_clock_out;
-  fprintf(stderr, "elapsed time:\n"
+  fprintf(stderr,
+          "elapsed time:\n"
           "  total %zu, %Lf\n"
           "  in %zu, %Lf\n"
           "  out %zu, %Lf\n"
           "  other %zu, %Lf\n"
           "\n",
-          (size_t)(clock_total), (long double)(clock_total) / CLOCKS_PER_SEC,
-          (size_t)zsv_clock_in, (long double)(zsv_clock_in) / CLOCKS_PER_SEC,
-          (size_t)zsv_clock_out, (long double)(zsv_clock_out) / CLOCKS_PER_SEC,
-          (size_t)clock_other, (long double)(clock_other) / CLOCKS_PER_SEC
-          );
+          (size_t)(clock_total), (long double)(clock_total) / CLOCKS_PER_SEC, (size_t)zsv_clock_in,
+          (long double)(zsv_clock_in) / CLOCKS_PER_SEC, (size_t)zsv_clock_out,
+          (long double)(zsv_clock_out) / CLOCKS_PER_SEC, (size_t)clock_other,
+          (long double)(clock_other) / CLOCKS_PER_SEC);
 }

--- a/app/utils/db.c
+++ b/app/utils/db.c
@@ -6,13 +6,12 @@
 
 // starts_w_str_underscore(): helper function
 // returns 1 if s starts with prefix (case-insensitive), followed by underscore
-static char starts_w_str_underscore(const unsigned char *s, size_t s_len,
-                                    const unsigned char *prefix) {
+static char starts_w_str_underscore(const unsigned char *s, size_t s_len, const unsigned char *prefix) {
   char result = 0;
   unsigned char *s_lc = zsv_strtolowercase(s, &s_len);
   size_t pfx_len = strlen((const char *)prefix);
   unsigned char *prefix_lc = zsv_strtolowercase(prefix, &pfx_len);
-  if(pfx_len + 1 < s_len && !memcmp(s_lc, prefix_lc, pfx_len) && s_lc[pfx_len] == '_')
+  if (pfx_len + 1 < s_len && !memcmp(s_lc, prefix_lc, pfx_len) && s_lc[pfx_len] == '_')
     result = 1;
   free(s_lc);
   free(prefix_lc);
@@ -24,7 +23,7 @@ int zsv_dbtable2json(sqlite3 *db, const char *tname, jsonwriter_handle jsw, size
   const char *index_sql = "select name, sql from sqlite_master where type = 'index' and tbl_name = :tbl_name";
   const char *unique_sql = "select 1 from PRAGMA_index_list(?) where name = ? and [unique] <> 0";
   sqlite3_str *data_sql = sqlite3_str_new(db);
-  if(data_sql) {
+  if (data_sql) {
     sqlite3_str_appendf(data_sql, "select * from \"%w\"", tname);
     sqlite3_stmt *data_stmt = NULL;
     sqlite3_stmt *index_stmt = NULL;
@@ -32,13 +31,13 @@ int zsv_dbtable2json(sqlite3 *db, const char *tname, jsonwriter_handle jsw, size
     int colcount = 0;
 
     err = 1;
-    if(sqlite3_prepare_v2(db, sqlite3_str_value(data_sql), -1, &data_stmt, NULL) != SQLITE_OK)
+    if (sqlite3_prepare_v2(db, sqlite3_str_value(data_sql), -1, &data_stmt, NULL) != SQLITE_OK)
       fprintf(stderr, "Unable to prepare %s: %s\n", sqlite3_str_value(data_sql), sqlite3_errmsg(db));
-    else if(!(colcount = sqlite3_column_count(data_stmt)))
+    else if (!(colcount = sqlite3_column_count(data_stmt)))
       fprintf(stderr, "No columns found in table %s\n", tname);
-    else if(sqlite3_prepare_v2(db, index_sql, -1, &index_stmt, NULL) != SQLITE_OK)
+    else if (sqlite3_prepare_v2(db, index_sql, -1, &index_stmt, NULL) != SQLITE_OK)
       fprintf(stderr, "Unable to prepare %s: %s\n", index_sql, sqlite3_errmsg(db));
-    else if(sqlite3_prepare_v2(db, unique_sql, -1, &unique_stmt, NULL) != SQLITE_OK)
+    else if (sqlite3_prepare_v2(db, unique_sql, -1, &unique_stmt, NULL) != SQLITE_OK)
       fprintf(stderr, "Unable to prepare %s: %s\n", unique_sql, sqlite3_errmsg(db));
     else {
       err = 0;
@@ -52,25 +51,26 @@ int zsv_dbtable2json(sqlite3 *db, const char *tname, jsonwriter_handle jsw, size
       // indexes
       jsonwriter_object_object(jsw, "indexes"); // indexes
       sqlite3_bind_text(index_stmt, 1, tname, (int)strlen(tname), SQLITE_STATIC);
-      while(sqlite3_step(index_stmt) == SQLITE_ROW) {
+      while (sqlite3_step(index_stmt) == SQLITE_ROW) {
         const unsigned char *text = sqlite3_column_text(index_stmt, 0);
         const unsigned char *ix_sql = sqlite3_column_text(index_stmt, 1);
         size_t len = text ? sqlite3_column_bytes(index_stmt, 0) : 0;
         size_t ix_sql_len = ix_sql ? sqlite3_column_bytes(index_stmt, 1) : 0;
 
-        if(text && ix_sql && len && ix_sql_len) {
+        if (text && ix_sql && len && ix_sql_len) {
           // on: for now we just look for the first and last parens
           const unsigned char *first_paren = memchr(ix_sql, '(', ix_sql_len);
           const unsigned char *last_paren = ix_sql + ix_sql_len;
-          while(first_paren && last_paren > first_paren + 1 && *last_paren != ')')
+          while (first_paren && last_paren > first_paren + 1 && *last_paren != ')')
             last_paren--;
-          if(first_paren && last_paren > first_paren) {
+          if (first_paren && last_paren > first_paren) {
             // name
 
             // strip the leading "tablename_" from the index name
             const char *ix_name = (const char *)text;
             size_t ix_name_len = len;
-            if(ix_name_len > strlen(tname) + 1 && starts_w_str_underscore((const unsigned char *)ix_name, ix_name_len, (const unsigned char *)tname)) {
+            if (ix_name_len > strlen(tname) + 1 &&
+                starts_w_str_underscore((const unsigned char *)ix_name, ix_name_len, (const unsigned char *)tname)) {
               ix_name += strlen(tname) + 1;
               ix_name_len -= strlen(tname) + 1;
             }
@@ -85,7 +85,7 @@ int zsv_dbtable2json(sqlite3 *db, const char *tname, jsonwriter_handle jsw, size
             // unique
             sqlite3_bind_text(unique_stmt, 1, tname, (int)strlen(tname), SQLITE_STATIC);
             sqlite3_bind_text(unique_stmt, 2, (const char *)text, len, SQLITE_STATIC);
-            if(sqlite3_step(unique_stmt) == SQLITE_ROW)
+            if (sqlite3_step(unique_stmt) == SQLITE_ROW)
               jsonwriter_object_bool(jsw, "unique", 1);
             sqlite3_reset(unique_stmt);
 
@@ -98,15 +98,15 @@ int zsv_dbtable2json(sqlite3 *db, const char *tname, jsonwriter_handle jsw, size
 
       // columns
       jsonwriter_object_array(jsw, "columns");
-      for(int i = 0; i < colcount; i++) {
+      for (int i = 0; i < colcount; i++) {
         const char *colname = sqlite3_column_name(data_stmt, i);
         jsonwriter_start_object(jsw);
         jsonwriter_object_cstr(jsw, "name", colname);
         const char *dtype = sqlite3_column_decltype(data_stmt, i);
-        if(dtype)
+        if (dtype)
           jsonwriter_object_cstr(jsw, "datatype", dtype);
 
-        // to do: collate nocase etc
+        // TO DO: collate nocase etc
         jsonwriter_end_object(jsw);
       }
       jsonwriter_end_array(jsw); // end columns
@@ -117,29 +117,29 @@ int zsv_dbtable2json(sqlite3 *db, const char *tname, jsonwriter_handle jsw, size
       jsonwriter_start_array(jsw);
       // for each row
       size_t count = 0;
-      while(sqlite3_step(data_stmt) == SQLITE_ROW) {
+      while (sqlite3_step(data_stmt) == SQLITE_ROW) {
         jsonwriter_start_array(jsw); // start row
-        for(int i = 0; i < colcount; i++) {
+        for (int i = 0; i < colcount; i++) {
           const unsigned char *text = sqlite3_column_text(data_stmt, i);
-          if(text) {
+          if (text) {
             int len = sqlite3_column_bytes(data_stmt, i);
             jsonwriter_strn(jsw, text, len);
           } else
             jsonwriter_null(jsw);
         }
         jsonwriter_end_array(jsw); // end row
-        if(limit && ++count >= limit)
+        if (limit && ++count >= limit)
           break;
       }
       jsonwriter_end_array(jsw);
 
       jsonwriter_end_array(jsw); // end of output
     }
-    if(data_stmt)
+    if (data_stmt)
       sqlite3_finalize(data_stmt);
-    if(index_stmt)
+    if (index_stmt)
       sqlite3_finalize(index_stmt);
-    if(unique_stmt)
+    if (unique_stmt)
       sqlite3_finalize(unique_stmt);
 
     sqlite3_free(sqlite3_str_finish(data_sql));

--- a/app/utils/dirs-no-jq.c
+++ b/app/utils/dirs-no-jq.c
@@ -1,2 +1,2 @@
-#define  ZSV_NO_JQ
+#define ZSV_NO_JQ
 #include "dirs.c"

--- a/app/utils/dirs.c
+++ b/app/utils/dirs.c
@@ -30,12 +30,12 @@
  * the buffer size should be FILENAME_MAX
  */
 
-static size_t chop_slash(char* buff, size_t len) {
-  if(buff[len-1] == '\\' || buff[len-1] == '/') {
-    buff[len-1] = '\0';
+static size_t chop_slash(char *buff, size_t len) {
+  if (buff[len - 1] == '\\' || buff[len - 1] == '/') {
+    buff[len - 1] = '\0';
     len--;
   }
-  return (size_t) len;
+  return (size_t)len;
 }
 
 /**
@@ -43,15 +43,15 @@ static size_t chop_slash(char* buff, size_t len) {
  * prefix should be determined at compile time e.g. /usr/local or ""
  * @return length written to buff, or 0 if failed
  */
-size_t zsv_get_config_dir(char* buff, size_t buffsize, const char *prefix) {
+size_t zsv_get_config_dir(char *buff, size_t buffsize, const char *prefix) {
 #if defined(_WIN32)
   const char *env_val = getenv("ZSV_CONFIG_DIR");
   (void)(prefix);
   //  if(!(env_val && *env_val))
   //    env_val = getenv(prefix);
-  if(!(env_val && *env_val))
+  if (!(env_val && *env_val))
     env_val = getenv("LOCALAPPDATA");
-  if(!(env_val && *env_val))
+  if (!(env_val && *env_val))
     env_val = "C:\\temp";
   int written = snprintf(buff, buffsize, "%s", env_val);
 #elif defined(__EMSCRIPTEN__)
@@ -59,12 +59,12 @@ size_t zsv_get_config_dir(char* buff, size_t buffsize, const char *prefix) {
 #else
   int written;
   const char *env_val = getenv("ZSV_CONFIG_DIR");
-  if(env_val && *env_val)
+  if (env_val && *env_val)
     written = snprintf(buff, buffsize, "%s", env_val);
   else
     written = snprintf(buff, buffsize, "%s/etc", prefix ? prefix : "");
 #endif
-  if(written > 0 && ((size_t)written) < buffsize)
+  if (written > 0 && ((size_t)written) < buffsize)
     return chop_slash(buff, written);
   return 0;
 }
@@ -75,7 +75,7 @@ size_t zsv_get_config_dir(char* buff, size_t buffsize, const char *prefix) {
  */
 int zsv_dir_exists(const char *path) {
   struct stat path_stat;
-  if(!stat(path, &path_stat))
+  if (!stat(path, &path_stat))
     return S_ISDIR(path_stat.st_mode);
   return 0;
 }
@@ -89,25 +89,26 @@ int zsv_mkdirs(const char *path, char path_is_filename) {
   int rc = 0;
 
   size_t len = strlen(path);
-  if(len < 1 || len > FILENAME_MAX)
+  if (len < 1 || len > FILENAME_MAX)
     return -1;
 
   char *tmp = strdup(path);
-  if(len && strchr("/\\", tmp[len - 1]))
+  if (len && strchr("/\\", tmp[len - 1]))
     tmp[--len] = 0;
 
   int offset = 0;
 #ifdef WIN32
-  if(len > 1) {
+  if (len > 1) {
     // starts with two slashes
-    if(strchr("/\\", tmp[0]) && strchr("/\\", tmp[1])) {
+    if (strchr("/\\", tmp[0]) && strchr("/\\", tmp[1])) {
       offset = 2;
       // find the next slash
       char *path_end = tmp + 3;
-      while(*path_end && !strchr("/\\", *path_end))
+      while (*path_end && !strchr("/\\", *path_end))
         path_end++;
-      if(*path_end) path_end++;
-      if(*path_end)
+      if (*path_end)
+        path_end++;
+      if (*path_end)
         offset = path_end - tmp;
       else {
         fprintf(stderr, "Invalid path: %s\n", path);
@@ -115,24 +116,25 @@ int zsv_mkdirs(const char *path, char path_is_filename) {
       }
     }
     // starts with *:
-    else if(tmp[1] == ':')
+    else if (tmp[1] == ':')
       offset = 2;
   }
 #else
   offset = 1;
 #endif
 
-  for(p = tmp + offset; !rc && *p; p++)
-    if(strchr("/\\", *p)) {
+  for (p = tmp + offset; !rc && *p; p++)
+    if (strchr("/\\", *p)) {
       char tmp_c = p[1];
       p[0] = FILESLASH;
       p[1] = '\0';
-      if(*tmp && !zsv_dir_exists(tmp)
-         && mkdir(tmp
+      if (*tmp && !zsv_dir_exists(tmp) &&
+          mkdir(tmp
 #ifndef WIN32
-                  , S_IRWXU
+                ,
+                S_IRWXU
 #endif
-                  )) {
+                )) {
         rc = -1;
         fprintf(stderr, "Error creating directory: ");
         perror(tmp);
@@ -140,31 +142,31 @@ int zsv_mkdirs(const char *path, char path_is_filename) {
         p[1] = tmp_c;
     }
 
-  if(!rc && path_is_filename == 0 && *tmp && !zsv_dir_exists(tmp)
-     && mkdir(tmp
+  if (!rc && path_is_filename == 0 && *tmp && !zsv_dir_exists(tmp) &&
+      mkdir(tmp
 #ifndef WIN32
-              , S_IRWXU
+            ,
+            S_IRWXU
 #endif
-              ))
+            ))
     rc = -1;
 
   free(tmp);
   return rc;
 }
 
-
 #if defined(_WIN32)
-size_t zsv_get_executable_path(char* buff, size_t buffsize) {
+size_t zsv_get_executable_path(char *buff, size_t buffsize) {
   return GetModuleFileNameA(NULL, buff, (DWORD)buffsize);
 }
 
 #elif defined(__APPLE__)
-  #include <mach-o/dyld.h>
-size_t zsv_get_executable_path(char* buff, size_t bufflen) {
+#include <mach-o/dyld.h>
+size_t zsv_get_executable_path(char *buff, size_t bufflen) {
   uint32_t pathlen = bufflen;
-  if(!_NSGetExecutablePath(buff, &pathlen)) {
+  if (!_NSGetExecutablePath(buff, &pathlen)) {
     char real[FILENAME_MAX];
-    if(realpath(buff, real) != NULL && strlen(real) < bufflen) {
+    if (realpath(buff, real) != NULL && strlen(real) < bufflen) {
       bufflen = strlen(real);
       memcpy(buff, real, bufflen);
       buff[bufflen] = '\0';
@@ -175,8 +177,8 @@ size_t zsv_get_executable_path(char* buff, size_t bufflen) {
   return 0;
 }
 #elif defined(__linux__) || defined(__EMSCRIPTEN__)
-  #include <unistd.h>
-size_t zsv_get_executable_path(char* buff, size_t buffsize) {
+#include <unistd.h>
+size_t zsv_get_executable_path(char *buff, size_t buffsize) {
   buffsize = readlink("/proc/self/exe", buff, buffsize - 1);
   buff[buffsize] = '\0';
   return buffsize;
@@ -184,7 +186,7 @@ size_t zsv_get_executable_path(char* buff, size_t buffsize) {
 #elif defined(__FreeBSD__)
 #include <sys/stat.h>
 #include <sys/sysctl.h>
-size_t zsv_get_executable_path(char* buff, size_t buffsize) {
+size_t zsv_get_executable_path(char *buff, size_t buffsize) {
   int mib[4];
   mib[0] = CTL_KERN;
   mib[1] = KERN_PROC;
@@ -211,12 +213,12 @@ struct dir_path {
  */
 static int rmdir_w_msg(const char *path, int *err) {
 #ifdef WIN32
-  if(!RemoveDirectoryA(path)) {
+  if (!RemoveDirectoryA(path)) {
     zsv_win_printLastError();
     *err = 1;
   }
 #else
-  if(remove(path)) {
+  if (remove(path)) {
     perror(path);
     *err = 1;
   }
@@ -226,20 +228,20 @@ static int rmdir_w_msg(const char *path, int *err) {
 
 static int zsv_foreach_dirent_remove(struct zsv_foreach_dirent_handle *h, size_t depth) {
   (void)(depth);
-  if(!h->is_dir) { // file
-    if(h->parent_and_entry) {
-      if(unlink(h->parent_and_entry)) {
+  if (!h->is_dir) { // file
+    if (h->parent_and_entry) {
+      if (unlink(h->parent_and_entry)) {
         perror(h->parent_and_entry); // "Unable to remove file");
         return 1;
       }
     }
-  } else {           // dir
+  } else { // dir
     struct dir_path *dn = calloc(1, sizeof(*dn));
-    if(!dn) {
+    if (!dn) {
       fprintf(stderr, "Out of memory!\n");
       return 1;
     }
-    if(h->parent_and_entry) {
+    if (h->parent_and_entry) {
       dn->path = strdup(h->parent_and_entry);
       dn->next = *((struct dir_path **)h->ctx);
       *((struct dir_path **)h->ctx) = dn;
@@ -249,32 +251,27 @@ static int zsv_foreach_dirent_remove(struct zsv_foreach_dirent_handle *h, size_t
 }
 
 // return error
-static
-int zsv_foreach_dirent_aux(const char *dir_path,
-                           size_t depth,
-                           size_t max_depth,
-                           zsv_foreach_dirent_handler handler, void *ctx,
-                           char verbose
-                           ) {
+static int zsv_foreach_dirent_aux(const char *dir_path, size_t depth, size_t max_depth,
+                                  zsv_foreach_dirent_handler handler, void *ctx, char verbose) {
   int err = 0;
-  if(!dir_path)
+  if (!dir_path)
     return 1;
 
-  if(max_depth > 0 && depth >= max_depth)
+  if (max_depth > 0 && depth >= max_depth)
     return 0;
 
   DIR *dr;
-  if((dr = opendir(dir_path))) {
+  if ((dr = opendir(dir_path))) {
     struct dirent *de;
-    while((de = readdir(dr)) != NULL) {
-      if(!*de->d_name || !strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
+    while ((de = readdir(dr)) != NULL) {
+      if (!*de->d_name || !strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
         continue;
       char *tmp;
       asprintf(&tmp, "%s%c%s", dir_path, FILESLASH, de->d_name);
-      if(!tmp)
+      if (!tmp)
         fprintf(stderr, "Out of memory!\n"), err = 1;
       else {
-        struct zsv_foreach_dirent_handle h = { 0 };
+        struct zsv_foreach_dirent_handle h = {0};
         h.verbose = verbose;
         stat(tmp, (struct stat *)&h.stat);
         h.parent = dir_path;
@@ -283,10 +280,10 @@ int zsv_foreach_dirent_aux(const char *dir_path,
         h.ctx = ctx;
         char is_dir = h.stat.st_mode & S_IFDIR ? 1 : 0;
         h.is_dir = is_dir;
-        if(handler)
+        if (handler)
           handler(&h, depth + 1);
 
-        if(is_dir && !h.no_recurse)
+        if (is_dir && !h.no_recurse)
           // recurse!
           err = zsv_foreach_dirent_aux(tmp, depth + 1, max_depth, handler, ctx, verbose);
         free(tmp);
@@ -297,11 +294,8 @@ int zsv_foreach_dirent_aux(const char *dir_path,
   return err;
 }
 
-int zsv_foreach_dirent(const char *dir_path,
-                       size_t max_depth,
-                       zsv_foreach_dirent_handler handler, void *ctx,
-                       char verbose
-                       ) {
+int zsv_foreach_dirent(const char *dir_path, size_t max_depth, zsv_foreach_dirent_handler handler, void *ctx,
+                       char verbose) {
   return zsv_foreach_dirent_aux(dir_path, 0, max_depth, handler, ctx, verbose);
 }
 
@@ -312,22 +306,21 @@ int zsv_remove_dir_recursive(const unsigned char *path) {
   // we will delete all files first, then
   // delete directories in the reverse order we received them
   struct dir_path *reverse_dirs = NULL;
-  int err = zsv_foreach_dirent((const char *)path, 0,
-                               zsv_foreach_dirent_remove, &reverse_dirs, 0);
+  int err = zsv_foreach_dirent((const char *)path, 0, zsv_foreach_dirent_remove, &reverse_dirs, 0);
   // unlink and free each dir
-  for(struct dir_path *next, *dn = reverse_dirs; !err && dn; dn = next) {
+  for (struct dir_path *next, *dn = reverse_dirs; !err && dn; dn = next) {
     next = dn->next;
     rmdir_w_msg(dn->path, &err);
     free(dn->path);
     free(dn);
   }
-  if(!err)
+  if (!err)
     rmdir_w_msg((const char *)path, &err);
 
   return err;
 }
 
-#ifndef  ZSV_NO_JQ
+#ifndef ZSV_NO_JQ
 #include "dirs_to_json.c"
 
 #include "dirs_from_json.c"

--- a/app/utils/dirs_from_json.c
+++ b/app/utils/dirs_from_json.c
@@ -11,19 +11,19 @@ struct zsv_dir_from_json_ctx {
   zsv_jq_handle zjq;
 
   int err;
-  unsigned char in_obj:1;
-  unsigned char do_check:1;
-  unsigned char dry:1;
-  unsigned char _:5;
+  unsigned char in_obj : 1;
+  unsigned char do_check : 1;
+  unsigned char dry : 1;
+  unsigned char _ : 5;
 };
 
 static void zsv_dir_from_json_close_out(struct zsv_dir_from_json_ctx *ctx) {
-  if(ctx->zjq) {
+  if (ctx->zjq) {
     zsv_jq_finish(ctx->zjq);
     zsv_jq_delete(ctx->zjq);
     ctx->zjq = NULL;
   }
-  if(ctx->out) {
+  if (ctx->out) {
     fclose(ctx->out);
     ctx->out = NULL;
     free(ctx->out_filepath);
@@ -31,47 +31,50 @@ static void zsv_dir_from_json_close_out(struct zsv_dir_from_json_ctx *ctx) {
   }
 }
 
-static int zsv_dir_from_json_map_key(yajl_helper_t yh,
-                               const unsigned char *s, size_t len) {
-  if(yajl_helper_level(yh) == 1 && len) { // new property file entry
+static int zsv_dir_from_json_map_key(yajl_helper_t yh, const unsigned char *s, size_t len) {
+  if (yajl_helper_level(yh) == 1 && len) { // new property file entry
     struct zsv_dir_from_json_ctx *ctx = yajl_helper_ctx(yh);
 
     char *fn = NULL;
-    if(ctx->filepath_prefix)
+    if (ctx->filepath_prefix)
       asprintf(&fn, "%s%c%.*s", ctx->filepath_prefix, FILESLASH, (int)len, s);
     else
       asprintf(&fn, "%.*s", (int)len, s);
 
     // if we have any backslashes, replace with fwd slash
-    if(fn)
-      for(int i = 0, j = strlen(fn); i < j; i++) if(fn[i] == '\\') fn[i] = '/';
-    if(!fn) {
+    if (fn)
+      for (int i = 0, j = strlen(fn); i < j; i++)
+        if (fn[i] == '\\')
+          fn[i] = '/';
+    if (!fn) {
       errno = ENOMEM;
       perror(NULL);
-    } else if(ctx->do_check) {
+    } else if (ctx->do_check) {
       // we just want to check if the destination file exists
-      if(access(fn, F_OK) != -1) { // it exists
+      if (access(fn, F_OK) != -1) { // it exists
         ctx->err = errno = EEXIST;
         perror(fn);
       }
-    } else if(ctx->dry) { // just output the name of the file
+    } else if (ctx->dry) { // just output the name of the file
       printf("%s\n", fn);
-    } else if(zsv_mkdirs(fn, 1)) {
+    } else if (zsv_mkdirs(fn, 1)) {
       fprintf(stderr, "Unable to create directories for %s\n", fn);
-    } else if(!((ctx->out = fopen(fn, "wb")))) {
+    } else if (!((ctx->out = fopen(fn, "wb")))) {
       perror(fn);
     } else {
       ctx->out_filepath = fn;
       fn = NULL;
 
       // if it's a JSON file, use a jq filter to pretty-print
-      if(strlen(ctx->out_filepath) > 5 && !zsv_stricmp((const unsigned char *)ctx->out_filepath + strlen(ctx->out_filepath) - 5, (const unsigned char *)".json")) {
+      if (strlen(ctx->out_filepath) > 5 &&
+          !zsv_stricmp((const unsigned char *)ctx->out_filepath + strlen(ctx->out_filepath) - 5,
+                       (const unsigned char *)".json")) {
         ctx->jctx.write1 = zsv_jq_fwrite1;
         ctx->jctx.ctx = ctx->out;
         ctx->jctx.flags = JV_PRINT_PRETTY | JV_PRINT_SPACE1;
         enum zsv_jq_status jqstat;
         ctx->zjq = zsv_jq_new((const unsigned char *)".", jv_to_json_func, &ctx->jctx, &jqstat);
-        if(!ctx->zjq) {
+        if (!ctx->zjq) {
           fprintf(stderr, "zsv_jq_new: unable to open for %s\n", ctx->out_filepath);
           zsv_dir_from_json_close_out(ctx);
         }
@@ -83,7 +86,7 @@ static int zsv_dir_from_json_map_key(yajl_helper_t yh,
 }
 
 static int zsv_dir_from_json_start_obj(yajl_helper_t yh) {
-  if(yajl_helper_level(yh) == 2) {
+  if (yajl_helper_level(yh) == 2) {
     struct zsv_dir_from_json_ctx *ctx = yajl_helper_ctx(yh);
     ctx->in_obj = 1;
     ctx->content_start = yajl_get_bytes_consumed(yajl_helper_yajl(yh)) - 1;
@@ -93,20 +96,19 @@ static int zsv_dir_from_json_start_obj(yajl_helper_t yh) {
 
 // zsv_dir_from_json_flush(): return err
 static int zsv_dir_from_json_flush(yajl_handle yajl, struct zsv_dir_from_json_ctx *ctx) {
-  if(ctx->zjq) {
+  if (ctx->zjq) {
     size_t current_position = yajl_get_bytes_consumed(yajl);
-    if(current_position <= ctx->content_start)
+    if (current_position <= ctx->content_start)
       fprintf(stderr, "Error! zsv_dir_from_json_flush unexpected current position\n");
     else
-      zsv_jq_parse(ctx->zjq, ctx->buff + ctx->content_start,
-                   current_position - ctx->content_start);
+      zsv_jq_parse(ctx->zjq, ctx->buff + ctx->content_start, current_position - ctx->content_start);
     ctx->content_start = 0;
   }
   return 0;
 }
 
 static int zsv_dir_from_json_end_obj(yajl_helper_t yh) {
-  if(yajl_helper_level(yh) == 1) { // just finished level 2
+  if (yajl_helper_level(yh) == 1) { // just finished level 2
     struct zsv_dir_from_json_ctx *ctx = yajl_helper_ctx(yh);
     zsv_dir_from_json_flush(yajl_helper_yajl(yh), yajl_helper_ctx(yh));
     zsv_dir_from_json_close_out(ctx);
@@ -115,21 +117,20 @@ static int zsv_dir_from_json_end_obj(yajl_helper_t yh) {
   return 1;
 }
 
-static int zsv_dir_from_json_process_value(yajl_helper_t yh,
-                                     struct json_value *value) {
-  if(yajl_helper_level(yh) == 1) { // just finished level 2
+static int zsv_dir_from_json_process_value(yajl_helper_t yh, struct json_value *value) {
+  if (yajl_helper_level(yh) == 1) { // just finished level 2
     struct zsv_dir_from_json_ctx *ctx = yajl_helper_ctx(yh);
     const unsigned char *jsstr;
     size_t len;
     json_value_default_string(value, &jsstr, &len);
-    if(ctx->zjq) {
+    if (ctx->zjq) {
       unsigned char *js = len ? zsv_json_from_str_n(jsstr, len) : NULL;
-      if(js)
+      if (js)
         zsv_jq_parse(ctx->zjq, js, strlen((char *)js));
       else
         zsv_jq_parse(ctx->zjq, "null", 4);
       free(js);
-    } else if(len && ctx->out)
+    } else if (len && ctx->out)
       fwrite(jsstr, 1, len, ctx->out);
     zsv_dir_from_json_close_out(ctx);
   }
@@ -143,34 +144,32 @@ static int zsv_dir_from_json_process_value(yajl_helper_t yh,
  * Files named with .json suffix will be exported as JSON (content must be valid JSON)
  * Files named with any other suffix will be exported as a single string value (do not try with large files)
  */
-int zsv_dir_from_json(const unsigned char *target_dir,
-                      FILE *src,
+int zsv_dir_from_json(const unsigned char *target_dir, FILE *src,
                       unsigned int flags, // ZSV_DIR_FLAG_XX
-                      unsigned char _verbose
-                      ) {
+                      unsigned char _verbose) {
   (void)(_verbose);
-  int err   = 0;
+  int err = 0;
   int force = !!(flags & ZSV_DIR_FLAG_FORCE);
-  int dry   = !!(flags & ZSV_DIR_FLAG_DRY);
+  int dry = !!(flags & ZSV_DIR_FLAG_DRY);
   char *tmp_fn = NULL; // only used if force = 0 and src == stdin
-  if(!force) {
+  if (!force) {
     // if input is stdin, we'll need to read it twice, so save it first
     // this isn't the most efficient way to do it, as it reads it 3 times
     // but it's easier and the diff is immaterial
-    if(src == stdin) {
+    if (src == stdin) {
       src = NULL;
       tmp_fn = zsv_get_temp_filename("zsv_prop_XXXXXXXX");
       FILE *tmp_f;
-      if(!tmp_fn) {
+      if (!tmp_fn) {
         err = errno = ENOMEM;
         perror(NULL);
-      } else if(!(tmp_f = fopen(tmp_fn, "wb"))) {
+      } else if (!(tmp_f = fopen(tmp_fn, "wb"))) {
         err = errno;
         perror(tmp_fn);
       } else {
         err = zsv_copy_file_ptr(stdin, tmp_f);
         fclose(tmp_f);
-        if(!(src = fopen(tmp_fn, "rb"))) {
+        if (!(src = fopen(tmp_fn, "rb"))) {
           err = errno;
           perror(tmp_fn);
         }
@@ -178,76 +177,73 @@ int zsv_dir_from_json(const unsigned char *target_dir,
     }
   }
 
-  if(!err) {
+  if (!err) {
     // we will run this loop either once (force) or twice (no force):
     // 1. check before running (no force)
     // 2. do the import
     char do_check = !force;
-    if(do_check && !zsv_dir_exists((const char *)target_dir))
+    if (do_check && !zsv_dir_exists((const char *)target_dir))
       do_check = 0;
 
-    for(int i = do_check ? 0 : 1; i < 2 && !err; i++) {
+    for (int i = do_check ? 0 : 1; i < 2 && !err; i++) {
       do_check = i == 0;
 
       size_t bytes_read;
       yajl_helper_t yh;
-      struct zsv_dir_from_json_ctx ctx = { 0 };
+      struct zsv_dir_from_json_ctx ctx = {0};
       ctx.filepath_prefix = (const char *)target_dir;
 
       int (*start_obj)(yajl_helper_t yh) = NULL;
       int (*end_obj)(yajl_helper_t yh) = NULL;
       int (*process_value)(struct yajl_helper_parse_state *, struct json_value *) = NULL;
 
-      if(do_check)
+      if (do_check)
         ctx.do_check = do_check;
       else {
         ctx.dry = dry;
-        if(!ctx.dry) {
+        if (!ctx.dry) {
           start_obj = zsv_dir_from_json_start_obj;
           end_obj = zsv_dir_from_json_end_obj;
           process_value = zsv_dir_from_json_process_value;
         }
       }
 
-      yh = yajl_helper_new(32,
-                           start_obj, end_obj, // map start/end
-                           zsv_dir_from_json_map_key,
-                           start_obj, end_obj, // array start/end
-                           process_value,
-                           &ctx);
-      if(!yh) {
+      yh = yajl_helper_new(32, start_obj, end_obj,                        // map start/end
+                           zsv_dir_from_json_map_key, start_obj, end_obj, // array start/end
+                           process_value, &ctx);
+      if (!yh) {
         err = errno = ENOMEM;
         perror(NULL);
       } else {
         yajl_handle y = yajl_helper_yajl(yh);
-        while((bytes_read = fread(ctx.buff, 1, sizeof(ctx.buff), src)) > 0) {
-          if(yajl_parse(y, ctx.buff, bytes_read) != yajl_status_ok)
+        while ((bytes_read = fread(ctx.buff, 1, sizeof(ctx.buff), src)) > 0) {
+          if (yajl_parse(y, ctx.buff, bytes_read) != yajl_status_ok)
             yajl_helper_print_err(y, ctx.buff, bytes_read);
-          if(ctx.in_obj)
+          if (ctx.in_obj)
             zsv_dir_from_json_flush(y, &ctx);
         }
-        if(yajl_complete_parse(y) != yajl_status_ok)
+        if (yajl_complete_parse(y) != yajl_status_ok)
           yajl_helper_print_err(y, ctx.buff, bytes_read);
 
-        if(ctx.out) { // e.g. if bad JSON and parse failed
+        if (ctx.out) { // e.g. if bad JSON and parse failed
           fclose(ctx.out);
           free(ctx.out_filepath);
         }
         yajl_helper_delete(yh);
       }
 
-      if(ctx.err)
+      if (ctx.err)
         err = ctx.err;
-      if(i == 0) {
+      if (i == 0) {
         rewind(src);
-        if(errno) {
+        if (errno) {
           err = errno;
           perror(NULL);
         }
       }
     }
   }
-  if(tmp_fn) {
+  if (tmp_fn) {
     unlink(tmp_fn);
     free(tmp_fn);
   }

--- a/app/utils/dirs_to_json.c
+++ b/app/utils/dirs_to_json.c
@@ -10,36 +10,41 @@ struct zsv_dir_foreach_to_json_ctx {
 static int zsv_dir_foreach_to_json(struct zsv_foreach_dirent_handle *h, size_t depth) {
   struct zsv_dir_foreach_to_json_ctx *ctx = h->ctx;
   h->ctx = ctx->zsv_dir_filter.ctx;
-  if(!ctx->zsv_dir_filter.filter(h, depth))
-    h->no_recurse = 1; // skip this node (only matters if node is dir)
-  else if(!h->is_dir) { // process this file
+  if (!ctx->zsv_dir_filter.filter(h, depth))
+    h->no_recurse = 1;   // skip this node (only matters if node is dir)
+  else if (!h->is_dir) { // process this file
     char suffix = 0;
-    if(strlen(h->parent_and_entry) > 5 && !zsv_stricmp((const unsigned char *)h->parent_and_entry + strlen(h->parent_and_entry) - 5, (const unsigned char *)".json"))
+    if (strlen(h->parent_and_entry) > 5 &&
+        !zsv_stricmp((const unsigned char *)h->parent_and_entry + strlen(h->parent_and_entry) - 5,
+                     (const unsigned char *)".json"))
       suffix = 'j'; // json
-    else if(strlen(h->parent_and_entry) > 4 && !zsv_stricmp((const unsigned char *)h->parent_and_entry + strlen(h->parent_and_entry) - 4, (const unsigned char *)".txt"))
+    else if (strlen(h->parent_and_entry) > 4 &&
+             !zsv_stricmp((const unsigned char *)h->parent_and_entry + strlen(h->parent_and_entry) - 4,
+                          (const unsigned char *)".txt"))
       suffix = 't'; // text
-    if(suffix) {
+    if (suffix) {
       // for now, only handle json or txt
       FILE *f = fopen(h->parent_and_entry, "rb");
-      if(!f)
+      if (!f)
         perror(h->parent_and_entry);
       else {
         // create an entry for this file. the map key is the file name; its value is the file contents
-        unsigned char *js = zsv_json_from_str((const unsigned char *)h->parent_and_entry + strlen((const char *)ctx->parent_dir) + 1);
-        if(!js)
+        unsigned char *js =
+          zsv_json_from_str((const unsigned char *)h->parent_and_entry + strlen((const char *)ctx->parent_dir) + 1);
+        if (!js)
           errno = ENOMEM, perror(NULL);
-        else if(*js) {
-          if(ctx->count > 0)
-            if(zsv_jq_parse(ctx->zjq, ",", 1))
+        else if (*js) {
+          if (ctx->count > 0)
+            if (zsv_jq_parse(ctx->zjq, ",", 1))
               ctx->err = 1;
-          if(!ctx->err) {
+          if (!ctx->err) {
             ctx->count++;
-            if(zsv_jq_parse(ctx->zjq, js, strlen((const char *)js)) || zsv_jq_parse(ctx->zjq, ":", 1))
+            if (zsv_jq_parse(ctx->zjq, js, strlen((const char *)js)) || zsv_jq_parse(ctx->zjq, ":", 1))
               ctx->err = 1;
             else {
-              switch(suffix) {
+              switch (suffix) {
               case 'j': // json
-                if(zsv_jq_parse_file(ctx->zjq, f))
+                if (zsv_jq_parse_file(ctx->zjq, f))
                   ctx->err = 1;
                 break;
               case 't': // txt
@@ -48,9 +53,10 @@ static int zsv_dir_foreach_to_json(struct zsv_foreach_dirent_handle *h, size_t d
                   unsigned char buff[4096];
                   size_t n = fread(buff, 1, sizeof(buff), f);
                   unsigned char *txt_js = NULL;
-                  if(n) {
+                  if (n) {
                     txt_js = zsv_json_from_str_n(buff, n);
-                    if(zsv_jq_parse(ctx->zjq, txt_js ? txt_js : (const unsigned char *)"null", txt_js ? strlen((const char *)txt_js) : 4))
+                    if (zsv_jq_parse(ctx->zjq, txt_js ? txt_js : (const unsigned char *)"null",
+                                     txt_js ? strlen((const char *)txt_js) : 4))
                       ctx->err = 1;
                   }
                 }
@@ -77,17 +83,14 @@ static int zsv_dir_foreach_to_json(struct zsv_foreach_dirent_handle *h, size_t d
  * @param parent_dir : directory to export
  * @param dest       : file path to output to, or NULL to output to stdout
  */
-int zsv_dir_to_json(const unsigned char *parent_dir,
-                    const unsigned char *output_filename,
-                    struct zsv_dir_filter *zsv_dir_filter,
-                    unsigned char verbose
-                    ) {
+int zsv_dir_to_json(const unsigned char *parent_dir, const unsigned char *output_filename,
+                    struct zsv_dir_filter *zsv_dir_filter, unsigned char verbose) {
   int err = 0;
   FILE *fdest = output_filename ? fopen((const char *)output_filename, "wb") : stdout;
-  if(!fdest)
+  if (!fdest)
     err = errno, perror((const char *)output_filename);
   else {
-    struct zsv_dir_foreach_to_json_ctx ctx = { 0 };
+    struct zsv_dir_foreach_to_json_ctx ctx = {0};
     ctx.zsv_dir_filter = *zsv_dir_filter;
     ctx.parent_dir = parent_dir;
 
@@ -97,16 +100,16 @@ int zsv_dir_to_json(const unsigned char *parent_dir,
     ctx.jctx.flags = JV_PRINT_PRETTY | JV_PRINT_SPACE1;
     enum zsv_jq_status jqstat;
     ctx.zjq = zsv_jq_new((const unsigned char *)".", jv_to_json_func, &ctx.jctx, &jqstat);
-    if(!ctx.zjq)
+    if (!ctx.zjq)
       err = 1, fprintf(stderr, "zsv_jq_new\n");
     else {
-      if(jqstat == zsv_jq_status_ok && zsv_jq_parse(ctx.zjq, "{", 1) == zsv_jq_status_ok) {
+      if (jqstat == zsv_jq_status_ok && zsv_jq_parse(ctx.zjq, "{", 1) == zsv_jq_status_ok) {
         // export each file
-        zsv_foreach_dirent((const char *)parent_dir, ctx.zsv_dir_filter.max_depth, zsv_dir_foreach_to_json,
-                           &ctx, verbose);
-        if(!ctx.err && zsv_jq_parse(ctx.zjq, "}", 1))
+        zsv_foreach_dirent((const char *)parent_dir, ctx.zsv_dir_filter.max_depth, zsv_dir_foreach_to_json, &ctx,
+                           verbose);
+        if (!ctx.err && zsv_jq_parse(ctx.zjq, "}", 1))
           ctx.err = 1;
-        if(!ctx.err && zsv_jq_finish(ctx.zjq))
+        if (!ctx.err && zsv_jq_finish(ctx.zjq))
           ctx.err = 1;
         zsv_jq_delete(ctx.zjq);
       }

--- a/app/utils/emcc/fs_api.c
+++ b/app/utils/emcc/fs_api.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <sys/stat.h>
-  
+
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #else
@@ -20,14 +20,14 @@ struct fs_data {
 EMSCRIPTEN_KEEPALIVE
 fshandle fsopen(const char *fn, const char *mode) {
   struct fs_data *d = calloc(1, sizeof(*d));
-  if(d)
+  if (d)
     d->f = fopen(fn, mode);
   return d;
 }
 
 EMSCRIPTEN_KEEPALIVE
-int fsclose(fshandle h){
-  if(h) {
+int fsclose(fshandle h) {
+  if (h) {
     int rc = fclose(h->f);
     free(h);
     return rc;
@@ -43,11 +43,11 @@ size_t fswrite(const void *ptr, size_t n, size_t m, fshandle h) {
 EMSCRIPTEN_KEEPALIVE
 void stdflush(int addNewline) {
   fflush(stdout);
-  if(addNewline)
+  if (addNewline)
     fprintf(stdout, "\n");
 
   fflush(stderr);
-  if(addNewline)
+  if (addNewline)
     fprintf(stderr, "\n");
 }
 
@@ -102,20 +102,19 @@ int fsprinterr(const char *s) {
   return 0;
 }
 
-
 /**
  * return single string of entries delimited by newline
  * caller must free()
  */
 EMSCRIPTEN_KEEPALIVE
 char *fsls(const char *dir) {
-  struct dirent *de;  // Pointer for directory entry
-  // opendir() returns a pointer of DIR type. 
-  if(!dir || !*dir)
+  struct dirent *de; // Pointer for directory entry
+  // opendir() returns a pointer of DIR type.
+  if (!dir || !*dir)
     dir = ".";
   DIR *dr = opendir(dir);
-  if(!dr)
-    fprintf(stderr, "Could not open current directory" );
+  if (!dr)
+    fprintf(stderr, "Could not open current directory");
   else {
     size_t total_mem = 0;
     struct tmp_str_list {
@@ -125,10 +124,10 @@ char *fsls(const char *dir) {
     struct tmp_str_list *head = NULL, **tail = &head;
     while ((de = readdir(dr)) != NULL) { // see http://pubs.opengroup.org/onlinepubs/7990989775/xsh/readdir.html
       struct tmp_str_list *tmp = malloc(sizeof(*tmp));
-      if(tmp) {
+      if (tmp) {
         tmp->next = NULL;
         tmp->c = strdup(de->d_name);
-        if(!tmp->c)
+        if (!tmp->c)
           free(tmp);
         else {
           total_mem += (1 + strlen(tmp->c));
@@ -139,21 +138,21 @@ char *fsls(const char *dir) {
     }
 
     char *final_result = NULL;
-    if(total_mem && (final_result = malloc(total_mem + 1))) {
+    if (total_mem && (final_result = malloc(total_mem + 1))) {
       size_t offset = 0;
-      for(struct tmp_str_list *tmp = head, *next; tmp; tmp = next) {
+      for (struct tmp_str_list *tmp = head, *next; tmp; tmp = next) {
         next = tmp->next;
         size_t len = strlen(tmp->c);
         memcpy(final_result + offset, tmp->c, len);
         offset += len + 1;
-        final_result[offset-1] = '\n';
+        final_result[offset - 1] = '\n';
         free(tmp->c);
         free(tmp);
       }
-      final_result[total_mem-1] = '\0';
+      final_result[total_mem - 1] = '\0';
     }
-  
-    closedir(dr);    
+
+    closedir(dr);
     return final_result;
   }
   return NULL;

--- a/app/utils/err.c
+++ b/app/utils/err.c
@@ -9,8 +9,8 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-int zsv_app_printerr(const char *appname, int eno, const char *fmt, ... ) {
-  if(appname && *appname)
+int zsv_app_printerr(const char *appname, int eno, const char *fmt, ...) {
+  if (appname && *appname)
     fprintf(stderr, "(%s) %i: ", appname, eno);
   else
     fprintf(stderr, "%i: ", eno);

--- a/app/utils/file.c
+++ b/app/utils/file.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <unistd.h> // for close()
-#include <fcntl.h> // open
+#include <fcntl.h>  // open
 
 #include <zsv/utils/dirs.h>
 #include <zsv/utils/file.h>
@@ -28,14 +28,14 @@
 char *zsv_get_temp_filename(const char *prefix) {
   TCHAR lpTempPathBuffer[MAX_PATH];
   DWORD dwRetVal = GetTempPath(MAX_PATH,          // length of the buffer
-                         lpTempPathBuffer);       // buffer for path
-  if(dwRetVal > 0 && dwRetVal < MAX_PATH) {
+                               lpTempPathBuffer); // buffer for path
+  if (dwRetVal > 0 && dwRetVal < MAX_PATH) {
     char szTempFileName[MAX_PATH];
     UINT uRetVal = GetTempFileName(lpTempPathBuffer, // directory for tmp files
                                    TEXT(prefix),     // temp file name prefix
                                    0,                // create unique name
                                    szTempFileName);  // buffer for name
-    if(uRetVal > 0)
+    if (uRetVal > 0)
       return strdup(szTempFileName);
   }
   return NULL;
@@ -45,15 +45,15 @@ char *zsv_get_temp_filename(const char *prefix) {
 char *zsv_get_temp_filename(const char *prefix) {
   char *s = NULL;
   char *tmpdir = getenv("TMPDIR");
-  if(!tmpdir)
+  if (!tmpdir)
     tmpdir = ".";
   asprintf(&s, "%s/%s_XXXXXXXX", tmpdir, prefix);
-  if(!s) {
+  if (!s) {
     const char *msg = strerror(errno);
     fprintf(stderr, "%s%c%s: %s\n", tmpdir, FILESLASH, prefix, msg ? msg : "Unknown error");
   } else {
     int fd = mkstemp(s);
-    if(fd > 0) {
+    if (fd > 0) {
       close(fd);
       return s;
     }
@@ -73,18 +73,17 @@ char *zsv_get_temp_filename(const char *prefix) {
  * @return fd needed to pass on to zsv_redirect_file_from_temp
  */
 #if defined(_WIN32) || defined(__FreeBSD__)
-# include <sys/stat.h> // S_IRUSR S_IWUSR
+#include <sys/stat.h> // S_IRUSR S_IWUSR
 #endif
 
-int zsv_redirect_file_to_temp(FILE *f, const char *tempfile_prefix,
-                              char **temp_filename) {
+int zsv_redirect_file_to_temp(FILE *f, const char *tempfile_prefix, char **temp_filename) {
   int new_fd;
   int old_fd = fileno(f);
   fflush(f);
   int bak = dup(old_fd);
   *temp_filename = zsv_get_temp_filename(tempfile_prefix);
 
-  new_fd = open(*temp_filename, O_WRONLY|O_CREAT, S_IRUSR|S_IWUSR);
+  new_fd = open(*temp_filename, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
 
   dup2(new_fd, old_fd);
   close(new_fd);
@@ -101,18 +100,18 @@ void zsv_redirect_file_from_temp(FILE *f, int bak, int old_fd) {
 }
 
 #if defined(_WIN32) || defined(WIN32) || defined(WIN)
-int zsv_file_exists(const char* filename) {
+int zsv_file_exists(const char *filename) {
   DWORD attributes = GetFileAttributes(filename);
   return (attributes != INVALID_FILE_ATTRIBUTES && !(attributes & FILE_ATTRIBUTE_DIRECTORY));
 }
 #else
-# include <sys/stat.h> // S_IRUSR S_IWUSR
+#include <sys/stat.h> // S_IRUSR S_IWUSR
 
-int zsv_file_exists(const char* filename) {
+int zsv_file_exists(const char *filename) {
   struct stat buffer;
-  if(stat(filename, &buffer) == 0) {
+  if (stat(filename, &buffer) == 0) {
     char is_dir = buffer.st_mode & S_IFDIR ? 1 : 0;
-    if(!is_dir)
+    if (!is_dir)
       return 1;
   }
   return 0;
@@ -125,7 +124,7 @@ int zsv_file_exists(const char* filename) {
  */
 int zsv_copy_file(const char *src, const char *dest) {
   // create one or more directories if needed
-  if(zsv_mkdirs(dest, 1)) {
+  if (zsv_mkdirs(dest, 1)) {
     fprintf(stderr, "Unable to create directories needed for %s\n", dest);
     return -1;
   }
@@ -133,15 +132,15 @@ int zsv_copy_file(const char *src, const char *dest) {
   // copy the file
   int err = 0;
   FILE *fsrc = fopen(src, "rb");
-  if(!fsrc)
+  if (!fsrc)
     err = errno ? errno : -1, perror(src);
   else {
     FILE *fdest = fopen(dest, "wb");
-    if(!fdest)
+    if (!fdest)
       err = errno ? errno : -1, perror(dest);
     else {
       err = zsv_copy_file_ptr(fsrc, fdest);
-      if(err)
+      if (err)
         perror(dest);
       fclose(fdest);
     }
@@ -158,8 +157,8 @@ int zsv_copy_file_ptr(FILE *src, FILE *dest) {
   int err = 0;
   char buffer[4096];
   size_t bytes_read;
-  while((bytes_read = fread(buffer, 1, sizeof(buffer), src)) > 0) {
-    if(fwrite(buffer, 1, bytes_read, dest) != bytes_read) {
+  while ((bytes_read = fread(buffer, 1, sizeof(buffer), src)) > 0) {
+    if (fwrite(buffer, 1, bytes_read, dest) != bytes_read) {
       err = errno ? errno : -1;
       break;
     }
@@ -168,8 +167,8 @@ int zsv_copy_file_ptr(FILE *src, FILE *dest) {
 }
 
 size_t zsv_dir_len_basename(const char *filepath, const char **basename) {
-  for(size_t len = strlen(filepath); len; len--) {
-    if(filepath[len-1] == '/' || filepath[len-1] == '\\') {
+  for (size_t len = strlen(filepath); len; len--) {
+    if (filepath[len - 1] == '/' || filepath[len - 1] == '\\') {
       *basename = filepath + len;
       return len - 1;
     }
@@ -182,18 +181,18 @@ size_t zsv_dir_len_basename(const char *filepath, const char **basename) {
 int zsv_file_readable(const char *filename, int *err, FILE **f_out) {
   FILE *f;
   int rc;
-  if(err)
+  if (err)
     *err = 0;
   // to do: use fstat()
-  if((f = fopen(filename, "rb")) == NULL) {
+  if ((f = fopen(filename, "rb")) == NULL) {
     rc = 0;
-    if(err)
+    if (err)
       *err = errno;
     else
       perror(filename);
   } else {
     rc = 1;
-    if(f_out)
+    if (f_out)
       *f_out = f;
     else
       fclose(f);

--- a/app/utils/json.c
+++ b/app/utils/json.c
@@ -26,7 +26,7 @@ static void str2hex(unsigned char *to, const unsigned char *p, size_t len) {
 static inline unsigned json_esc_char(unsigned char c, char replace[]) {
   unsigned replacelen;
   char hex = 0;
-  switch(c) {
+  switch (c) {
   case '"':
     replace[1] = '"';
     break;
@@ -49,16 +49,16 @@ static inline unsigned json_esc_char(unsigned char c, char replace[]) {
     replace[1] = 't';
     break;
   default:
-    hex=1;
+    hex = 1;
   }
 
   replace[0] = '\\';
-  if(hex) {
+  if (hex) {
     // unicode-hex: but 2/3 are not always zeroes...
     replace[1] = 'u';
     replace[2] = '0';
     replace[3] = '0';
-    str2hex((unsigned char *)replace+4, &c, 1);
+    str2hex((unsigned char *)replace + 4, &c, 1);
     replacelen = 6;
     replace[6] = '\0';
   } else {
@@ -70,7 +70,7 @@ static inline unsigned json_esc_char(unsigned char c, char replace[]) {
 
 static unsigned json_escaped_str_len(const unsigned char *s, size_t len) {
   unsigned count = 0;
-  for(size_t i = 0; i < len; i++, count++) {
+  for (size_t i = 0; i < len; i++, count++) {
     switch (s[i]) {
     case '"':
     case '\\':
@@ -93,14 +93,14 @@ static unsigned json_escaped_str_len(const unsigned char *s, size_t len) {
 unsigned char *zsv_json_from_str_n(const unsigned char *s, size_t len) {
   size_t new_len = json_escaped_str_len(s, len);
   unsigned char *new_s = calloc(new_len + 2, sizeof(*new_s));
-  if(new_s) {
-    new_s[0] = new_s[new_len-1] = (unsigned char) '"';
-    if(new_len == len + 2)
+  if (new_s) {
+    new_s[0] = new_s[new_len - 1] = (unsigned char)'"';
+    if (new_len == len + 2)
       memcpy(new_s + 1, s, len);
     else {
       char replace[8];
-      for(size_t i = 0, j = 1; i < len && j < new_len - 1; i++) {
-        if(!is_json_esc_char(s[i]))
+      for (size_t i = 0, j = 1; i < len && j < new_len - 1; i++) {
+        if (!is_json_esc_char(s[i]))
           new_s[j++] = s[i];
         else {
           size_t rlen = json_esc_char(s[i], replace);
@@ -114,7 +114,7 @@ unsigned char *zsv_json_from_str_n(const unsigned char *s, size_t len) {
 }
 
 unsigned char *zsv_json_from_str(const unsigned char *s) {
-  if(!s)
+  if (!s)
     return (unsigned char *)strdup("null");
   return zsv_json_from_str_n(s, strlen((const char *)s));
 }

--- a/app/utils/mem.c
+++ b/app/utils/mem.c
@@ -12,7 +12,7 @@
 /* zsv_memdup(): return copy with double-NULL terminator. caller must free() */
 void *zsv_memdup(const void *src, size_t n) {
   void *m = calloc(1, n + 2);
-  if(n)
+  if (n)
     memcpy(m, src, n);
   return m;
 }

--- a/app/utils/memmem.c
+++ b/app/utils/memmem.c
@@ -1,4 +1,5 @@
 // from musl 1.37.5 system/lib/libc/musl/src/string/memmem.c
+// clang-format off
 #include <string.h>
 #include <stdint.h>
 static char *twobyte_memmem(const unsigned char *h, size_t k, const unsigned char *n)

--- a/app/utils/os.c
+++ b/app/utils/os.c
@@ -49,8 +49,7 @@ void zsv_win_to_unicode(const void *path, wchar_t *wbuf, size_t wbuf_len) {
    * match the original, something is fishy, reject. */
   memset(wbuf, 0, wbuf_len * sizeof(wchar_t));
   MultiByteToWideChar(CP_UTF8, 0, buf, -1, wbuf, (int)wbuf_len);
-  WideCharToMultiByte(CP_UTF8, 0, wbuf, (int)wbuf_len, buf2,
-                      sizeof(buf2), NULL, NULL);
+  WideCharToMultiByte(CP_UTF8, 0, wbuf, (int)wbuf_len, buf2, sizeof(buf2), NULL, NULL);
   if (strcmp(buf, buf2) != 0) {
     wbuf[0] = L'\0';
   }
@@ -64,42 +63,31 @@ int zsv_replace_file(const void *src, const void *dest) {
   zsv_win_to_unicode(dest, wdest, ARRAY_SIZE(wdest));
   zsv_win_to_unicode(src, wsrc, ARRAY_SIZE(wsrc));
 
-  if(MoveFileExW(wsrc, wdest, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) // success
+  if (MoveFileExW(wsrc, wdest, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) // success
     return 0;
 
-  if(GetLastError() == 2) // file not found, could be target. use simple rename
+  if (GetLastError() == 2)        // file not found, could be target. use simple rename
     return _wrename(wsrc, wdest); // returns 0 on success
 
   return 1; // fail
 }
 
-
 void zsv_win_printLastError() {
   DWORD dw = GetLastError();
   LPVOID lpMsgBuf;
   LPVOID lpDisplayBuf;
-  FormatMessage(
-                FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                FORMAT_MESSAGE_FROM_SYSTEM |
-                FORMAT_MESSAGE_IGNORE_INSERTS,
-                NULL,
-                dw,
-                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                (LPTSTR) &lpMsgBuf,
-                0, NULL );
+  FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, dw,
+                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&lpMsgBuf, 0, NULL);
   // Display the error message and exit the process
-  lpDisplayBuf = (LPVOID)LocalAlloc(LMEM_ZEROINIT,
-                                    (lstrlen((LPCTSTR)lpMsgBuf) + 40) * sizeof(TCHAR));
-  StringCchPrintf((LPTSTR)lpDisplayBuf,
-                  LocalSize(lpDisplayBuf) / sizeof(TCHAR),
-                  TEXT("%s\r\n"), lpMsgBuf);
+  lpDisplayBuf = (LPVOID)LocalAlloc(LMEM_ZEROINIT, (lstrlen((LPCTSTR)lpMsgBuf) + 40) * sizeof(TCHAR));
+  StringCchPrintf((LPTSTR)lpDisplayBuf, LocalSize(lpDisplayBuf) / sizeof(TCHAR), TEXT("%s\r\n"), lpMsgBuf);
   fprintf(stderr, "%s\r\n", (LPCTSTR)lpDisplayBuf);
   LocalFree(lpMsgBuf);
   LocalFree(lpDisplayBuf);
 }
 
 void zsv_perror(const char *s) {
-  if(s && *s)
+  if (s && *s)
     fwrite(s, 1, strlen(s), stderr);
   zsv_win_printLastError(0);
 }

--- a/app/utils/prop.c
+++ b/app/utils/prop.c
@@ -8,29 +8,26 @@
 #include <zsv/utils/file.h>
 #include <yajl_helper/yajl_helper.h>
 
-
-//////
-///////////
 #ifndef ZSVTLS
-# ifndef NO_THREADING
-#  define ZSVTLS _Thread_local
-# else
-#  define ZSVTLS
-# endif
+#ifndef NO_THREADING
+#define ZSVTLS _Thread_local
+#else
+#define ZSVTLS
 #endif
-/// see arg.c
+#endif
+// see arg.c
 
 static struct zsv_prop_handler *zsv_with_default_custom_prop_handler(char mode) {
   ZSVTLS static char zsv_default_custom_prop_handler_initd = 0;
-  ZSVTLS static struct zsv_prop_handler zsv_default_custom_prop_handler = { 0 };
+  ZSVTLS static struct zsv_prop_handler zsv_default_custom_prop_handler = {0};
 
-  switch(mode) {
+  switch (mode) {
   case 'c': // clear
     memset(&zsv_default_custom_prop_handler, 0, sizeof(zsv_default_custom_prop_handler));
     zsv_default_custom_prop_handler_initd = 0;
     break;
   case 'g': // get
-    if(!zsv_default_custom_prop_handler_initd) {
+    if (!zsv_default_custom_prop_handler_initd) {
       zsv_default_custom_prop_handler_initd = 1;
       zsv_default_custom_prop_handler.handler = NULL;
       zsv_default_custom_prop_handler.ctx = NULL;
@@ -54,13 +51,10 @@ ZSV_EXPORT
 void zsv_set_default_custom_prop_handler(struct zsv_prop_handler custom_prop_handler) {
   *zsv_with_default_custom_prop_handler(0) = custom_prop_handler;
 }
-///////////
 
-
-// to do: import these through a proper header
+// TO DO: import these through a proper header
 static int zsv_properties_parse_process_value(yajl_helper_t yh, struct json_value *value);
-unsigned char *zsv_cache_filepath(const unsigned char *data_filepath,
-                                  enum zsv_cache_type type, char create_dir,
+unsigned char *zsv_cache_filepath(const unsigned char *data_filepath, enum zsv_cache_type type, char create_dir,
                                   char temp_file);
 
 struct zsv_properties_parser {
@@ -72,7 +66,6 @@ struct zsv_properties_parser {
   struct zsv_opts *opts;
   struct zsv_prop_handler *custom_prop_handler;
   const unsigned char *filepath; // path to this properties file
-
 };
 
 const unsigned char *zsv_properties_parser_get_filepath(void *p_) {
@@ -95,19 +88,17 @@ struct zsv_opts *zsv_properties_parser_get_opts(void *p_) {
  */
 struct zsv_properties_parser *zsv_properties_parser_new(const unsigned char *path,
                                                         struct zsv_prop_handler *custom_prop_handler,
-                                                        struct zsv_file_properties *fp,
-                                                        struct zsv_opts *opts) {
+                                                        struct zsv_file_properties *fp, struct zsv_opts *opts) {
   struct zsv_properties_parser *parser = calloc(1, sizeof(*parser));
-  if(parser) {
+  if (parser) {
     parser->yh = yajl_helper_new(32,
                                  NULL, // start_map,
                                  NULL, // end_map,
                                  NULL, // map_key,
                                  NULL, // start_array,
                                  NULL, // end_array,
-                                 zsv_properties_parse_process_value,
-                                 parser);
-    if(!parser->yh)
+                                 zsv_properties_parse_process_value, parser);
+    if (!parser->yh)
       free(parser);
     else {
       parser->custom_prop_handler = custom_prop_handler;
@@ -126,7 +117,7 @@ struct zsv_properties_parser *zsv_properties_parser_new(const unsigned char *pat
  * Finished parsing
  */
 enum zsv_status zsv_properties_parse_complete(struct zsv_properties_parser *parser) {
-  if(parser && parser->stat == yajl_status_ok)
+  if (parser && parser->stat == yajl_status_ok)
     parser->stat = yajl_complete_parse(yajl_helper_yajl(parser->yh));
   return parser && parser->stat == yajl_status_ok ? zsv_status_ok : zsv_status_error;
 }
@@ -139,7 +130,6 @@ enum zsv_status zsv_properties_parser_destroy(struct zsv_properties_parser *pars
   yajl_status stat = parser->stat;
   free(parser);
   return stat == yajl_status_ok ? zsv_status_ok : zsv_status_error;
-
 }
 
 /**
@@ -154,45 +144,44 @@ enum zsv_status zsv_properties_parser_destroy(struct zsv_properties_parser *pars
  * @param cmd_opts_used (optional) cmd option codes to skip + warn if found
  * @return zsv_status_ok on success
  */
-struct zsv_file_properties zsv_cache_load_props(const char *data_filepath,
-                                                struct zsv_opts *opts,
+struct zsv_file_properties zsv_cache_load_props(const char *data_filepath, struct zsv_opts *opts,
                                                 struct zsv_prop_handler *custom_prop_handler,
                                                 const char *cmd_opts_used) {
   // we need some memory to save the parsed properties
   // if the caller did not provide that, use our own
-  struct zsv_file_properties tmp = { 0 };
-  if(!(data_filepath && *data_filepath)) return tmp; // e.g. input = stdin
+  struct zsv_file_properties tmp = {0};
+  if (!(data_filepath && *data_filepath))
+    return tmp; // e.g. input = stdin
 
   struct zsv_file_properties *fp = &tmp;
   struct zsv_properties_parser *p = NULL;
-  unsigned char *fn = zsv_cache_filepath((const unsigned char *)data_filepath,
-                                         zsv_cache_type_property, 0, 0);
-  if(!fn)
+  unsigned char *fn = zsv_cache_filepath((const unsigned char *)data_filepath, zsv_cache_type_property, 0, 0);
+  if (!fn)
     tmp.stat = zsv_status_memory;
   else {
     FILE *f;
     int err;
-    if(!zsv_file_readable((char *)fn, &err, &f)) {
-      if(err != ENOENT) {
+    if (!zsv_file_readable((char *)fn, &err, &f)) {
+      if (err != ENOENT) {
         perror((const char *)fn);
         tmp.stat = zsv_status_error;
       }
     } else {
       p = zsv_properties_parser_new(fn, custom_prop_handler, fp, opts);
-      if(!p)
+      if (!p)
         tmp.stat = zsv_status_memory;
-      else if(p->stat != yajl_status_ok)
+      else if (p->stat != yajl_status_ok)
         tmp.stat = zsv_status_error;
       else {
         unsigned char buff[1024];
         size_t bytes_read;
-        while((bytes_read = fread(buff, 1, sizeof(buff), f))) {
-          if((p->stat = yajl_parse(yajl_helper_yajl(p->yh), buff, bytes_read)) != yajl_status_ok) {
+        while ((bytes_read = fread(buff, 1, sizeof(buff), f))) {
+          if ((p->stat = yajl_parse(yajl_helper_yajl(p->yh), buff, bytes_read)) != yajl_status_ok) {
             tmp.stat = zsv_status_error;
             break;
           }
         }
-        if(tmp.stat == zsv_status_ok)
+        if (tmp.stat == zsv_status_ok)
           zsv_properties_parse_complete(p);
       }
       fclose(f);
@@ -200,24 +189,22 @@ struct zsv_file_properties zsv_cache_load_props(const char *data_filepath,
     free(fn);
   }
 
-  if(tmp.stat == zsv_status_ok) {
+  if (tmp.stat == zsv_status_ok) {
     // warn if the loaded properties conflict with command-line options
-    if(fp->skip_specified) {
-      if(cmd_opts_used && strchr(cmd_opts_used, 'R'))
+    if (fp->skip_specified) {
+      if (cmd_opts_used && strchr(cmd_opts_used, 'R'))
         fprintf(stderr, "Warning: file property 'skip-head' overridden by command option\n");
-      else if(opts)
+      else if (opts)
         opts->rows_to_ignore = fp->skip;
     }
-    if(fp->header_span_specified) {
-      if(cmd_opts_used && strchr(cmd_opts_used, 'd'))
+    if (fp->header_span_specified) {
+      if (cmd_opts_used && strchr(cmd_opts_used, 'd'))
         fprintf(stderr, "Warning: file property 'header-row-span' overridden by command option\n");
-      else if(opts)
+      else if (opts)
         opts->header_span = fp->header_span;
     }
   }
-  if(p && tmp.stat == zsv_status_ok
-     && zsv_properties_parser_destroy(p) != zsv_status_ok
-     )
+  if (p && tmp.stat == zsv_status_ok && zsv_properties_parser_destroy(p) != zsv_status_ok)
     tmp.stat = zsv_status_error;
   return tmp;
 }
@@ -225,34 +212,34 @@ struct zsv_file_properties zsv_cache_load_props(const char *data_filepath,
 static int zsv_properties_parse_process_value(yajl_helper_t yh, struct json_value *value) {
   struct zsv_properties_parser *parser = yajl_helper_ctx(yh);
   struct zsv_file_properties *fp = parser->fp;
-  if(yajl_helper_level_raw(yh) == 1) {
+  if (yajl_helper_level_raw(yh) == 1) {
     const char *prop_name = yajl_helper_get_map_key(yh, 0);
     unsigned int *target = NULL;
-    if(!strcmp(prop_name, "skip-head")) {
+    if (!strcmp(prop_name, "skip-head")) {
       target = &fp->skip;
       fp->skip_specified = 1;
-    } else if(!strcmp(prop_name, "header-row-span")) {
+    } else if (!strcmp(prop_name, "header-row-span")) {
       target = &fp->header_span;
       fp->header_span_specified = 1;
     }
 
-    if(!target) {
+    if (!target) {
       int rc = 1;
       struct zsv_prop_handler *custom_prop_handler = parser->custom_prop_handler;
-      if(custom_prop_handler && custom_prop_handler->handler)
+      if (custom_prop_handler && custom_prop_handler->handler)
         rc = custom_prop_handler->handler(parser, prop_name, value);
-      if(rc) {
+      if (rc) {
         fprintf(stderr, "Unrecognized property: %s\n", prop_name);
         fp->stat = zsv_status_error;
       }
     } else {
       int err = 0;
       long long i = json_value_long(value, &err);
-      if(err || i < 0 || i > UINT_MAX) {
+      if (err || i < 0 || i > UINT_MAX) {
         fp->stat = zsv_status_error;
         fprintf(stderr, "Invalid %s property value: should be an integer between 0 and %u", prop_name, UINT_MAX);
       } else
-        *target = (unsigned int) i;
+        *target = (unsigned int)i;
     }
   }
   return 1;
@@ -267,20 +254,15 @@ static int zsv_properties_parse_process_value(yajl_helper_t yh, struct json_valu
  *
  * optional `struct zsv_file_properties` supports custom file property processing
  */
-enum zsv_status zsv_new_with_properties(struct zsv_opts *opts,
-                                        struct zsv_prop_handler *custom_prop_handler,
-                                        const char *input_path,
-                                        const char *opts_used,
-                                        zsv_parser *handle_out
-                                        ) {
+enum zsv_status zsv_new_with_properties(struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler,
+                                        const char *input_path, const char *opts_used, zsv_parser *handle_out) {
   *handle_out = NULL;
-  if(input_path) {
-    struct zsv_file_properties fp =
-      zsv_cache_load_props(input_path, opts, custom_prop_handler, opts_used);
-    if(fp.stat != zsv_status_ok)
+  if (input_path) {
+    struct zsv_file_properties fp = zsv_cache_load_props(input_path, opts, custom_prop_handler, opts_used);
+    if (fp.stat != zsv_status_ok)
       return fp.stat;
   }
-  if((*handle_out = zsv_new(opts)))
+  if ((*handle_out = zsv_new(opts)))
     return zsv_status_ok;
   return zsv_status_memory;
 }

--- a/app/utils/signal.c
+++ b/app/utils/signal.c
@@ -16,8 +16,8 @@ volatile sig_atomic_t zsv_signal_interrupted = 0;
 #include <windows.h>
 
 static int consoleHandler(DWORD signal) {
-  if(signal == CTRL_C_EVENT) {
-    if(!zsv_signal_interrupted) {
+  if (signal == CTRL_C_EVENT) {
+    if (!zsv_signal_interrupted) {
       zsv_signal_interrupted = 1;
       fclose(stdin);
       return 1;
@@ -27,7 +27,7 @@ static int consoleHandler(DWORD signal) {
 }
 
 void zsv_handle_ctrl_c_signal() {
-  if(!SetConsoleCtrlHandler(consoleHandler, 1))
+  if (!SetConsoleCtrlHandler(consoleHandler, 1))
     fprintf(stderr, "Warning: unable to set signal handler\n");
 }
 
@@ -38,7 +38,7 @@ void zsv_handle_ctrl_c_signal() {
 
 static void INThandler(int sig) {
   signal(sig, SIG_IGN); // ignore
-  if(!zsv_signal_interrupted) {
+  if (!zsv_signal_interrupted) {
     zsv_signal_interrupted = 1;
     signal(SIGINT, NULL); // restore default handler
   }

--- a/app/utils/string.c
+++ b/app/utils/string.c
@@ -29,17 +29,17 @@ static utf8proc_int32_t utf8proc_tolower1(utf8proc_int32_t codepoint, void *data
 }
 
 static unsigned char *utf8proc_tolower_str(const unsigned char *str, size_t *len) {
-  // note: for some unknown reason, this func intermittently can fail on win (compiled w mingw64) when called in a tight loop
-  // may be related to realloc()
+  // note: for some unknown reason, this func intermittently can fail on win (compiled w mingw64) when called in a tight
+  // loop may be related to realloc()
   utf8proc_uint8_t *output;
-  utf8proc_option_t options = { 0 };
+  utf8proc_option_t options = {0};
   /* options = UTF8PROC_COMPOSE | UTF8PROC_COMPAT
   | UTF8PROC_CASEFOLD | UTF8PROC_IGNORE | UTF8PROC_STRIPMARK | UTF8PROC_STRIPCC | UTF8PROC_STRIPNA;
   */
   // utf8proc_map_custom allocates new mem
   options = UTF8PROC_STRIPNA;
-  *len = (size_t) utf8proc_map_custom((const utf8proc_uint8_t *)str, (utf8proc_ssize_t)*len, &output,
-                                      options, utf8proc_tolower1, NULL);
+  *len = (size_t)utf8proc_map_custom((const utf8proc_uint8_t *)str, (utf8proc_ssize_t)*len, &output, options,
+                                     utf8proc_tolower1, NULL);
   return (unsigned char *)output;
 }
 #endif // ndef NO_UTF8PROC
@@ -49,9 +49,9 @@ unsigned char *zsv_strtolowercase(const unsigned char *s, size_t *lenp) {
 #ifndef NO_UTF8PROC
   size_t len_orig = *lenp;
   unsigned char *new_s = utf8proc_tolower_str(s, lenp);
-  if(!new_s && len_orig) { //
+  if (!new_s && len_orig) { //
     unsigned char *tmp_s = malloc(len_orig + 1);
-    if(tmp_s) {
+    if (tmp_s) {
       fprintf(stderr, "Warning: malformed UTF8 '%.*s'\n", (int)len_orig, s);
       memcpy(tmp_s, s, len_orig);
       tmp_s[len_orig] = '\0';
@@ -60,10 +60,10 @@ unsigned char *zsv_strtolowercase(const unsigned char *s, size_t *lenp) {
       free(tmp_s);
     }
   }
-#else // ndef NO_UTF8PROC
+#else  // ndef NO_UTF8PROC
   unsigned char *new_s = malloc((*lenp + 1) * sizeof(*new_s));
-  if(new_s) {
-    for(size_t i = 0, j = *lenp; i < j; i++)
+  if (new_s) {
+    for (size_t i = 0, j = *lenp; i < j; i++)
       new_s[i] = tolower(s[i]);
     new_s[*lenp] = '\0';
   }
@@ -73,9 +73,7 @@ unsigned char *zsv_strtolowercase(const unsigned char *s, size_t *lenp) {
 
 // zsv_strstr(): strstr
 const unsigned char *zsv_strstr(const unsigned char *hay, const unsigned char *needle) {
-  return (const unsigned char *)strstr(
-                                       (const char *)hay,
-                                       (const char *)needle);
+  return (const unsigned char *)strstr((const char *)hay, (const char *)needle);
 }
 
 /*
@@ -91,14 +89,14 @@ int zsv_stricmp(const unsigned char *s1, const unsigned char *s2) {
 }
 
 int zsv_strincmp_ascii(const unsigned char *s1, size_t len1, const unsigned char *s2, size_t len2) {
-  while(len1 && len2) {
-    if(!*s1)
+  while (len1 && len2) {
+    if (!*s1)
       return *s2 == 0 ? 0 : -1;
-    if(!*s2)
+    if (!*s2)
       return 1;
     int c1 = tolower(*s1);
     int c2 = tolower(*s2);
-    if(c1 == c2) {
+    if (c1 == c2) {
       s1++, s2++, len1--, len2--;
     } else
       return c1 < c2 ? -1 : 1;
@@ -111,7 +109,7 @@ int zsv_strincmp(const unsigned char *s1, size_t len1, const unsigned char *s2, 
   unsigned char *lc1 = zsv_strtolowercase(s1, &len1);
   unsigned char *lc2 = zsv_strtolowercase(s2, &len2);
   int result;
-  if(VERY_UNLIKELY(!lc1 || !lc2))
+  if (VERY_UNLIKELY(!lc1 || !lc2))
     fprintf(stderr, "Out of memory!\n"), result = -2;
   else
     result = strcmp((char *)lc1, (char *)lc2);
@@ -123,18 +121,17 @@ int zsv_strincmp(const unsigned char *s1, size_t len1, const unsigned char *s2, 
 #endif
 }
 
-__attribute__((always_inline)) static inline const unsigned char *zsv_strtrim_left_inline(const char unsigned * restrict s, size_t *lenp) {
+__attribute__((always_inline)) static inline const unsigned char *zsv_strtrim_left_inline(
+  const char unsigned *restrict s, size_t *lenp) {
   utf8proc_ssize_t bytes_read;
   utf8proc_int32_t codepoint = 0;
   size_t len = *lenp;
   utf8proc_category_t category;
 
   // trim front
-  while((bytes_read = zsv_strnext(s, len, &codepoint)) > 0
-        && ((category = utf8proc_category(codepoint)) == UTF8PROC_CATEGORY_ZS
-            || category == UTF8PROC_CATEGORY_ZL
-            || category == UTF8PROC_CATEGORY_ZP
-            )) {
+  while ((bytes_read = zsv_strnext(s, len, &codepoint)) > 0 &&
+         ((category = utf8proc_category(codepoint)) == UTF8PROC_CATEGORY_ZS || category == UTF8PROC_CATEGORY_ZL ||
+          category == UTF8PROC_CATEGORY_ZP)) {
     s += bytes_read;
     len -= bytes_read;
   }
@@ -142,42 +139,41 @@ __attribute__((always_inline)) static inline const unsigned char *zsv_strtrim_le
   return s;
 }
 
-__attribute__((always_inline)) static inline const unsigned char *zsv_strtrim_right_inline(const char unsigned * restrict s, size_t *lenp) {
+__attribute__((always_inline)) static inline const unsigned char *zsv_strtrim_right_inline(
+  const char unsigned *restrict s, size_t *lenp) {
   utf8proc_ssize_t bytes_read;
   utf8proc_int32_t codepoint = 0;
   size_t len = *lenp;
   utf8proc_category_t category;
 
   // trim back
-  while((bytes_read = zsv_strlast(s, len, (int32_t *)&codepoint)) > 0
-        && ((category = utf8proc_category(codepoint)) == UTF8PROC_CATEGORY_ZS
-            || category == UTF8PROC_CATEGORY_ZL
-            || category == UTF8PROC_CATEGORY_ZP
-            )) {
+  while ((bytes_read = zsv_strlast(s, len, (int32_t *)&codepoint)) > 0 &&
+         ((category = utf8proc_category(codepoint)) == UTF8PROC_CATEGORY_ZS || category == UTF8PROC_CATEGORY_ZL ||
+          category == UTF8PROC_CATEGORY_ZP)) {
     len -= bytes_read;
   }
   *lenp = len;
   return s;
 }
 
-const unsigned char *zsv_strtrim_right(const char unsigned * restrict s, size_t *lenp) {
+const unsigned char *zsv_strtrim_right(const char unsigned *restrict s, size_t *lenp) {
   return zsv_strtrim_right_inline(s, lenp);
 }
 
-const unsigned char *zsv_strtrim_left(const char unsigned * restrict s, size_t *lenp) {
+const unsigned char *zsv_strtrim_left(const char unsigned *restrict s, size_t *lenp) {
   return zsv_strtrim_left_inline(s, lenp);
 }
 
-const unsigned char *zsv_strtrim(const char unsigned * restrict s, size_t *lenp) {
+const unsigned char *zsv_strtrim(const char unsigned *restrict s, size_t *lenp) {
   s = zsv_strtrim_left_inline(s, lenp);
   return zsv_strtrim_right_inline(s, lenp);
 }
 
 size_t zsv_strnext(const unsigned char *s, size_t len, int32_t *codepoint) {
   utf8proc_ssize_t bytes_read = utf8proc_iterate(s, len, (utf8proc_int32_t *)codepoint);
-  if(bytes_read < 1)
+  if (bytes_read < 1)
     return 0;
-  return (size_t) bytes_read;
+  return (size_t)bytes_read;
 }
 
 /**
@@ -185,14 +181,14 @@ size_t zsv_strnext(const unsigned char *s, size_t len, int32_t *codepoint) {
  */
 __attribute__((always_inline)) static inline size_t zsv_strlast_position(const unsigned char *s, size_t len) {
   // from the end, search backwards for the first byte that begins with 0 or 11
-  while(len && !(s[len-1] < 128 || s[len-1] >= 192))
+  while (len && !(s[len - 1] < 128 || s[len - 1] >= 192))
     len--;
   return len;
 }
 
 size_t zsv_strlast(const unsigned char *s, size_t len, int32_t *codepoint) {
   size_t position = zsv_strlast_position(s, len);
-  if(position) {
+  if (position) {
     position--;
     return zsv_strnext(s + position, len - position, codepoint);
   }
@@ -205,9 +201,9 @@ size_t zsv_strlast(const unsigned char *s, size_t len, int32_t *codepoint) {
 size_t zsv_strnext_is_currency(const unsigned char *s, size_t len) {
   utf8proc_int32_t codepoint;
   utf8proc_ssize_t bytes_read = utf8proc_iterate(s, len, &codepoint);
-  if(VERY_LIKELY(bytes_read > 0)) {
+  if (VERY_LIKELY(bytes_read > 0)) {
     utf8proc_category_t category = utf8proc_category(codepoint);
-    if(category == UTF8PROC_CATEGORY_SC)
+    if (category == UTF8PROC_CATEGORY_SC)
       return (size_t)bytes_read;
   }
   return 0;
@@ -217,13 +213,14 @@ size_t zsv_strnext_is_currency(const unsigned char *s, size_t len) {
  *  Check if the next char is a plus or minus. If so, return its length, else return 0
  */
 size_t zsv_strnext_is_sign(const unsigned char *s, size_t len) {
-  if(len && *s == '+') return 1;
+  if (len && *s == '+')
+    return 1;
 
   utf8proc_int32_t codepoint;
   utf8proc_ssize_t bytes_read = utf8proc_iterate(s, len, &codepoint);
-  if(VERY_LIKELY(bytes_read > 0)) {
+  if (VERY_LIKELY(bytes_read > 0)) {
     utf8proc_category_t category = utf8proc_category(codepoint);
-    if(category == UTF8PROC_CATEGORY_PD)
+    if (category == UTF8PROC_CATEGORY_PD)
       return (size_t)bytes_read;
   }
   return 0;
@@ -242,22 +239,22 @@ size_t zsv_strwhite(unsigned char *s, size_t len, unsigned int flags) {
   char replacement = ' ';
   int clen;
 
-  for(size_t i = 0; i < len; i += clen) {
+  for (size_t i = 0; i < len; i += clen) {
 #ifndef NO_UTF8PROC
     clen = ZSV_UTF8_CHARLEN(s[i]);
     this_is_space = 0;
-    if(UNLIKELY(clen < 1 || i + clen > len)) { // bad UTF8. replace w '?'
+    if (UNLIKELY(clen < 1 || i + clen > len)) { // bad UTF8. replace w '?'
       clen = 1;
       s[i] = '?';
-    } else if(UNLIKELY(clen > 1)) { // multi-byte UTF8
+    } else if (UNLIKELY(clen > 1)) { // multi-byte UTF8
       utf8proc_int32_t codepoint;
       utf8proc_ssize_t bytes_read = utf8proc_iterate(s + i, clen, &codepoint);
-      if(UNLIKELY(bytes_read < 1)) { // error! but this could only happen if ZSV_UTF8_CHARLEN was wrong
+      if (UNLIKELY(bytes_read < 1)) { // error! but this could only happen if ZSV_UTF8_CHARLEN was wrong
         clen = 1;
         s[i] = '?';
       } else {
         utf8proc_category_t category = utf8proc_category(codepoint);
-        switch(category) { // Unicode space categories
+        switch (category) {        // Unicode space categories
         case UTF8PROC_CATEGORY_ZL: // line separator
         case UTF8PROC_CATEGORY_ZP: // paragraph separator
           this_is_space = 1;
@@ -274,24 +271,24 @@ size_t zsv_strwhite(unsigned char *s, size_t len, unsigned int flags) {
     } else { // regular ascii, clen == 1
       this_is_space = isspace(s[i]);
     }
-#else // no UTF8PROC, assume clen = 1
+#else  // no UTF8PROC, assume clen = 1
     {
       clen = 1;
       this_is_space = isspace(s[i]);
     }
 #endif // ndef NO_UTF8PROC
 
-    if(this_is_space) {
-      if(UNLIKELY((s[i] == '\n' || s[i] == '\r')) && !(flags & ZSV_STRWHITE_FLAG_NO_EMBEDDED_NEWLINE))
+    if (this_is_space) {
+      if (UNLIKELY((s[i] == '\n' || s[i] == '\r')) && !(flags & ZSV_STRWHITE_FLAG_NO_EMBEDDED_NEWLINE))
         replacement = '\n';
-      else if(!last_was_space)
+      else if (!last_was_space)
         replacement = ' ';
       last_was_space = 1;
     } else {
       // current position is not a space
-      if(last_was_space)
+      if (last_was_space)
         s[new_len++] = replacement;
-      for(int j = 0; j < clen; j++)
+      for (int j = 0; j < clen; j++)
         s[new_len++] = s[i + j];
       last_was_space = 0;
     }
@@ -300,10 +297,10 @@ size_t zsv_strwhite(unsigned char *s, size_t len, unsigned int flags) {
 }
 
 size_t zsv_strip_trailing_zeros(const char *s, size_t len) {
-  if(len && memchr(s, '.', len)) {
-    while(len && s[len-1] == '0')
+  if (len && memchr(s, '.', len)) {
+    while (len && s[len - 1] == '0')
       len--;
-    if(len && s[len-1] == '.')
+    if (len && s[len - 1] == '.')
       len--;
   }
   return len;
@@ -317,11 +314,11 @@ size_t zsv_strip_trailing_zeros(const char *s, size_t len) {
  * @param flags bitfield of ZSV_STRWHITE_FLAG_XXX values
  */
 size_t zsv_strunescape_backslash(unsigned char *s, size_t len) {
-  if(len == 0 || !memchr(s, '\\', len - 1))
+  if (len == 0 || !memchr(s, '\\', len - 1))
     return len;
   size_t j = 0;
-  for(size_t i = 0; i < len; i++, j++) {
-    if(UNLIKELY(s[i] == '\\' && i + 1 < len && memchr("tnr", s[i+1], 3))) {
+  for (size_t i = 0; i < len; i++, j++) {
+    if (UNLIKELY(s[i] == '\\' && i + 1 < len && memchr("tnr", s[i + 1], 3))) {
       ++i;
       s[j] = s[i] == 't' ? '\t' : s[i] == 'n' ? '\n' : '\r';
     } else
@@ -332,13 +329,14 @@ size_t zsv_strunescape_backslash(unsigned char *s, size_t len) {
 
 // zsv_strtod_exact(const char *s): return error; if 0, set value of *d
 int zsv_strtod_exact(const char *s, double *d) {
-  if(!*s) return 1;
+  if (!*s)
+    return 1;
   char *end;
   *d = strtod(s, &end);
-  if(*end) return 1;
+  if (*end)
+    return 1;
   return 0;
 }
-
 
 #ifndef ZSV_STRING_LIB_ONLY
 struct zsv_cell zsv_get_cell_trimmed(zsv_parser parser, size_t ix) {

--- a/app/utils/win/dl.c
+++ b/app/utils/win/dl.c
@@ -11,7 +11,7 @@
 #include <zsv/utils/os.h>
 
 #define RTLD_LAZY 0
-void *dlsym(void* handle, const char* symbol) {
+void *dlsym(void *handle, const char *symbol) {
   return (void *)GetProcAddress((HINSTANCE)(handle), (symbol));
 }
 

--- a/app/utils/writer.c
+++ b/app/utils/writer.c
@@ -13,22 +13,25 @@
 #include <string.h>
 #include <stdlib.h>
 
-///
-/* return 0 on eof, +1 on error, > 0 if valid utf8 first byte read */
+// clang-format off
+
+// return 0 on eof, +1 on error, > 0 if valid utf8 first byte read
 static inline char UTF8_charLenC_noerr(int c) {
   char len;
-  if(c == EOF) len = 0;
-  else if(!(c & 128)) len = 1;
-  else if((c & 224) == 192) len = 2; /* 110xxxxx */
-  else if((c & 240) == 224) len = 3; /* 1110xxxx */
-  else if((c & 248) == 240) len = 4; /* 11110xxx */
-  else if((c & 252) == 248) len = 5; /* 111110xx */
-  else if((c & 254) == 252) len = 6; /* 1111110x */
+  if (c == EOF) len = 0;
+  else if (!(c & 128)) len = 1;
+  else if ((c & 224) == 192) len = 2; // 110xxxxx
+  else if ((c & 240) == 224) len = 3; // 1110xxxx
+  else if ((c & 248) == 240) len = 4; // 11110xxx
+  else if ((c & 252) == 248) len = 5; // 111110xx
+  else if ((c & 254) == 252) len = 6; // 1111110x
   else len = 1; // error, but we are going to ignore and just call it a 1-byte char
   return len;
 }
 
-static struct zsv_csv_writer_options zsv_csv_writer_default_opts = { 0 };
+// clang-format on
+
+static struct zsv_csv_writer_options zsv_csv_writer_default_opts = {0};
 static char zsv_writer_default_opts_initd = 0;
 void zsv_writer_set_default_opts(struct zsv_csv_writer_options opts) {
   zsv_writer_default_opts_initd = 1;
@@ -36,28 +39,26 @@ void zsv_writer_set_default_opts(struct zsv_csv_writer_options opts) {
 }
 
 struct zsv_csv_writer_options zsv_writer_get_default_opts(void) {
-  if(!zsv_writer_default_opts_initd) {
+  if (!zsv_writer_default_opts_initd) {
     zsv_writer_default_opts_initd = 1;
-    zsv_csv_writer_default_opts.write = (size_t (*)(const void * restrict,  size_t,  size_t,  void * restrict))fwrite;
+    zsv_csv_writer_default_opts.write = (size_t(*)(const void *restrict, size_t, size_t, void *restrict))fwrite;
     zsv_csv_writer_default_opts.stream = stdout;
   }
   return zsv_csv_writer_default_opts;
 }
 
 // zsv_csv_quote() returns:
-//   NULL if no quoting needed
-//   buff if buff size was large enough to hold result
-//   newly-allocated char * if buff not large enough, and was able to get from heap
+// - NULL if no quoting needed
+// - buff if buff size was large enough to hold result
+// - newly-allocated char * if buff not large enough, and was able to get from heap
 // in last case, caller must free
-unsigned char *zsv_csv_quote(const unsigned char *utf8_value,
-                             size_t len,
-                             unsigned char *buff, size_t buffsize) {
+unsigned char *zsv_csv_quote(const unsigned char *utf8_value, size_t len, unsigned char *buff, size_t buffsize) {
   char need = 0;
   unsigned quotes = 0;
   char clen;
-  for(unsigned int i = 0; i < len; i+=clen) {
-    if((clen = UTF8_charLenC_noerr(utf8_value[i])) == 1)
-      switch(utf8_value[i]) {
+  for (unsigned int i = 0; i < len; i += clen) {
+    if ((clen = UTF8_charLenC_noerr(utf8_value[i])) == 1)
+      switch (utf8_value[i]) {
       case ',':
       case '\n':
       case '\r':
@@ -69,26 +70,26 @@ unsigned char *zsv_csv_quote(const unsigned char *utf8_value,
         break;
       }
   }
-  if(!need)
+  if (!need)
     return NULL;
 
   unsigned char *target;
   unsigned mem_length = len + quotes + 3; // str + 2 quotes + terminating null
-  if(mem_length < buffsize)
+  if (mem_length < buffsize)
     target = buff;
   else
     target = malloc(mem_length * sizeof(*target));
 
-  if(target) {
+  if (target) {
     *target = '"';
-    if(!quotes)
+    if (!quotes)
       memcpy(target + 1, utf8_value, len);
     else {
-      for(unsigned int i = 0, j = 0; i < len; i+=clen, j += clen) {
-        if(utf8_value[i] == '"')
+      for (unsigned int i = 0, j = 0; i < len; i += clen, j += clen) {
+        if (utf8_value[i] == '"')
           target[++j] = '"';
         clen = UTF8_charLenC_noerr(utf8_value[i]);
-        if(i + clen > len) // safety in case of invalid utf8 input
+        if (i + clen > len) // safety in case of invalid utf8 input
           clen = len - i;
         memcpy(target + 1 + j, utf8_value + i, clen);
       }
@@ -99,7 +100,7 @@ unsigned char *zsv_csv_quote(const unsigned char *utf8_value,
   return target;
 }
 
-#define ZSV_OUTPUT_BUFF_SIZE 65536*4
+#define ZSV_OUTPUT_BUFF_SIZE 65536 * 4
 
 struct zsv_output_buff {
   char *buff; // will be ZSV_OUTPUT_BUFF_SIZE. to do: option to modify buff size
@@ -109,7 +110,7 @@ struct zsv_output_buff {
 };
 
 struct zsv_writer_data {
-  size_t buffsize; // corresponds to buf
+  size_t buffsize;     // corresponds to buf
   unsigned char *buff; // option
 
   struct zsv_output_buff out;
@@ -119,13 +120,12 @@ struct zsv_writer_data {
 
   const char *cell_prepend;
 
-  unsigned char with_bom:1;
-  unsigned char started:1;
-  unsigned char _:6;
+  unsigned char with_bom : 1;
+  unsigned char started : 1;
+  unsigned char _ : 6;
 };
 
 #include <unistd.h> // write
-
 
 static inline void zsv_output_buff_flush(struct zsv_output_buff *b) {
   b->write(b->buff, b->used, 1, b->stream);
@@ -133,10 +133,10 @@ static inline void zsv_output_buff_flush(struct zsv_output_buff *b) {
 }
 
 static inline void zsv_output_buff_write(struct zsv_output_buff *b, const unsigned char *s, size_t n) {
-  if(n) {
-    if(n + b->used > ZSV_OUTPUT_BUFF_SIZE) {
+  if (n) {
+    if (n + b->used > ZSV_OUTPUT_BUFF_SIZE) {
       zsv_output_buff_flush(b);
-      if(n > ZSV_OUTPUT_BUFF_SIZE) { // n too big, so write directly
+      if (n > ZSV_OUTPUT_BUFF_SIZE) { // n too big, so write directly
         b->write(s, n, 1, b->stream);
         return;
       }
@@ -147,29 +147,28 @@ static inline void zsv_output_buff_write(struct zsv_output_buff *b, const unsign
   }
 }
 
-void zsv_writer_set_temp_buff(zsv_csv_writer w, unsigned char *buff,
-                                size_t buffsize) {
+void zsv_writer_set_temp_buff(zsv_csv_writer w, unsigned char *buff, size_t buffsize) {
   w->buff = buff;
   w->buffsize = buffsize;
 }
 
 zsv_csv_writer zsv_writer_new(struct zsv_csv_writer_options *opts) {
   struct zsv_writer_data *w = calloc(1, sizeof(*w));
-  if(w) {
-    if(!(w->out.buff = malloc(ZSV_OUTPUT_BUFF_SIZE))) {
+  if (w) {
+    if (!(w->out.buff = malloc(ZSV_OUTPUT_BUFF_SIZE))) {
       free(w); // out of memory!
       return NULL;
     }
 
-    if(!opts) {
-      w->out.write = (size_t (*)(const void * restrict,  size_t,  size_t,  void * restrict))fwrite;
+    if (!opts) {
+      w->out.write = (size_t(*)(const void *restrict, size_t, size_t, void *restrict))fwrite;
       w->out.stream = stdout;
     } else {
-      if(opts->write) {
+      if (opts->write) {
         w->out.write = opts->write;
         w->out.stream = opts->stream;
       } else {
-        w->out.write = (size_t (*)(const void * restrict,  size_t,  size_t,  void * restrict))fwrite;
+        w->out.write = (size_t(*)(const void *restrict, size_t, size_t, void *restrict))fwrite;
         w->out.stream = opts->stream ? opts->stream : stdout;
       }
 
@@ -182,37 +181,37 @@ zsv_csv_writer zsv_writer_new(struct zsv_csv_writer_options *opts) {
 }
 
 enum zsv_writer_status zsv_writer_flush(zsv_csv_writer w) {
-  if(!w) return zsv_writer_status_missing_handle;
+  if (!w)
+    return zsv_writer_status_missing_handle;
 
   zsv_output_buff_flush(&w->out);
   return zsv_writer_status_ok;
 }
 
 enum zsv_writer_status zsv_writer_delete(zsv_csv_writer w) {
-  if(!w) return zsv_writer_status_missing_handle;
+  if (!w)
+    return zsv_writer_status_missing_handle;
 
   zsv_output_buff_flush(&w->out);
-  if(w->started)
+  if (w->started)
     w->out.write("\n", 1, 1, w->out.stream);
 
-  if(w->out.buff)
+  if (w->out.buff)
     free(w->out.buff);
   free(w);
   return zsv_writer_status_ok;
 }
 
-static inline
-enum zsv_writer_status zsv_writer_cell_aux(zsv_csv_writer w,
-                                           const unsigned char *s, size_t len,
-                                           char check_if_needs_quoting) {
-  if(len) {
-    if(check_if_needs_quoting) {
+static inline enum zsv_writer_status zsv_writer_cell_aux(zsv_csv_writer w, const unsigned char *s, size_t len,
+                                                         char check_if_needs_quoting) {
+  if (len) {
+    if (check_if_needs_quoting) {
       unsigned char *quoted_s = zsv_csv_quote(s, len, w->buff, w->buffsize);
-      if(!quoted_s)
+      if (!quoted_s)
         zsv_output_buff_write(&w->out, s, len);
       else {
         zsv_output_buff_write(&w->out, quoted_s, strlen((char *)quoted_s));
-        if(!(w->buff && quoted_s == w->buff))
+        if (!(w->buff && quoted_s == w->buff))
           free(quoted_s);
       }
     } else
@@ -221,25 +220,25 @@ enum zsv_writer_status zsv_writer_cell_aux(zsv_csv_writer w,
   return zsv_writer_status_ok;
 }
 
-enum zsv_writer_status zsv_writer_cell(zsv_csv_writer w, char new_row,
-                                       const unsigned char *s, size_t len,
+enum zsv_writer_status zsv_writer_cell(zsv_csv_writer w, char new_row, const unsigned char *s, size_t len,
                                        char check_if_needs_quoting) {
-  if(!w) return zsv_writer_status_missing_handle;
-  if(!w->started) {
-    if(w->table_init)
+  if (!w)
+    return zsv_writer_status_missing_handle;
+  if (!w->started) {
+    if (w->table_init)
       w->table_init(w->table_init_ctx);
-    if(w->with_bom)
+    if (w->with_bom)
       zsv_output_buff_write(&w->out, (const unsigned char *)"\xef\xbb\xbf", 3);
     w->started = 1;
-  } else if(new_row)
+  } else if (new_row)
     zsv_output_buff_write(&w->out, (const unsigned char *)"\n", 1);
   else
     zsv_output_buff_write(&w->out, (const unsigned char *)",", 1);
 
-  if(VERY_UNLIKELY(w->cell_prepend && *w->cell_prepend)) {
+  if (VERY_UNLIKELY(w->cell_prepend && *w->cell_prepend)) {
     char *tmp = NULL;
     asprintf(&tmp, "%s%.*s", w->cell_prepend, (int)len, s ? s : (const unsigned char *)"");
-    if(!tmp)
+    if (!tmp)
       return zsv_writer_status_error; // zsv_writer_status_memory;
     s = (const unsigned char *)tmp;
     len = len + strlen(w->cell_prepend);
@@ -254,16 +253,15 @@ void zsv_writer_cell_prepend(zsv_csv_writer w, const unsigned char *s) {
   w->cell_prepend = (const char *)s;
 }
 
-enum zsv_writer_status zsv_writer_cell_Lf(zsv_csv_writer w, char new_row, const char *fmt_spec,
-                                              long double ldbl) {
+enum zsv_writer_status zsv_writer_cell_Lf(zsv_csv_writer w, char new_row, const char *fmt_spec, long double ldbl) {
   char s[128];
   char fmt[64];
   int n = snprintf(fmt, sizeof(fmt), "%%%sLf", fmt_spec ? fmt_spec : "");
-  if(!(n > 0 && n < (int)sizeof(fmt)))
+  if (!(n > 0 && n < (int)sizeof(fmt)))
     fprintf(stderr, "Invalid format specifier, should be X for format %%XLf e.g. '.2'\n");
   else {
     n = snprintf(s, sizeof(s), fmt, ldbl);
-    if(!(n > 0 && n < (int)sizeof(fmt)))
+    if (!(n > 0 && n < (int)sizeof(fmt)))
       fprintf(stderr, "Unable to format value with fmt %s: %Lf\n", fmt, ldbl);
     else
       return zsv_writer_cell(w, new_row, (unsigned char *)s, n, 0);
@@ -279,25 +277,23 @@ enum zsv_writer_status zsv_writer_cell_blank(zsv_csv_writer w, char new_row) {
 enum zsv_writer_status zsv_writer_cell_zu(zsv_csv_writer w, char new_row, size_t zu) {
   char s[64];
   int n = snprintf(s, sizeof(s), "%zu", zu);
-  if(n < 1 || n >= (int)sizeof(s))
+  if (n < 1 || n >= (int)sizeof(s))
     n = 0; // unexpected overflow
   return zsv_writer_cell(w, new_row, (unsigned char *)s, n, 0);
 }
 
-enum zsv_writer_status zsv_writer_cell_s(zsv_csv_writer w, char new_row,
-                                         const unsigned char *s,
+enum zsv_writer_status zsv_writer_cell_s(zsv_csv_writer w, char new_row, const unsigned char *s,
                                          char check_if_needs_quoting) {
-  return zsv_writer_cell(w, new_row, s, s ? strlen((const char *)s) : 0,
-                           check_if_needs_quoting);
+  return zsv_writer_cell(w, new_row, s, s ? strlen((const char *)s) : 0, check_if_needs_quoting);
 }
 
 /*
  * returns: newly allocated value (caller must free) or NULL
  */
 unsigned char *zsv_writer_str_to_csv(const unsigned char *s, size_t len) {
-  if(len) {
+  if (len) {
     unsigned char *csv_s = zsv_csv_quote(s, len, NULL, 0);
-    if(csv_s)
+    if (csv_s)
       return csv_s;
     csv_s = malloc(len + 1);
     memcpy(csv_s, s, len);

--- a/app/zsv_command_standalone.c
+++ b/app/zsv_command_standalone.c
@@ -10,7 +10,7 @@ int main(int argc, const char *argv[]) {
   char opts_used[ZSV_OPTS_SIZE_MAX];
   struct zsv_opts opts;
   enum zsv_status stat = zsv_args_to_opts(argc, argv, &argc, argv, &opts, opts_used);
-  if(stat != zsv_status_ok)
+  if (stat != zsv_status_ok)
     return stat;
   return ZSV_MAIN_FUNC(ZSV_COMMAND)(argc, argv, &opts, NULL, opts_used);
 #endif

--- a/app/zsv_main.h
+++ b/app/zsv_main.h
@@ -9,15 +9,17 @@
  * options. Each set has a macro each for the entry point name and declaration
  */
 
-#define ZSV_MAIN_FUNC1(x) zsv_ ## x ## _main
-#define ZSV_MAIN_NO_OPTIONS_FUNC1(x) zsv_ ## x ## _main_no_options
+#define ZSV_MAIN_FUNC1(x) zsv_##x##_main
+#define ZSV_MAIN_NO_OPTIONS_FUNC1(x) zsv_##x##_main_no_options
 
 struct zsv_opts;
 struct zsv_prop_handler;
 
 /* macros for commands that use common zsv parsing */
 #define ZSV_MAIN_FUNC(x) ZSV_MAIN_FUNC1(x)
-#define ZSV_MAIN_DECL(x) int ZSV_MAIN_FUNC(x)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler, const char *opts_used)
+#define ZSV_MAIN_DECL(x)                                                                                               \
+  int ZSV_MAIN_FUNC(x)(int argc, const char *argv[], struct zsv_opts *opts,                                            \
+                       struct zsv_prop_handler *custom_prop_handler, const char *opts_used)
 
 /* macros for commands that do not use common zsv parsing */
 #define ZSV_MAIN_NO_OPTIONS_FUNC(x) ZSV_MAIN_NO_OPTIONS_FUNC1(x)

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -1,60 +1,84 @@
 # Tabular file compare
 
-zsv's `compare` command compares multiple tables and outputs differences in tabular or JSON format.
+zsv's `compare` command compares multiple tables and outputs differences in
+tabular or JSON format.
 
 ## Background
 
-Examples where multiple tables may contain differences that need to be identified include:
-- preliminary vs final data, where a transaction or activity involves a set of resources that may have changed
-- transactions involving assets that are known to multiple parties, each with independent systems of record
-- predictive model updates where values in a column of outputs may change when a model version changes
+Examples where multiple tables may contain differences that need to be
+identified include:
+
+- preliminary vs final data, where a transaction or activity involves a set of
+  resources that may have changed
+- transactions involving assets that are known to multiple parties, each with
+  independent systems of record
+- predictive model updates where values in a column of outputs may change when a
+  model version changes
 
 ## Challenges
 
-Comparing tables of data presents several challenges, some of which are addressed by `zsv compare` and others that are not.
+Comparing tables of data presents several challenges, some of which are
+addressed by `zsv compare` and others that are not.
 
 Challenges that `zsv compare` addresses include:
-* Comparing multiple tables currently is somewhat achievable using a collection of common utilities,
-  but requires different solutions for different operating systems and platforms, and typically requires custom
-  scripting that depends on both platform and specific input schema. Searching for "table comparison" on stackoverflow, for example,
-  yields multiple questions whose answers all involving different sets of tools and custom scripts (and many of which assume the tables already
-  reside in a relational database), and even fewer that consider performance. A better solution would be consistent across platforms, support
-  canned options for common use cases, have few or no additional dependencies, and well-defined performance expectations and limitations
-* Achieve high performance and scalability with bounded memory (for pre-sorted input)
-* Columns might not appear in the same order across all inputs
-* Column population may not be the same across all inputs
-* Column names might be duplicated within any one input
-* Values may have leading whitespace that should be ignored
-* Matching might be 1-1, but alternatively might be by one or more 'key' columns
-* Row population may not be identical; one or more input(s) may have rows (as identified by 'key' columns)
-  that one or more other input(s) do not
-* The number of inputs to compare might exceed 2
-* Inputs may be large and memory may be limited
-* Desired output format may be any of myriad tabular, JSON or other formats
-* Case-insensitive matching across a full Unicode character set
-* Desired output may include additional columns for context
+
+- Comparing multiple tables currently is somewhat achievable using a collection
+  of common utilities, but requires different solutions for different operating
+  systems and platforms, and typically requires custom scripting that depends on
+  both platform and specific input schema. Searching for "table comparison" on
+  StackOverflow, for example, yields multiple questions whose answers all
+  involving different sets of tools and custom scripts (and many of which assume
+  the tables already reside in a relational database), and even fewer that
+  consider performance. A better solution would be consistent across platforms,
+  support canned options for common use cases, have few or no additional
+  dependencies, and well-defined performance expectations and limitations
+- Achieve high performance and scalability with bounded memory (for pre-sorted
+  input)
+- Columns might not appear in the same order across all inputs
+- Column population may not be the same across all inputs
+- Column names might be duplicated within any one input
+- Values may have leading whitespace that should be ignored
+- Matching might be 1-1, but alternatively might be by one or more 'key' columns
+- Row population may not be identical; one or more input(s) may have rows (as
+  identified by 'key' columns) that one or more other input(s) do not
+- The number of inputs to compare might exceed 2
+- Inputs may be large and memory may be limited
+- Desired output format may be any of myriad tabular, JSON or other formats
+- Case-insensitive matching across a full Unicode character set
+- Desired output may include additional columns for context
 
 Challenges that `zsv compare` aims to solve for limited cases include:
-* Input data might be unsorted, but small enough to sort with reasonable performance using [vanilla sqlite3 sort](https://www.sqlite.org/eqp.html#temporary_sorting_b_trees)
+
+- Input data might be unsorted, but small enough to sort with reasonable
+  performance using [vanilla sqlite3
+  sort](https://www.sqlite.org/eqp.html#temporary_sorting_b_trees)
 
 Challenges that `zsv compare` does not try to solve include:
-* The name of any given column to compare across inputs might differ across inputs
-  (e.g. input 1 contains "My Column X" that we want to compare against input 2's "My_Column_X")
-* Exact comparison may be undesirable when content differs cosmetically but not substantively, e.g. in
-  scale ("70" vs "0.70"), format ("1/1/2023" vs "2023-01-01", or "70%" vs "0.7"), enumeration ("Washington" vs "WA"),
-  precision ("5.2499999999999" vs "5.25") and/or other
-* When comparing large, unsorted datasets in order to sort prior to comparison, a high-performance sort that offers parallelization,
-  multi-threading, algorithm control and/or other high-performance sort features may be desired
 
-(If you are an interested in solutions to these kinds of problems, please contact <a href="mailto:info@liquidaty.com">Liquidaty</a>
-and/or check out https://hub.liquidaty.com.)
+- The name of any given column to compare across inputs might differ across
+  inputs (e.g. input 1 contains "My Column X" that we want to compare against
+  input 2's "My_Column_X")
+- Exact comparison may be undesirable when content differs cosmetically but not
+  substantively, e.g. in scale ("70" vs "0.70"), format ("1/1/2023" vs
+  "2023-01-01", or "70%" vs "0.7"), enumeration ("Washington" vs "WA"),
+  precision ("5.2499999999999" vs "5.25") and/or other
+- When comparing large, unsorted datasets in order to sort prior to comparison,
+  a high-performance sort that offers parallelization, multi-threading,
+  algorithm control and/or other high-performance sort features may be desired
+
+(If you are an interested in solutions to these kinds of problems, please
+contact <a href="mailto:info@liquidaty.com">Liquidaty</a> and/or check out
+<https://hub.liquidaty.com>.)
 
 ## Matching and sorting
 
 Row matching and sorting is handled as follows:
-* Rows between inputs are matched either by row number or by one or more specified key columns
-* Input is assumed to be sorted and uses bounded memory
-* Unsorted input can still be processed; will sort using the [sqlite3 API](https://www.sqlite.org/eqp.html#temporary_sorting_b_trees)
+
+- Rows between inputs are matched either by row number or by one or more
+  specified key columns
+- Input is assumed to be sorted and uses bounded memory
+- Unsorted input can still be processed; will sort using the [sqlite3
+  API](https://www.sqlite.org/eqp.html#temporary_sorting_b_trees)
 
 ## Example
 
@@ -62,70 +86,73 @@ Imagine we want to compare the following two tables:
 
 ### Table 1 ([t1.csv](../data/compare/t1.csv))
 
-|Country|City|AccentCity|Region|Population|Latitude|Longitude|
-|--|--|--|--|--|--|--|
-|de|placken|Placken|07||52.15|8.433333|
-|gb|duffryn|Duffryn|Z3||51.4375|-3.304444|
-|id|kemitang|Kemitang|07||-7.544444|109.183333|
-|ie|oggal|Oggal|02||54.2597222|-7.9266667|
-|mk|cvetovo|Cvetovo|92||41.8580556|21.4097222|
-|pl|ciesle male|Ciesle Male|86||52.176861|17.649143|
-|ru|chishmabash|Chishmabash|73||55.4708|53.8996|
-|tz|lituhi mission|Lituhi Mission|14||-10.55|34.6|
-|us|steep falls|Steep Falls|ME||43.7938889|-70.6530556|
-|za|hota|Hota|05||-31.640685|27.681357|
-|zr|kakova|Kakova|09||0.7333333|29.0166667|
+| Country | City           | AccentCity     | Region | Population | Latitude   | Longitude   |
+| ------- | -------------- | -------------- | ------ | ---------- | ---------- | ----------- |
+| de      | placken        | Placken        | 07     |            | 52.15      | 8.433333    |
+| gb      | duffryn        | Duffryn        | Z3     |            | 51.4375    | -3.304444   |
+| id      | kemitang       | Kemitang       | 07     |            | -7.544444  | 109.183333  |
+| ie      | oggal          | Oggal          | 02     |            | 54.2597222 | -7.9266667  |
+| mk      | cvetovo        | Cvetovo        | 92     |            | 41.8580556 | 21.4097222  |
+| pl      | ciesle male    | Ciesle Male    | 86     |            | 52.176861  | 17.649143   |
+| ru      | chishmabash    | Chishmabash    | 73     |            | 55.4708    | 53.8996     |
+| tz      | lituhi mission | Lituhi Mission | 14     |            | -10.55     | 34.6        |
+| us      | steep falls    | Steep Falls    | ME     |            | 43.7938889 | -70.6530556 |
+| za      | hota           | Hota           | 05     |            | -31.640685 | 27.681357   |
+| zr      | kakova         | Kakova         | 09     |            | 0.7333333  | 29.0166667  |
 
 ### Table 2 ([t2.csv](../data/compare/t2.csv))
 
-|Region|Population|Latitude|Longitude|Country|City|AccentCity|
-|--|--|--|--|--|--|--|
-|92||41.8580556|21.4097222|mk|cvetovo|Cvetovo|
-|86||52.176861|17.649143|pl|ciesle male|Ciesle XXX|
-|39||41.677473|27.067859|tr|yenioe|Yenioe|
-|14||-10.55|34.6|tz|lituhi mission|Lituhi Mission|
-|ME||43.7938889|-70.6530556|us|steep falls|Steep Falls|
-|05||-31.640685|27.681357|za|hota|Hota|
-|XX||0.7333333|29.0166667|zr|kakova|Kakova|
-|03||26.934908|115.628584|cn|fulongling|Fulongling|
-|07||52.15|10.4|de|placken|Placken|
-|Z3||51.4375|-3.304444|gb|duffryn|Duffryn|
-|07||-7.544444|109.183333|id|kemitang|Kemitang|
-|12||52.9911111|-6.8938889|ie|burtown cross roads|Burtown XXX|
-|02||54.2597222|-7.9266667|ie|oggal|Oggal|
-|16||34.788889|127.670833|kr|chusamdong|Chusamdong|
+| Region | Population | Latitude   | Longitude   | Country | City                | AccentCity     |
+| ------ | ---------- | ---------- | ----------- | ------- | ------------------- | -------------- |
+| 92     |            | 41.8580556 | 21.4097222  | mk      | cvetovo             | Cvetovo        |
+| 86     |            | 52.176861  | 17.649143   | pl      | ciesle male         | Ciesle XXX     |
+| 39     |            | 41.677473  | 27.067859   | tr      | yenioe              | Yenioe         |
+| 14     |            | -10.55     | 34.6        | tz      | lituhi mission      | Lituhi Mission |
+| ME     |            | 43.7938889 | -70.6530556 | us      | steep falls         | Steep Falls    |
+| 05     |            | -31.640685 | 27.681357   | za      | hota                | Hota           |
+| XX     |            | 0.7333333  | 29.0166667  | zr      | kakova              | Kakova         |
+| 03     |            | 26.934908  | 115.628584  | cn      | fulongling          | Fulongling     |
+| 07     |            | 52.15      | 10.4        | de      | placken             | Placken        |
+| Z3     |            | 51.4375    | -3.304444   | gb      | duffryn             | Duffryn        |
+| 07     |            | -7.544444  | 109.183333  | id      | kemitang            | Kemitang       |
+| 12     |            | 52.9911111 | -6.8938889  | ie      | burtown cross roads | Burtown XXX    |
+| 02     |            | 54.2597222 | -7.9266667  | ie      | oggal               | Oggal          |
+| 16     |            | 34.788889  | 127.670833  | kr      | chusamdong          | Chusamdong     |
 
 Then:
-* rows should be matched on the key combination of city and country
-* input will need to be sorted
-* each table has a slightly different population
+
+- rows should be matched on the key combination of city and country
+- input will need to be sorted
+- each table has a slightly different population
 
 We can run:
-```
+
+```shell
 zsv compare t1.csv t2.csv --sort -k country -k city
 ```
 
 and get the following output:
 
-|country|city|Column|t1.csv|t2.csv|
-|--|--|--|--|--|
-|cn|fulongling|&lt;key&gt;|Missing||
-|de|placken|Longitude|8.433333|10.4|
-|ie|burtown cross roads|&lt;key&gt;|Missing||
-|kr|chusamdong|&lt;key&gt;|Missing||
-|pl|ciesle male|AccentCity|Ciesle Male|Ciesle XXX|
-|ru|chishmabash|&lt;key&gt;||Missing|
-|tr|yenioe|&lt;key&gt;|Missing||
-|zr|kakova|Region|09|XX|
+| country | city                | Column      | t1.csv      | t2.csv     |
+| ------- | ------------------- | ----------- | ----------- | ---------- |
+| cn      | fulongling          | &lt;key&gt; | Missing     |            |
+| de      | placken             | Longitude   | 8.433333    | 10.4       |
+| ie      | burtown cross roads | &lt;key&gt; | Missing     |            |
+| kr      | chusamdong          | &lt;key&gt; | Missing     |            |
+| pl      | ciesle male         | AccentCity  | Ciesle Male | Ciesle XXX |
+| ru      | chishmabash         | &lt;key&gt; |             | Missing    |
+| tr      | yenioe              | &lt;key&gt; | Missing     |            |
+| zr      | kakova              | Region      | 09          | XX         |
 
 Or in either of two JSON formats:
-```
+
+```shell
 zsv compare --json t1.csv t2.csv --sort -k country -k city
 ```
 
 to get:
 
-```
+```json
 [
   [
     "country",
@@ -153,12 +180,14 @@ to get:
 ```
 
 or:
-```
+
+```shell
 zsv compare --json-object t1.csv t2.csv --sort -k country -k city
 ```
 
 to get:
-```
+
+```json
 [
   {
     "country": "cn",
@@ -177,37 +206,41 @@ to get:
 ]
 ```
 
-and in each case if we wanted to include additional data in the output for context, we can
-do so using `--add`, e.g.:
-```
+and in each case if we wanted to include additional data in the output for
+context, we can do so using `--add`, e.g.:
+
+```shell
 zsv compare --add accentcity t1.csv t2.csv --sort -k country -k city
 ```
 
 which outputs:
 
-|country|city|accentcity|Column|t1.csv|t2.csv|
-|--|--|--|--|--|--|
-|cn|fulongling|Placken|<key>|Missing||
-|de|placken|Placken|Longitude|8.433333|10.4|
-|ie|burtown cross roads|Oggal|<key>|Missing||
-|kr|chusamdong|Cvetovo|<key>|Missing||
-|pl|ciesle male|Ciesle Male|AccentCity|Ciesle Male|Ciesle XXX|
-|ru|chishmabash|Chishmabash|<key>||Missing|
-|tr|yenioe|Lituhi Mission|<key>|Missing||
-|zr|kakova|Kakova|Region|9|XX|
+| country | city                | accentcity     | Column     | t1.csv      | t2.csv     |
+| ------- | ------------------- | -------------- | ---------- | ----------- | ---------- |
+| cn      | fulongling          | Placken        | <key>      | Missing     |            |
+| de      | placken             | Placken        | Longitude  | 8.433333    | 10.4       |
+| ie      | burtown cross roads | Oggal          | <key>      | Missing     |            |
+| kr      | chusamdong          | Cvetovo        | <key>      | Missing     |            |
+| pl      | ciesle male         | Ciesle Male    | AccentCity | Ciesle Male | Ciesle XXX |
+| ru      | chishmabash         | Chishmabash    | <key>      |             | Missing    |
+| tr      | yenioe              | Lituhi Mission | <key>      | Missing     |            |
+| zr      | kakova              | Kakova         | Region     | 9           | XX         |
 
 ## Performance
 
-No rigorous benchmarking has yet been performed, but preliminary testing yields reasonable performance and memory usage.
+No rigorous benchmarking has yet been performed, but preliminary testing yields
+reasonable performance and memory usage.
 
-Using a 2019 MBA, running a comparison of two 40MB CSV files, each a table of 100,000 rows with 61 columns, containing approximately
-60,000 differences, took about 5.5 seconds and used a maximum about 1.8MB of RAM on a 2019 MBA.
+Using a 2019 MBA, running a comparison of two 40MB CSV files, each a table of
+100,000 rows with 61 columns, containing approximately 60,000 differences, took
+about 5.5 seconds and used a maximum about 1.8MB of RAM on a 2019 MBA.
 
-The same test with sorting used significantly more memory (up to ~40MB) and took about 7.8 seconds to complete.
+The same test with sorting used significantly more memory (up to ~40MB) and took
+about 7.8 seconds to complete.
 
 ## Usage details
 
-```
+```shell
 zsv compare -h
 
 Usage: compare [options] [file1.csv] [file2.csv] [...]

--- a/docs/csv.schema.json
+++ b/docs/csv.schema.json
@@ -7,40 +7,78 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string",
-            "examples": ["City", "State", "My Column"]
+            "examples": [
+              "City",
+              "State",
+              "My Column"
+            ]
           },
           "datatype": {
-            "enum": ["int", "text", "real"]
+            "enum": [
+              "int",
+              "text",
+              "real"
+            ]
           },
           "collate": {
-            "enum": [ "nocase", "binary", "rtrim" ]
+            "enum": [
+              "nocase",
+              "binary",
+              "rtrim"
+            ]
           }
         }
       }
     }
   ],
-  "additionalItems": 
-  {
-      "type": "array",
-      "description": "row of data",
-      "examples": [["A1 value", 22, true],
-                   ["Abc", "def", "ghi"],
-                   ["abc", "Def", ""]
-                  ],
-      "items": {
-        "examples": ["Hi there", 123],
-        "oneOf": [
-          { "type": "null" },
-          { "type": "integer" },
-          { "type": "number" },
-          { "type": "string" },
-          { "type": "boolean" }
-        ]
-      }
+  "additionalItems": {
+    "type": "array",
+    "description": "row of data",
+    "examples": [
+      [
+        "A1 value",
+        22,
+        true
+      ],
+      [
+        "Abc",
+        "def",
+        "ghi"
+      ],
+      [
+        "abc",
+        "Def",
+        ""
+      ]
+    ],
+    "items": {
+      "examples": [
+        "Hi there",
+        123
+      ],
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     }
-
+  }
 }

--- a/docs/csv_json_sqlite.md
+++ b/docs/csv_json_sqlite.md
@@ -7,12 +7,15 @@ Summary:
   - more API-friendly than CSV
   - more git- and diff-friendly than binary formats (like sqlite3)
   - can hold metadata as well as data
-  - can be converted to other formats (e.g. parquet) with other existing utilities
+  - can be converted to other formats (e.g. parquet) with other existing
+    utilities
   - with an appropriate schema, can be efficiently processed as a stream
 - Many common approaches to converting CSV or sqlite3 to JSON use a JSON Schema
-  with unnecessarily limits to utility, extensibility and/or performance efficiency.
-  With a few tweaks to the target schema, however, you can have your cake and eat it
-- [`zsv`](../README.md) provides high-performance conversion between CSV (or similar), JSON and sqlite3 (and for running SQL queries against CSV)
+  with unnecessarily limits to utility, extensibility and/or performance
+  efficiency. With a few tweaks to the target schema, however, you can have your
+  cake and eat it
+- [`zsv`](../README.md) provides high-performance conversion between CSV (or
+  similar), JSON and sqlite3 (and for running SQL queries against CSV)
 
 ## Background
 
@@ -50,7 +53,7 @@ including:
 - JSON (as arrays, objects, or [database-friendly table schema](db.schema.json))
 - sqlite3
 
-To install `zsv`, see https://github.com/liquidaty/zsv/blob/main/BUILD.md
+To install `zsv`, see <https://github.com/liquidaty/zsv/blob/main/BUILD.md>.
 
 `zsv`'s `2json`, `2db` and `jq` commands provide conversion between delimited,
 json and sqlite3 formats. A streamlined JSON schema is used to retain metadata
@@ -59,7 +62,9 @@ when converting between JSON and sqlite3 formats, using the
 and [sqlite3](https://www.sqlite.org) libraries.
 
 ### Getting some sample data
+
 Let's get some sample data to work with:
+
 ```
 curl -LO https://raw.githubusercontent.com/datasets/world-cities/master/data/world-cities.csv
 ```
@@ -124,22 +129,26 @@ it does not allow for table-level metadata.
 
 #### Adding table metadata
 
-To support both table and column metadata, `zsv` uses a 
-[database-friendly approach](db.schema.json) this supports table metadata
-(such as table name and indexes) through a tuple (ordered list)
-containing two elements (metadata followed by data).
-At the table level, this approach could also be merged with the aforementioned [row-based
-schema](csv.schema.json) to support row-level or cell-level metadata, to
-represent spreadsheet data such as cell-level formatting.
+To support both table and column metadata, `zsv` uses a [database-friendly
+approach](db.schema.json) this supports table metadata (such as table name and
+indexes) through a tuple (ordered list) containing two elements (metadata
+followed by data). At the table level, this approach could also be merged with
+the aforementioned [row-based schema](csv.schema.json) to support row-level or
+cell-level metadata, to represent spreadsheet data such as cell-level
+formatting.
 
-The `zsv` conversion implementations as of this writing are limited; future improvements under consideration include:
-* automatic determination / suggestion of column data type
-* conversion/coercion of text to the specified data type for the corresponding column
-* load to other database back-end e.g. mssql or redshift
+The `zsv` conversion implementations as of this writing are limited; future
+improvements under consideration include:
 
-Future enhancements to both the schema and the conversion implementation under consideration
-include support for other table-level features such as validations/constraints, other database object types
-such as views, and whole-database conversion.
+- automatic determination / suggestion of column data type
+- conversion/coercion of text to the specified data type for the corresponding
+  column
+- load to other database back-end e.g. mssql or redshift
+
+Future enhancements to both the schema and the conversion implementation under
+consideration include support for other table-level features such as
+validations/constraints, other database object types such as views, and
+whole-database conversion.
 
 ```shell
 # Convert CSV to JSON
@@ -178,6 +187,7 @@ zsv jq '.[]|if (.|type) == "object" then (.columns|[.[]|.name]) else . end|.[]' 
 ### Sqlite to JSON
 
 Now let's go the other way:
+
 ```shell
 # sqlite3 to JSON
 zsv 2json --from-db world-cities.db > world-cities.from-db.json
@@ -185,7 +195,6 @@ zsv 2json --from-db world-cities.db > world-cities.from-db.json
 # verify it's the same as what we generated above
 cmp world-cities.from-db.json world-cities.db.json && echo "It's the same"'!' || echo "Uh oh"
 ```
-
 
 ## Questions
 
@@ -316,5 +325,6 @@ breaking change in order to leverage for extended purposes
 
 ### Can you extend the `zsv 2db` command and/or related JSON schema to support the sqlite3 feature XYZ
 
-If it's supported in the sqlite3 library, the answer is generally yes. Please [open an issue](https://github.com/liquidaty/zsv/issues/new/choose) with
-your request.
+If it's supported in the sqlite3 library, the answer is generally yes. Please
+[open an issue](https://github.com/liquidaty/zsv/issues/new/choose) with your
+request.

--- a/docs/db.schema.json
+++ b/docs/db.schema.json
@@ -3,7 +3,9 @@
   "items": [
     {
       "type": "object",
-      "required": ["columns"],
+      "required": [
+        "columns"
+      ],
       "properties": {
         "name": {
           "description": "table name",
@@ -14,24 +16,40 @@
           "description": "ordered array of column specifications",
           "items": {
             "type": "object",
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
               "name": {
                 "type": "string",
-                "examples": ["City", "State", "My Column"]
+                "examples": [
+                  "City",
+                  "State",
+                  "My Column"
+                ]
               },
               "datatype": {
-                "enum": ["int", "text", "real"]
+                "enum": [
+                  "int",
+                  "text",
+                  "real"
+                ]
               },
               "collate": {
-                "enum": [ "nocase", "binary", "rtrim" ]
+                "enum": [
+                  "nocase",
+                  "binary",
+                  "rtrim"
+                ]
               }
             }
           }
         },
         "indexes": {
           "type": "object",
-          "required": ["on"],
+          "required": [
+            "on"
+          ],
           "description": "map of table indexes; property name is the index name",
           "additionalProperties": {
             "type": "object",
@@ -40,19 +58,26 @@
                 "oneOf": [
                   {
                     "type": "string",
-                    "examples": ["[My Column 1], lower([My Column 2])"]
+                    "examples": [
+                      "[My Column 1], lower([My Column 2])"
+                    ]
                   },
                   {
                     "description": "array of indexed expressions (not yet supported by `zsv 2db`)",
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "examples": ["My Column 1", "lower([My Column 2])"]
+                      "examples": [
+                        "My Column 1",
+                        "lower([My Column 2])"
+                      ]
                     }
                   }
                 ]
               },
-              "unique": { "type": "boolean" }
+              "unique": {
+                "type": "boolean"
+              }
             }
           }
         }
@@ -63,18 +88,44 @@
       "description": "2x2 table of data",
       "items": {
         "type": "array",
-        "examples": [["A1 value", 22, true],
-                     ["Abc", "def", "ghi"],
-                     ["abc", "Def", ""]
-                    ],
+        "examples": [
+          [
+            "A1 value",
+            22,
+            true
+          ],
+          [
+            "Abc",
+            "def",
+            "ghi"
+          ],
+          [
+            "abc",
+            "Def",
+            ""
+          ]
+        ],
         "items": {
-          "examples": ["Hi there", 123],
+          "examples": [
+            "Hi there",
+            123
+          ],
           "oneOf": [
-            { "type": "null" },
-            { "type": "integer" },
-            { "type": "number" },
-            { "type": "string" },
-            { "type": "boolean" }
+            {
+              "type": "null"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "boolean"
+            }
           ]
         }
       }

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -1,2 +1,1 @@
 # Extending ZSV
-

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,40 +1,37 @@
-********************************************************************************
-   ZSV/lib: Memory usage
-********************************************************************************
+# zsvlib: memory usage
 
 ZSVLIB makes efficient use of memory through the following techniques:
 
-* Memory copying is minimized. Bytes are read from the input (e.g. via `fread`)
+- Memory copying is minimized. Bytes are read from the input (e.g. via `fread`)
   and copied to a buffer. Usually, by the time the cell() and row() callbacks
   are called, no further copying is performed, and `zsv_get_cell()` will return
   a pointer back to the location in the buffer where the data was originally
   copied into from the initial read. Exceptions to this are:
 
-    - escaped double-quotes are removed using a memmove call (e.g. `"aaa""aaa"`
-      becomes `aaa"aaa`). Note: we are considering
-      adding an option to skip this step; feel free to let us know if you have
-      an opinion on that
+  - escaped double-quotes are removed using a `memmove` call (e.g. `"aaa""aaa"`
+    becomes `aaa"aaa`). Note: we are considering adding an option to skip this
+    step; feel free to let us know if you have an opinion on that
 
-    - when the end of the buffer is reached, any partial row content if moved
-      to the beginning of the row. This occurs on average once every N rows,
-      where N is the average number of rows contained in each chunk of data
-      read from the input. By default, the buffer size is 256k, which typically
-      yields a high enough value of N that the impact of end-of-buffer copy is
-      negigible. If your table rows are so large as to make this copy operation
-      have a noticeable performance impact, use a higher buffer size
+  - when the end of the buffer is reached, any partial row content if moved to
+    the beginning of the row. This occurs on average once every N rows, where N
+    is the average number of rows contained in each chunk of data read from the
+    input. By default, the buffer size is 256k, which typically yields a high
+    enough value of N that the impact of end-of-buffer copy is negligible. If
+    your table rows are so large as to make this copy operation have a
+    noticeable performance impact, use a higher buffer size
 
-    - when a cell value is fetched, the parser returns the cell contents, the
-      length, and a flag indicating whether the contents contain any delimiter or
-      embedded dbl-quote that will require the value to be further processed if
-      output as CSV (or TSV, JSON etc). This allows the caller to skip unnecessary
-      scanning of cell contents in the common case where no quoting is required
+  - when a cell value is fetched, the parser returns the cell contents, the
+    length, and a flag indicating whether the contents contain any delimiter or
+    embedded dbl-quote that will require the value to be further processed if
+    output as CSV (or TSV, JSON etc). This allows the caller to skip unnecessary
+    scanning of cell contents in the common case where no quoting is required
 
-* Each row's entire contents are stored in a single contiguous block of memory.
-  To operate on the entire block of row memory, you can simply operate on the memory
-  that starts at the first cell's `.str` address and ends with the last cell's
-  `.str + .len` address. This can be advantageous for bulk operations, especially
-  those that can be vectorized
+- Each row's entire contents are stored in a single contiguous block of memory.
+  To operate on the entire block of row memory, you can simply operate on the
+  memory that starts at the first cell's `.str` address and ends with the last
+  cell's `.str + .len` address. This can be advantageous for bulk operations,
+  especially those that can be vectorized.
 
-* The maximum row size is a function of the maximum size of the internal buffer,
+- The maximum row size is a function of the maximum size of the internal buffer,
   which is set (either to a default or a caller-specified value) when the parser
-  is initialized
+  is initialized.

--- a/examples/js/README.md
+++ b/examples/js/README.md
@@ -2,79 +2,101 @@
 
 ## Overview
 
-Two examples here demonstrate how the zsv CSV parser can be compiled to web assembly and called via javascript
-via a static page in a browser or a Node module.
+Two examples here demonstrate how the zsv CSV parser can be compiled to web
+assembly and called via javascript via a static page in a browser or a Node
+module.
 
-Most of the operative code is in [js/foot.js](js/foot.js) which effectively just converts between Javascript and emscripten.
+Most of the operative code is in [js/foot.js](js/foot.js) which effectively just
+converts between Javascript and emscripten.
 
 ### Browser
-To run the browser demo, run `make run`.
-Static files will be built in a subdirectory of the `build` directory, and a python local https server
-will be started to serve them on https://127.0.0.1:8888
 
-You can view a [demo of the built example here](https://liquidaty.github.io/zsv/examples/wasm/build/)
+To run the browser demo, run `make run`. Static files will be built in a
+subdirectory of the `build` directory, and a python local https server will be
+started to serve them on <https://127.0.0.1:8888>
+
+You can view a [demo of the built example
+here](https://liquidaty.github.io/zsv/examples/wasm/build/)
 
 ### Node module
 
-To build a node module, run `make node`. Module files will be placed in node/node_modules/zsv-parser
+To build a node module, run `make node`. Module files will be placed in
+node/node_modules/zsv-parser
 
 ### Node example and test
-To run a test via node, run `make test`. The node module will be built, a sample program will be copied to
-`node/index.js`, which reads CSV from stdin and outputs JSON, and a test will be run
+
+To run a test via node, run `make test`. The node module will be built, a sample
+program will be copied to `node/index.js`, which reads CSV from stdin and
+outputs JSON, and a test will be run
 
 ## Prerequisites
 
-To build, you need emscripten. To run the example web server, you need python3. Unlike some of the other examples,
-this example does not require that libzsv is already installed
+To build, you need emscripten. To run the example web server, you need python3.
+Unlike some of the other examples, this example does not require that libzsv is
+already installed
 
 ## Quick start
 
-1. From the zsv base directory, run configure in your emscripten environment and save the config output
-   to config.emcc:
-   ```
+1. From the zsv base directory, run configure in your emscripten environment and
+   save the config output to `config.emcc`:
+
+   ```shell
    emconfigure ./configure CONFIGFILE=config.emcc
    ```
 
-2. Change back to this directory (examples/wasm), then run `emmake make run`. You should see output messages
-   ending with `Listening on https://127.0.0.1:8888`
+2. Change back to this directory (examples/wasm), then run `emmake make run`.
+   You should see output messages ending with:
 
-3. Navigate to https://127.0.0.1:8888. If you get a browser warning, then using Chrome you can type "thisisunsafe" to proceed
+   ```shell
+   Listening on https://127.0.0.1:8888
+   ```
 
-4. Click the button to upload a file
+3. Navigate to <https://127.0.0.1:8888>. If you get a browser warning, then
+   using Chrome you can type "thisisunsafe" to proceed.
+
+4. Click the button to upload a file.
 
 ## Performance
 
-Running ZSV lib from Javascript is still experimental and is not yet fully optimized.
-Some performance challenges are particular to web assembly + Javascript, e.g. where a lot of string data
-is being passed between Javascript and the library (see e.g. https://hacks.mozilla.org/2019/08/webassembly-interface-types/).
+Running ZSV lib from Javascript is still experimental and is not yet fully
+optimized. Some performance challenges are particular to web assembly +
+Javascript, e.g. where a lot of string data is being passed between Javascript
+and the library (see e.g.
+<https://hacks.mozilla.org/2019/08/webassembly-interface-types/>).
 
 However, initial results are promising:
 
-* Running only "count", zsv-lib is ~90%+ faster than `csv-parser` and `papaparse`
-* The more cell data that is fetched, the more this advantage diminishes due to the aforementioned Javascript/wasm memory overhead.
-  Our benchmarking suggests that if the entire row's data is fetched, performance is about on par with both csv-parser and papaparse.
-  If only a portion is fetched, performance is about the same for papaparse, and faster than csv-parser (how much faster
-  being roughly proportional to the difference between count (~90% faster) and the
-  amount of total data fetched)
+- Running only "count", zsv-lib is ~90%+ faster than `csv-parser` and
+  `papaparse`
+- The more cell data that is fetched, the more this advantage diminishes due to
+  the aforementioned Javascript/wasm memory overhead. Our benchmarking suggests
+  that if the entire row's data is fetched, performance is about on par with
+  both `csv-parser` and `papaparse`. If only a portion is fetched, performance
+  is about the same for `papaparse`, and faster than `csv-parser` (how much
+  faster being roughly proportional to the difference between count (~90%
+  faster) and the amount of total data fetched)
 
 ## All the build commands
 
 Separate commands can be used for build, run and clean:
-```
+
+```shell
 make build
 make node
 make run
 make clean
 ```
 
-Add MINIFY=1 to any of the above to generate minified code
+Add `MINIFY=1` to any of the above to generate minified code.
 
 To run benchmark tests:
-```
+
+```shell
 make benchmark
 ```
 
 To see all make options:
-```
+
+```shell
 make
 ```

--- a/examples/js/browser/index.html
+++ b/examples/js/browser/index.html
@@ -1,9 +1,12 @@
 <html>
-  <head>
-    <script src="zsv.js"></script>
-    <script src="zsv-browser-example.js"></script>
-  </head>
-  <body>
-    <input id="file_input" type="file" accept=".csv">
-  </body>
+
+<head>
+  <script src="zsv.js"></script>
+  <script src="zsv-browser-example.js"></script>
+</head>
+
+<body>
+  <input id="file_input" type="file" accept=".csv">
+</body>
+
 </html>

--- a/examples/js/browser/zsv-browser-example.js
+++ b/examples/js/browser/zsv-browser-example.js
@@ -21,7 +21,7 @@ function rowHandler() {
   rowcount++;
   let count = zHandle.cellCount();
   let row = [];
-  for(let i = 0; i < count; i++)
+  for (let i = 0; i < count; i++)
     row.push(zHandle.getCell(i));
   data.push(row);
 }
@@ -31,24 +31,24 @@ function finish() {
   zHandle.finish();
   zHandle.delete();
   alert('Parsed ' + bytes_read + ' bytes; ' + rowcount + ' rows in '
-        + (performance.now() - start) + 'ms. '
-        + 'You can view the parsed data in your browser dev tools console (right-click and select Inspect)');
+    + (performance.now() - start) + 'ms. '
+    + 'You can view the parsed data in your browser dev tools console (right-click and select Inspect)');
   console.log('zsv parsed data', data);
   data = null;
 }
 
 // whenever the file input element changes, parse the file the user selected
 function fileChanged(e) {
-  if(e.target.files && e.target.files.length) {
+  if (e.target.files && e.target.files.length) {
     // initialize
     reset();
     zHandle = zsvParser.new(rowHandler);
 
     // stream the file through our parser
-    let chunkSize = 1024*1024; // 1 mb
-    streamFile(e.target.files[0], chunkSize, function(err, data) {
-      if(!err) {
-        if(data) {
+    let chunkSize = 1024 * 1024; // 1 mb
+    streamFile(e.target.files[0], chunkSize, function (err, data) {
+      if (!err) {
+        if (data) {
           bytes_read += data.length;
           zHandle.parseBytes(data);
         } else // all done
@@ -63,14 +63,14 @@ function fileChanged(e) {
 }
 
 // after the page has loaded, add our change listener to the file input element
-window.addEventListener('load', function() {
+window.addEventListener('load', function () {
   let file_input = document.body.querySelector('#file_input');
   file_input.addEventListener('change', fileChanged);
 })
 
 // Generic function to stream a file through a function
 function streamFile(file, chunk_size, cb) {
-  if(!(chunk_size >= 1024))
+  if (!(chunk_size >= 1024))
     chunk_size = 1024;
   let offset = 0;
   let fr = new FileReader();
@@ -81,19 +81,19 @@ function streamFile(file, chunk_size, cb) {
     fr.readAsArrayBuffer(slice);
   }
 
-  fr.onload = function() {
+  fr.onload = function () {
     let view = new Uint8Array(fr.result);
-    if(!cb(null, view)) {
+    if (!cb(null, view)) {
       offset += chunk_size;
 
-      if(offset < file.size && view.length)
+      if (offset < file.size && view.length)
         getNextChunk();
       else // all done
         cb(null, null);
     }
   };
 
-  fr.onerror = function() {
+  fr.onerror = function () {
     cb('read error');
   };
 

--- a/examples/js/npm/README.md
+++ b/examples/js/npm/README.md
@@ -1,21 +1,24 @@
 # zsv-lib
 
-zsv-lib is a node package of the high-performance zsv parser library for CSV and other delimited
-or fixed-width tabular text data
+zsv-lib is a node package of the high-performance zsv parser library for CSV and
+other delimited or fixed-width tabular text data
 
-This is a low-level library for "unopinionated" CSV parsing. Note that the related zsv CLI,
-which offers additional features such as ad hoc SQL, header manipulation, serializing, flattening,
-converting to JSON or SQLITE3 etc, is not part of this package, but may in the future be offered
-as part of a separate npm package.
+This is a low-level library for "unopinionated" CSV parsing. Note that the
+related zsv CLI, which offers additional features such as ad hoc SQL, header
+manipulation, serializing, flattening, converting to JSON or SQLITE3 etc, is not
+part of this package, but may in the future be offered as part of a separate npm
+package.
 
-Note: the zsv C library supports a very wide range of options; not all are yet exposed in this
-package. Please feel free to post a ticket at https://github.com/liquidaty/zsv/issues
-if you'd like to request any feature that is available in the underlying library but
-not exposed in this package (or that does not yet exist in the underlying library at all)
+Note: the zsv C library supports a very wide range of options; not all are yet
+exposed in this package. Please feel free to post a ticket at
+<https://github.com/liquidaty/zsv/issues> if you'd like to request any feature
+that is available in the underlying library but not exposed in this package (or
+that does not yet exist in the underlying library at all).
 
-Please (see here for further notes re performance)[../README.md#Performance].
+Please [see here for further notes re performance](../README.md#Performance).
 
-For more information about zsv+lib, please visit https://github.com/liquidaty/zsv
+For more information about zsv+lib, please visit
+<https://github.com/liquidaty/zsv>.
 
 ## Installation
 
@@ -26,26 +29,28 @@ npm install zsv-lib
 ## Usage
 
 libzsv works generally as follows:
+
 1. Create a custom a row handler function and create a parser with that function
 2. Push chunks of data through the parser
 3. The parser calls your custom function for each row that is parsed
-4. Your row handler extracts data from the parser and processes it however you want
+4. Your row handler extracts data from the parser and processes it however you
+   want
 
-See the source for a (simple example that counts rows)[test/count.js]
-or (another simple example that outputs row data as json)[test/select_all.js]
+See the source for a [simple example that counts rows](test/count.js) or
+[another simple example that outputs row data as json](test/select_all.js)
 
-THIS PACKAGE IS STILL IN ALPHA. THE API USED IN THE EXAMPLES IS EXPECTED TO CHANGE.
+THIS PACKAGE IS STILL IN ALPHA. THE API USED IN THE EXAMPLES IS EXPECTED TO
+CHANGE.
 
 ### API
 
 Note: libzsv supports a wide range of options; not all are yet exposed in this
-package. Please feel free to post a ticket at https://github.com/liquidaty/zsv/issues
-if you'd like to request any feature
-that is either unexposed from the underlying library, or does not yet exist in the
-underlying library
+package. Please feel free to post a ticket at
+<https://github.com/liquidaty/zsv/issues> if you'd like to request any feature
+that is either unexposed from the underlying library, or does not yet exist in
+the underlying library
 
-
-```
+```js
 /**
  * Create a parser
  * @param  rowHandler callback that takes a single (optional) argument
@@ -101,11 +106,12 @@ runOnLoad(callback)
  * @param  parser
  */
 abort(z)
-
 ```
 
 ## Contributing
+
 Pull requests are welcome. Please make sure to update tests as appropriate.
 
 ## License
+
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/examples/js/npm/test/count-csv-parser.js
+++ b/examples/js/npm/test/count-csv-parser.js
@@ -1,15 +1,17 @@
-const process= require('node:process');
+const process = require('node:process');
 const { PerformanceObserver, performance } = require('node:perf_hooks');
 const fs = require('fs');
 const csv = require('csv-parser')
 
 /**
- * Example using libzsv to parse CSV input and execute a custom row handler function as each row is parsed
+ * Example using libzsv to parse CSV input and execute a custom row handler
+ * function as each row is parsed
  */
 
 /**
- * We will use a separate context for each parser, which is a pattern that allows us to run multiple
- * parsers at the same time independently, although this example only runs one at a time
+ * We will use a separate context for each parser, which is a pattern that
+ * allows us to run multiple parsers at the same time independently, although
+ * this example only runs one at a time
  */
 function createContext() {
   return {
@@ -27,7 +29,7 @@ function finish(ctx) {
 
   /* output a message describing the parse volume and performance */
   console.error('Parsed ' + ctx.rowcount +
-                ' rows in ' + (endTime - ctx.startTime) + 'ms\n');
+    ' rows in ' + (endTime - ctx.startTime) + 'ms\n');
 }
 
 

--- a/examples/js/npm/test/count-papaparse.js
+++ b/examples/js/npm/test/count-papaparse.js
@@ -1,15 +1,17 @@
-const process= require('node:process');
+const process = require('node:process');
 const { PerformanceObserver, performance } = require('node:perf_hooks');
 const fs = require('fs');
 const papa = require('papaparse');
 
 /**
- * Example using libzsv to parse CSV input and execute a custom row handler function as each row is parsed
+ * Example using libzsv to parse CSV input and execute a custom row handler
+ * function as each row is parsed
  */
 
 /**
- * We will use a separate context for each parser, which is a pattern that allows us to run multiple
- * parsers at the same time independently, although this example only runs one at a time
+ * We will use a separate context for each parser, which is a pattern that
+ * allows us to run multiple parsers at the same time independently, although
+ * this example only runs one at a time
  */
 function createContext() {
   return {
@@ -28,30 +30,27 @@ function finish(ctx) {
 
   /* output a message describing the parse volume and performance */
   console.error('Parsed ' + ctx.rowcount +
-                ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
-                'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
-  
+    ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
+    'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
+
   /**
-   * output the parsed data (we could have also done this while we parsed, and not
-   * bothered to accumulate it, to save memory)
+   * output the parsed data (we could have also done this while we parsed, and
+   * not bothered to accumulate it, to save memory)
    */
   console.log(ctx.data);
 }
 
-
 let ctx = createContext();
 
 let opts = {};
-
-opts.step = function(results, parser) {
+opts.step = function (results, parser) {
   ctx.rowcount++;
   results.data = [];
   return results;
 };
-opts.complete = function(results) {
+opts.complete = function (results) {
   finish(ctx);
 }
-
 
 /* read stdin if we have no arguments, else the first argument */
 const readStream = process.argv.length < 3 || !process.argv[2] ? process.stdin : fs.createReadStream(process.argv[2])

--- a/examples/js/npm/test/count_sync.js
+++ b/examples/js/npm/test/count_sync.js
@@ -1,15 +1,17 @@
-const process= require('node:process');
+const process = require('node:process');
 const { PerformanceObserver, performance } = require('node:perf_hooks');
 const fs = require('fs');
 const zsvParser = require('zsv-lib');
 
 /**
- * Example using libzsv to parse CSV input and execute a custom row handler function as each row is parsed
+ * Example using libzsv to parse CSV input and execute a custom row handler
+ * function as each row is parsed
  */
 
 /**
- * We will use a separate context for each parser, which is a pattern that allows us to run multiple
- * parsers at the same time independently, although this example only runs one at a time
+ * We will use a separate context for each parser, which is a pattern that
+ * allows us to run multiple parsers at the same time independently, although
+ * this example only runs one at a time
  */
 function createContext() {
   return {
@@ -19,8 +21,8 @@ function createContext() {
 }
 
 /**
- * Define a row handler which will be called each time a row is parsed, and which
- * accesses all data through a context object
+ * Define a row handler which will be called each time a row is parsed, and
+ * which accesses all data through a context object
  */
 function rowHandler(row, ctx, z) {
   ctx.rowcount++;
@@ -39,14 +41,14 @@ function rowHandler(row, ctx, z) {
  * Define the steps to take after all parsing has completed
  */
 function finish(ctx, parser) {
-  if(parser) {
+  if (parser) {
     parser.finish();                  /* finish parsing */
     let endTime = performance.now()   /* check the time */
 
     /* output a message describing the parse volume and performance */
     console.error('Parsed ' + parser.getBytesRead() + ' bytes; ' + ctx.rowcount +
-                  ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
-                  'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
+      ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
+      'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
 
     /* destroy the parser */
     parser.delete();
@@ -57,7 +59,7 @@ function finish(ctx, parser) {
  * After the zsv-lib module has loaded, read from stdin or the specified file,
  * parse the input, apply the row handler for each parsed row and finish
  */
-zsvParser.runOnLoad(function() {
+zsvParser.runOnLoad(function () {
 
   /* get a new context */
   let ctx = createContext();
@@ -72,7 +74,7 @@ zsvParser.runOnLoad(function() {
   parser.syncInput(readFile);
 
   /* parse */
-  while(parser.parseMore() == 0);
+  while (parser.parseMore() == 0);
 
   /* finish */
   finish(ctx, parser);

--- a/examples/js/npm/test/select_all-csv-parser.js
+++ b/examples/js/npm/test/select_all-csv-parser.js
@@ -1,15 +1,17 @@
-const process= require('node:process');
+const process = require('node:process');
 const { PerformanceObserver, performance } = require('node:perf_hooks');
 const fs = require('fs');
 const csv = require('csv-parser')
 
 /**
- * Example using libzsv to parse CSV input and execute a custom row handler function as each row is parsed
+ * Example using libzsv to parse CSV input and execute a custom row handler
+ * function as each row is parsed
  */
 
 /**
- * We will use a separate context for each parser, which is a pattern that allows us to run multiple
- * parsers at the same time independently, although this example only runs one at a time
+ * We will use a separate context for each parser, which is a pattern that
+ * allows us to run multiple parsers at the same time independently, although
+ * this example only runs one at a time
  */
 function createContext() {
   return {
@@ -28,12 +30,12 @@ function finish(ctx) {
 
   /* output a message describing the parse volume and performance */
   console.error('Parsed ' + ctx.rowcount +
-                ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
-                'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
-  
+    ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
+    'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
+
   /**
-   * output the parsed data (we could have also done this while we parsed, and not
-   * bothered to accumulate it, to save memory)
+   * output the parsed data (we could have also done this while we parsed, and
+   * not bothered to accumulate it, to save memory)
    */
   console.log(ctx.data);
 }
@@ -42,7 +44,7 @@ function finish(ctx) {
 let ctx = createContext();
 
 let opts = {};
-if(process.argv.length > 3 && process.argv[3]) {
+if (process.argv.length > 3 && process.argv[3]) {
   let indexes = JSON.parse(process.argv[3]);
   opts.mapHeaders = ({ header, index }) => (indexes.indexOf(index) > -1 ? header : null);
 }
@@ -59,4 +61,3 @@ readStream
   .on('end', () => {
     finish(ctx);
   });
-

--- a/examples/js/npm/test/select_all-papaparse.js
+++ b/examples/js/npm/test/select_all-papaparse.js
@@ -1,15 +1,17 @@
-const process= require('node:process');
+const process = require('node:process');
 const { PerformanceObserver, performance } = require('node:perf_hooks');
 const fs = require('fs');
 const papa = require('papaparse');
 
 /**
- * Example using libzsv to parse CSV input and execute a custom row handler function as each row is parsed
+ * Example using libzsv to parse CSV input and execute a custom row handler
+ * function as each row is parsed
  */
 
 /**
- * We will use a separate context for each parser, which is a pattern that allows us to run multiple
- * parsers at the same time independently, although this example only runs one at a time
+ * We will use a separate context for each parser, which is a pattern that
+ * allows us to run multiple parsers at the same time independently, although
+ * this example only runs one at a time
  */
 function createContext() {
   return {
@@ -28,39 +30,37 @@ function finish(ctx) {
 
   /* output a message describing the parse volume and performance */
   console.error('Parsed ' + ctx.rowcount +
-                ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
-                'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
-  
+    ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
+    'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
+
   /**
-   * output the parsed data (we could have also done this while we parsed, and not
-   * bothered to accumulate it, to save memory)
+   * output the parsed data (we could have also done this while we parsed, and
+   * not bothered to accumulate it, to save memory)
    */
   console.log(ctx.data);
 }
-
 
 let ctx = createContext();
 
 let opts = {};
 
-if(process.argv.length > 3 && process.argv[3]) {
+if (process.argv.length > 3 && process.argv[3]) {
   let indexes = JSON.parse(process.argv[3]);
-  opts.step = function(results, parser) {
+  opts.step = function (results, parser) {
     ctx.rowcount++;
     ctx.data.push(indexes.map(ix => results.data[ix]));
     return results;
   };
-  opts.complete = function(results) {
+  opts.complete = function (results) {
     finish(ctx);
   }
 } else {
-  opts.complete = function(results) {
+  opts.complete = function (results) {
     ctx.rowcount = results.data.length;
     ctx.data = results.data;
     finish(ctx);
   }
 }
-
 
 /* read stdin if we have no arguments, else the first argument */
 const readStream = process.argv.length < 3 || !process.argv[2] ? process.stdin : fs.createReadStream(process.argv[2])

--- a/examples/js/npm/test/select_all.js
+++ b/examples/js/npm/test/select_all.js
@@ -1,15 +1,17 @@
-const process= require('node:process');
+const process = require('node:process');
 const { PerformanceObserver, performance } = require('node:perf_hooks');
 const fs = require('fs');
 const zsvParser = require('zsv-lib');
 
 /**
- * Example using libzsv to parse CSV input and execute a custom row handler function as each row is parsed
+ * Example using libzsv to parse CSV input and execute a custom row handler
+ * function as each row is parsed
  */
 
 /**
- * We will use a separate context for each parser, which is a pattern that allows us to run multiple
- * parsers at the same time independently, although this example only runs one at a time
+ * We will use a separate context for each parser, which is a pattern that
+ * allows us to run multiple parsers at the same time independently, although
+ * this example only runs one at a time
  */
 function createContext() {
   return {
@@ -20,8 +22,8 @@ function createContext() {
 }
 
 /**
- * Define a row handler which will be called each time a row is parsed, and which
- * accesses all data through a context object
+ * Define a row handler which will be called each time a row is parsed, and
+ * which accesses all data through a context object
  */
 function rowHandler(row, ctx, z) {
   ctx.rowcount++;
@@ -37,12 +39,12 @@ function finish(ctx, parser) {
 
   /* output a message describing the parse volume and performance */
   console.error('Parsed ' + parser.getBytesRead() + ' bytes; ' + ctx.rowcount +
-                ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
-                'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
+    ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
+    'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
 
   /**
-   * output the parsed data (we could have also done this while we parsed, and not
-   * bothered to accumulate it, to save memory)
+   * output the parsed data (we could have also done this while we parsed, and
+   * not bothered to accumulate it, to save memory)
    */
   console.log(ctx.data);
 }
@@ -51,8 +53,7 @@ function finish(ctx, parser) {
  * After the zsv-lib module has loaded, read from stdin or the specified file,
  * parse the input, apply the row handler for each parsed row and finish
  */
-zsvParser.runOnLoad(function() {
-
+zsvParser.runOnLoad(function () {
   /* get a new context */
   let ctx = createContext();
 
@@ -60,7 +61,7 @@ zsvParser.runOnLoad(function() {
   const readFile = process.argv.length < 3 || !process.argv[2] ? process.stdin : fs.createReadStream(process.argv[2]);
 
   let outputIndexes;
-  if(process.argv.length > 3 && process.argv[3])
+  if (process.argv.length > 3 && process.argv[3])
     outputIndexes = JSON.parse(process.argv[3]);
 
   /* initialize parser */

--- a/examples/js/npm/test/select_all_sync.js
+++ b/examples/js/npm/test/select_all_sync.js
@@ -1,15 +1,17 @@
-const process= require('node:process');
+const process = require('node:process');
 const { PerformanceObserver, performance } = require('node:perf_hooks');
 const fs = require('fs');
 const zsvParser = require('zsv-lib');
 
 /**
- * Example using libzsv to parse CSV input and execute a custom row handler function as each row is parsed
+ * Example using libzsv to parse CSV input and execute a custom row handler
+ * function as each row is parsed
  */
 
 /**
- * We will use a separate context for each parser, which is a pattern that allows us to run multiple
- * parsers at the same time independently, although this example only runs one at a time
+ * We will use a separate context for each parser, which is a pattern that
+ * allows us to run multiple parsers at the same time independently, although
+ * this example only runs one at a time
  */
 function createContext() {
   return {
@@ -20,8 +22,8 @@ function createContext() {
 }
 
 /**
- * Define a row handler which will be called each time a row is parsed, and which
- * accesses all data through a context object
+ * Define a row handler which will be called each time a row is parsed, and
+ * which accesses all data through a context object
  */
 function rowHandler(row, ctx, z) {
   ctx.rowcount++;
@@ -40,18 +42,18 @@ function rowHandler(row, ctx, z) {
  * Define the steps to take after all parsing has completed
  */
 function finish(ctx, parser) {
-  if(parser) {
+  if (parser) {
     parser.finish();                  /* finish parsing */
     let endTime = performance.now()   /* check the time */
 
     /* output a message describing the parse volume and performance */
     console.error('Parsed ' + parser.getBytesRead() + ' bytes; ' + ctx.rowcount +
-                  ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
-                  'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
+      ' rows in ' + (endTime - ctx.startTime) + 'ms\n' +
+      'You can view the parsed data in your browser dev tools console (rt-click and select Inspect)');
 
     /**
-     * output the parsed data (we could have also done this while we parsed, and not
-     * bothered to accumulate it, to save memory)
+     * output the parsed data (we could have also done this while we parsed, and
+     * not bothered to accumulate it, to save memory)
      */
     console.log(ctx.data);
 
@@ -64,7 +66,7 @@ function finish(ctx, parser) {
  * After the zsv-lib module has loaded, read from stdin or the specified file,
  * parse the input, apply the row handler for each parsed row and finish
  */
-zsvParser.runOnLoad(function() {
+zsvParser.runOnLoad(function () {
 
   /* get a new context */
   let ctx = createContext();
@@ -79,7 +81,7 @@ zsvParser.runOnLoad(function() {
   parser.syncInput(readFile);
 
   /* parse */
-  while(parser.parseMore() == 0);
+  while (parser.parseMore() == 0);
 
   /* finish */
   finish(ctx, parser);

--- a/examples/lib/README.md
+++ b/examples/lib/README.md
@@ -4,16 +4,17 @@
 
 This directory contains the following examples:
 
-| file     | description |
-| -- | -- |
-| [pull.c](pull.c) | Same as simple.c, but uses pull parsing via `zsv_pull_next_row()`|
-| [simple.c](simple.c) | parse a CSV file and for each row, output the row number, the total number of cells and the number of blank cells |
-| [print_my_column.c](print_my_column.c) | parse a CSV file, look for a specified column of data, and for each row of data, output only that column |
-| [parse_by_chunk.c](parse_by_chunk.c) | read a CSV file in chunks, parse each chunk, and output number of rows. This example uses `zsv_parse_bytes()` (whereas the other two examples use `zsv_parse_more()`) |
+| file                                   | description                                                                                                                                                           |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [pull.c](pull.c)                       | Same as simple.c, but uses pull parsing via `zsv_pull_next_row()`                                                                                                     |
+| [simple.c](simple.c)                   | parse a CSV file and for each row, output the row number, the total number of cells and the number of blank cells                                                     |
+| [print_my_column.c](print_my_column.c) | parse a CSV file, look for a specified column of data, and for each row of data, output only that column                                                              |
+| [parse_by_chunk.c](parse_by_chunk.c)   | read a CSV file in chunks, parse each chunk, and output number of rows. This example uses `zsv_parse_bytes()` (whereas the other two examples use `zsv_parse_more()`) |
 
 ## Building
 
-To build the examples in this directory, cd to here (`cd examples/lib`) and then run `make build`
+To build the examples in this directory, cd to here (`cd examples/lib`) and then
+run `make build`
 
 For further make options, run `make`
 
@@ -21,20 +22,22 @@ For further make options, run `make`
 
 ### Example
 
-A typical usage conssits of:
+A typical usage consists of:
+
 - defining row and/or cell handler functions
 - connecting an input stream, and
 - running the parser
 
 For example, to simply count lines:
-```
+
+```c
 void count_row(void *ctx) {
   unsigned *count = ctx;
   (*count)++;
 }
 
 zsv_parser p = zsv_new(NULL);
-if(!p)
+if (!p)
   fprintf(stderr, "Out of memory!\n");
 else {
   size_t count = 0;
@@ -50,13 +53,15 @@ else {
 ### Getting data into the parser
 
 Data can be passed into libzsv through any of the following:
+
 1. passing a FILE pointer
-2. passing a custom read function (such as `fread` and context pointer (such as `FILE *`))
+2. passing a custom read function (such as `fread` and context pointer (such as
+   `FILE *`))
 3. passing a byte array
 
-In the first two approaches, which are marginally faster due to less memory copying,
-data is read in chunks by the library. In the third approach, each chunk is
-passed manually by your code to the library.
+In the first two approaches, which are marginally faster due to less memory
+copying, data is read in chunks by the library. In the third approach, each
+chunk is passed manually by your code to the library.
 
 ### Getting parsed data from the parser to your code
 
@@ -67,15 +72,15 @@ You can either pull data from the parser, or push it to your code.
 With pull parsing, your code "pulls" each row using `zsv_next_row()`, which
 returns `zsv_status_row` until no more rows are left to parse
 
-```
+```c
 zsv_parser parser = zsv_new(...);
-while(zsv_next_row(parser) == zsv_status_row) { /* for each row */
+while (zsv_next_row(parser) == zsv_status_row) { // for each row
   // do something
   size_t cell_count = zsv_cell_count(parser);
   for(size_t i = 0; i < cell_count; i++) {
     struct zsv_cell c = zsv_get_cell(parser, i);
     fprintf(stderr, "Cell: %.*s\n", c.len, c.str);
-    ...
+    // ...
   }
 }
 ```
@@ -87,83 +92,89 @@ An full example is at [pull.c](pull.c).
 For either pull or push parsing, the current row and each of its cells can be
 fetched using `zsv_cell_count()` and `zsv_get_cell()`:
 
-```
+```c
 size_t cell_count = zsv_cell_count(parser);
 
-for(size_t i = 0; i < cell_count; i++) {      /* for each cell in this row */
+for (size_t i = 0; i < cell_count; i++) { // for each cell in this row
   struct zsv_cell c = zsv_get_cell(parser, i);
-  /* now c.len contains the cell length in bytes */
-  /* if c.len > 0, c.str contains the cell contents */
+  // now c.len contains the cell length in bytes
+  // if c.len > 0, c.str contains the cell contents
   printf("Got cell: %.*s\n", c.len, c.len ? c.str : "");
 }
 ```
 
 #### Push parsing
 
-Data is "pushed" to handler callback, for each cell and/or row that is parsed. Each
-series of "pushes" is invoked via `zsv_parse_more()`, which reads the next chunk of
-bytes from your source and parses all of its contents.
+Data is "pushed" to handler callback, for each cell and/or row that is parsed.
+Each series of "pushes" is invoked via `zsv_parse_more()`, which reads the next
+chunk of bytes from your source and parses all of its contents.
 
-Push parsing in conjunction with a file or custom reader performs the fastest
-of all of the approaches, but the difference is too small to be measurable for
-any but the most trivial of tasks.
+Push parsing in conjunction with a file or custom reader performs the fastest of
+all of the approaches, but the difference is too small to be measurable for any
+but the most trivial of tasks.
 
 ##### Row handling
 
-With push parsing, you specify a cell and/or row handler.
-Usually, only a row handler will suffice. If your row handler code
-needs access to row contents (which is usually the case), then
-you just need to ensure its context argument points to a structure
-that contains your zsv parser, so that the row
-contents can be retrieved.
+With push parsing, you specify a cell and/or row handler. Usually, only a row
+handler will suffice. If your row handler code needs access to row contents
+(which is usually the case), then you just need to ensure its context argument
+points to a structure that contains your zsv parser, so that the row contents
+can be retrieved.
 
 For example, we could process each cell as follows:
-```
+
+```c
 static void my_row_handler(void *ctx) {
   struct my_data *data = ctx;
-
-  /* print every other cell */
+  // print every other cell
   size_t cell_count = zsv_cell_count(data->parser);
-  for(size_t i = 0, j = zsv_cell_count(data->parser); i < j; i++) {
-    /* use zsv_get_cell() and do something */
+  for (size_t i = 0, j = zsv_cell_count(data->parser); i < j; i++) {
+    // use zsv_get_cell() and do something
   }
 }
-
 ...
 
-struct my_data d = { 0 };
+struct my_data d = {0};
 d.parser = zsv_new(NULL);
 zsv_set_row_handler(d.parser, my_row_handler);
 zsv_set_context(p, &d);
 ```
 
 ### Other options
-Many other options are supported through the use of `struct zsv_opts`, only some of which are described
-in this introduction. For further detail, please visit
+
+Many other options are supported through the use of `struct zsv_opts`, only some
+of which are described in this introduction. For further detail, please visit
 [zsv/common.h](../../include/zsv/common.h).
 
 #### Delimiter
+
 The `delimiter` option can specify any single-character delimiter other than
 newline, form feed or quote. The default value is a comma.
 
 #### Blank leading rows
-By default, libzsv skips any leading blank rows, before it makes any callbacks. This behavior
-can be disabled by setting the `keep_empty_header_rows` option flag.
+
+By default, libzsv skips any leading blank rows, before it makes any callbacks.
+This behavior can be disabled by setting the `keep_empty_header_rows` option
+flag.
 
 #### Maximum number of rows
+
 By default, libzsv assumes a maximum number of columns per table of 1024. This
 can be changed by setting the `max_columns` option.
 
 #### Header row span
-If your header spans more than one row, you can instruct libzsv to merge header cells
-with a single space before it makes its initial row handler call by setting `header_span`
-to a number greater than 1. For example, if your input is as follows:
-```
+
+If your header spans more than one row, you can instruct libzsv to merge header
+cells with a single space before it makes its initial row handler call by
+setting `header_span` to a number greater than 1. For example, if your input is
+as follows:
+
+```csv
 Street,Phone,City,Zip
 Address,Number,,Code
 888 Madison,212-555-1212,New York,10001
 ```
 
-and you set `header_span` to 2, then in your first row handler call, the cell values
-will be `Street Address`, `Phone Number`, `City` and `Zip Code`, after which the
-row handler will be called for each single row that is parsed.
+and you set `header_span` to 2, then in your first row handler call, the cell
+values will be `Street Address`, `Phone Number`, `City` and `Zip Code`, after
+which the row handler will be called for each single row that is parsed.

--- a/examples/lib/parse_by_chunk.c
+++ b/examples/lib/parse_by_chunk.c
@@ -39,8 +39,8 @@ static void chunk_parse_row(void *dat) {
  * otherwise will read from stdin and run through the CSV parser
  */
 int main(int argc, const char *argv[]) {
-  if(argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
-    printf("Usage: parse_by_chunk < myfile.csv\n\n");
+  if (argc > 1 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+    printf("Usage: parse_by_chunk < file.csv\n\n");
     printf("Reads stdin in chunks, parses each chunk using `zsv_parse_bytes()`,\n");
     printf("and outputs the number of rows parsed.\n");
     return 0;
@@ -52,14 +52,14 @@ int main(int argc, const char *argv[]) {
    * create a vanilla parser
    */
   zsv_parser p = zsv_new(NULL);
-  if(!p)
+  if (!p)
     fprintf(stderr, "Out of memory!");
   else {
     /**
      * Configure the parser to use our row handler, and to pass
      * it our data when it's called
      */
-    struct chunk_parse_data d = { 0 };
+    struct chunk_parse_data d = {0};
     zsv_set_row_handler(p, chunk_parse_row);
     zsv_set_context(p, &d);
 
@@ -74,9 +74,9 @@ int main(int argc, const char *argv[]) {
     /**
      * Read and parse each chunk until the end of the stream is reached
      */
-    while(1) {
+    while (1) {
       size_t bytes_read = fread(buff, 1, chunk_size, f);
-      if(!bytes_read)
+      if (!bytes_read)
         break;
       zsv_parse_bytes(p, buff, bytes_read);
     }

--- a/examples/lib/print_my_column.c
+++ b/examples/lib/print_my_column.c
@@ -45,16 +45,16 @@ static void find_my_column(void *ctx) {
   /* iterate through each cell */
   size_t cell_count = zsv_cell_count(data->parser);
   char found = 0;
-  for(size_t i = 0; i < cell_count; i++) {
+  for (size_t i = 0; i < cell_count; i++) {
     struct zsv_cell c = zsv_get_cell(data->parser, i);
-    if(c.len == target_column_name_len && !memcmp(data->target_column_name, c.str, c.len)) {
+    if (c.len == target_column_name_len && !memcmp(data->target_column_name, c.str, c.len)) {
       data->target_column_position = i;
       found = 1;
       break;
     }
   }
 
-  if(!found) {
+  if (!found) {
     /**
      * We couldn't find the target column name in our header row. Output a message and abort
      */
@@ -98,23 +98,25 @@ static void print_my_column(void *ctx) {
  * name, read from stdin, and output, for each row, the specified column
  */
 int main(int argc, const char *argv[]) {
-  if(argc < 2) {
+  if (argc < 2) {
     fprintf(stderr, "Usage: print_my_column column_name < input.csv\n");
-    fprintf(stderr, "Example:\n"
-            "  echo \"A,B,C\\nA1,B1,C1\\nA2,B2,\\nA3,,C3\\n,,C3\" | %s B\n\n", argv[0]);
+    fprintf(stderr,
+            "Example:\n"
+            "  echo \"A,B,C\\nA1,B1,C1\\nA2,B2,\\nA3,,C3\\n,,C3\" | %s B\n\n",
+            argv[0]);
     return 0;
   }
 
   /**
    * Initialize context data
    */
-  struct my_data data = { 0 };
+  struct my_data data = {0};
   data.target_column_name = argv[1];
 
   /**
    * Initialize parser options
    */
-  struct zsv_opts opts = { 0 };
+  struct zsv_opts opts = {0};
   opts.row_handler = find_my_column;
   opts.ctx = &data;
 
@@ -128,7 +130,7 @@ int main(int argc, const char *argv[]) {
    * or an error has occurred (such as not finding the specified
    * column name in the first row)
    */
-  while(zsv_parse_more(data.parser) == zsv_status_ok)
+  while (zsv_parse_more(data.parser) == zsv_status_ok)
     ;
 
   /**

--- a/examples/lib/pull.c
+++ b/examples/lib/pull.c
@@ -25,17 +25,19 @@
  * and output, for each row, the numbers of total and blank cells
  */
 int main(int argc, const char *argv[]) {
-  if(argc != 2) {
+  if (argc != 2) {
     fprintf(stderr, "Reads a CSV file or stdin, and for each row,\n"
-            " output counts of total and blank cells\n");
+                    " output counts of total and blank cells\n");
     fprintf(stderr, "Usage: simple <filename or dash(-) for stdin>\n");
-    fprintf(stderr, "Example:\n"
-            "  echo \"A1,B1,C1\\nA2,B2,\\nA3,,C3\\n,,C3\" | %s -\n\n", argv[0]);
+    fprintf(stderr,
+            "Example:\n"
+            "  echo \"A1,B1,C1\\nA2,B2,\\nA3,,C3\\n,,C3\" | %s -\n\n",
+            argv[0]);
     return 0;
   }
 
   FILE *f = strcmp(argv[1], "-") ? fopen(argv[1], "rb") : stdin;
-  if(!f) {
+  if (!f) {
     perror(argv[1]);
     return 1;
   }
@@ -43,10 +45,10 @@ int main(int argc, const char *argv[]) {
   /**
    * Create a parser
    */
-  struct zsv_opts opts = { 0 };
+  struct zsv_opts opts = {0};
   opts.stream = f;
   zsv_parser parser = zsv_new(&opts);
-  if(!parser) {
+  if (!parser) {
     fprintf(stderr, "Could not allocate parser!\n");
     return -1;
   }
@@ -55,7 +57,7 @@ int main(int argc, const char *argv[]) {
    * iterate through all rows
    */
   size_t row_num = 0;
-  while(zsv_next_row(parser) == zsv_status_row) {
+  while (zsv_next_row(parser) == zsv_status_row) {
     row_num++;
 
     /* get a cell count */
@@ -63,24 +65,24 @@ int main(int argc, const char *argv[]) {
 
     /* iterate through each cell in this row, to count blanks */
     size_t nonblank = 0;
-    for(size_t i = 0; i < cell_count; i++) {
+    for (size_t i = 0; i < cell_count; i++) {
       struct zsv_cell c = zsv_get_cell(parser, i);
       /* use r.values[] and r.lengths[] to get cell data */
       /* Here, we only care about lengths */
-      if(c.len > 0)
+      if (c.len > 0)
         nonblank++;
     }
 
     /* print our results for this row */
-    printf("Row %zu has %zu columns of which %zu %s non-blank\n", row_num,
-           cell_count, nonblank, nonblank == 1 ? "is" : "are");
+    printf("Row %zu has %zu columns of which %zu %s non-blank\n", row_num, cell_count, nonblank,
+           nonblank == 1 ? "is" : "are");
   }
   /**
    * Clean up
    */
   zsv_delete(parser);
 
-  if(f != stdin)
+  if (f != stdin)
     fclose(f);
 
   return 0;

--- a/examples/lib/simple.c
+++ b/examples/lib/simple.c
@@ -37,17 +37,18 @@ void my_row_handler(void *ctx) {
 
   /* iterate through each cell in this row, to count blanks */
   size_t nonblank = 0;
-  for(size_t i = 0; i < cell_count; i++) {
+  for (size_t i = 0; i < cell_count; i++) {
     /* use zsv_get_cell() to get our cell data */
     struct zsv_cell c = zsv_get_cell(data->parser, i);
 
     /* check if the cell data length is zero */
-    if(c.len > 0)
+    if (c.len > 0)
       nonblank++;
   }
 
   /* print our results for this row */
-  printf("Row %zu has %zu columns of which %zu %s non-blank\n", ++data->row_num, cell_count, nonblank, nonblank == 1 ? "is" : "are");
+  printf("Row %zu has %zu columns of which %zu %s non-blank\n", ++data->row_num, cell_count, nonblank,
+         nonblank == 1 ? "is" : "are");
 }
 
 /**
@@ -59,17 +60,19 @@ int main(int argc, const char *argv[]) {
   /**
    * Process our arguments; output usage and/or errors if appropriate
    */
-  if(argc != 2) {
+  if (argc != 2) {
     fprintf(stderr, "Reads a CSV file or stdin, and for each row,\n"
-            " output counts of total and blank cells\n");
+                    " output counts of total and blank cells\n");
     fprintf(stderr, "Usage: simple <filename or dash(-) for stdin>\n");
-    fprintf(stderr, "Example:\n"
-            "  echo \"A1,B1,C1\\nA2,B2,\\nA3,,C3\\n,,C3\" | %s -\n\n", argv[0]);
+    fprintf(stderr,
+            "Example:\n"
+            "  echo \"A1,B1,C1\\nA2,B2,\\nA3,,C3\\n,,C3\" | %s -\n\n",
+            argv[0]);
     return 0;
   }
 
   FILE *f = strcmp(argv[1], "-") ? fopen(argv[1], "rb") : stdin;
-  if(!f) {
+  if (!f) {
     perror(argv[1]);
     return 1;
   }
@@ -81,9 +84,9 @@ int main(int argc, const char *argv[]) {
    * delimited; header row span etc)-- for details, see
    * ../../include/zsv/api.h
    */
-  struct zsv_opts opts = { 0 };
+  struct zsv_opts opts = {0};
   opts.row_handler = my_row_handler;
-  struct my_data data = { 0 };
+  struct my_data data = {0};
   opts.ctx = &data;
   opts.stream = f;
 
@@ -96,8 +99,7 @@ int main(int argc, const char *argv[]) {
    * Continuously parse our input until we have no more input
    */
   enum zsv_status stat;
-  while((stat = zsv_parse_more(data.parser)) == zsv_status_ok)
-    ;
+  while ((stat = zsv_parse_more(data.parser)) == zsv_status_ok);
 
   /**
    * Clean up
@@ -105,13 +107,13 @@ int main(int argc, const char *argv[]) {
   zsv_finish(data.parser);
   zsv_delete(data.parser);
 
-  if(f != stdin)
+  if (f != stdin)
     fclose(f);
 
   /**
    * If there was a parse error, print it
    */
-  if(stat != zsv_status_no_more_input) {
+  if (stat != zsv_status_no_more_input) {
     fprintf(stderr, "Parse error: %s\n", zsv_parse_status_desc(stat));
     return 1;
   }

--- a/examples/lib/simple.c
+++ b/examples/lib/simple.c
@@ -99,7 +99,8 @@ int main(int argc, const char *argv[]) {
    * Continuously parse our input until we have no more input
    */
   enum zsv_status stat;
-  while ((stat = zsv_parse_more(data.parser)) == zsv_status_ok);
+  while ((stat = zsv_parse_more(data.parser)) == zsv_status_ok)
+    ;
 
   /**
    * Clean up

--- a/include/zsv/api.h
+++ b/include/zsv/api.h
@@ -18,7 +18,7 @@
 #define ZSV_ROW_MAX_SIZE_MIN_S "1024"
 
 #define ZSV_MIN_SCANNER_BUFFSIZE 4096
-#define ZSV_DEFAULT_SCANNER_BUFFSIZE (1<<18) // 256k
+#define ZSV_DEFAULT_SCANNER_BUFFSIZE (1 << 18) // 256k
 
 #include "zsv_export.h"
 /*****************************************************************************
@@ -78,7 +78,6 @@ ZSV_EXPORT enum zsv_status zsv_finish(zsv_parser);
  * Dispose of a parser that was created with `zsv_new()` or `zsv_new_with_properties()`
  */
 ZSV_EXPORT enum zsv_status zsv_delete(zsv_parser);
-
 
 /******************************************************************************
  * minimal access functions:
@@ -154,8 +153,7 @@ const char *zsv_lib_version(void);
  * @param parser
  * @param row_handler new callback value
  */
-ZSV_EXPORT void zsv_set_row_handler(zsv_parser,
-                                    void (*row_handler)(void *ctx));
+ZSV_EXPORT void zsv_set_row_handler(zsv_parser, void (*row_handler)(void *ctx));
 
 /**
  * Check if the row we just parsed consisted entirely of blank data
@@ -183,8 +181,7 @@ void zsv_set_context(zsv_parser parser, void *ctx);
  * @param stream        value that is passed to read_function when it is called
  */
 ZSV_EXPORT
-void zsv_set_read(zsv_parser parser,
-                  size_t (*read_func)(void * restrict, size_t n, size_t size, void * restrict));
+void zsv_set_read(zsv_parser parser, size_t (*read_func)(void *restrict, size_t n, size_t size, void *restrict));
 
 /**
  * Set the input stream our parser reads from. If not explicity set, defaults to
@@ -209,9 +206,7 @@ void zsv_set_input(zsv_parser, void *in);
  *               does not exceed the bufflen it was passed
  */
 ZSV_EXPORT enum zsv_status zsv_set_scan_filter(zsv_parser parser,
-                                               size_t (*filter)(void *ctx,
-                                                                unsigned char *buff,
-                                                                size_t bufflen),
+                                               size_t (*filter)(void *ctx, unsigned char *buff, size_t bufflen),
                                                void *ctx);
 
 /**
@@ -233,9 +228,7 @@ ZSV_EXPORT enum zsv_status zsv_set_fixed_offsets(zsv_parser parser, size_t count
  *               the parser buffer!
  * @param len    length of the input to parse
  */
-ZSV_EXPORT enum zsv_status zsv_parse_bytes(zsv_parser parser,
-                                           const unsigned char *restrict buff,
-                                           size_t len);
+ZSV_EXPORT enum zsv_status zsv_parse_bytes(zsv_parser parser, const unsigned char *restrict buff, size_t len);
 
 /**
  * Get a text description of a status code
@@ -288,23 +281,16 @@ char zsv_quoted(zsv_parser parser);
  * Each argument to `zsv_opts_new()` corresponds to the same-named `struct zsv_opts` element
  * See common.h for details
  */
-ZSV_EXPORT struct zsv_opts *
-zsv_opts_new(
-               void (*row_handler)(void *ctx),
-               void (*cell_handler)(void *ctx, unsigned char *utf8_value, size_t len),
-               void *ctx,
-               zsv_generic_read read,
-               void *stream,
-               unsigned char *buff,
-               size_t buffsize,
-               unsigned max_columns,
-               unsigned max_row_size,
-               char delimiter,
-               char no_quotes
+ZSV_EXPORT struct zsv_opts *zsv_opts_new(void (*row_handler)(void *ctx),
+                                         void (*cell_handler)(void *ctx, unsigned char *utf8_value, size_t len),
+                                         void *ctx, zsv_generic_read read, void *stream, unsigned char *buff,
+                                         size_t buffsize, unsigned max_columns, unsigned max_row_size, char delimiter,
+                                         char no_quotes
 #ifdef ZSV_EXTRAS
-               , size_t max_rows
+                                         ,
+                                         size_t max_rows
 #endif
-             );
+);
 
 /**
  * Destroy an option structure that was created by zsv_opts_new()
@@ -323,7 +309,6 @@ ZSV_EXPORT void zsv_opts_delete(struct zsv_opts *);
  */
 ZSV_EXPORT
 enum zsv_status zsv_next_row(zsv_parser parser);
-
 
 /******************************************************************************
  * Miscellaneous functions used by the parser that may have standalone utility

--- a/include/zsv/common.h
+++ b/include/zsv/common.h
@@ -10,11 +10,11 @@
 #define ZSV_COMMON_H
 
 #ifdef __cplusplus
-# define ZSV_BEGIN_DECL extern "C" {
-# define ZSV_END_DECL	}
+#define ZSV_BEGIN_DECL extern "C" {
+#define ZSV_END_DECL }
 #else
-# define ZSV_BEGIN_DECL
-# define ZSV_END_DECL	/* empty */
+#define ZSV_BEGIN_DECL
+#define ZSV_END_DECL /* empty */
 #endif
 
 enum zsv_status {
@@ -27,14 +27,15 @@ enum zsv_status {
   zsv_status_row,
   zsv_status_done = 100
 #ifdef ZSV_EXTRAS
-  ,zsv_status_max_rows_read = 999
+    ,
+  zsv_status_max_rows_read = 999
 #endif
 };
 
 /**
  * `zsv_parser` is the type of a zsv parser handle
  */
-typedef struct zsv_scanner * zsv_parser;
+typedef struct zsv_scanner *zsv_parser;
 
 /**
  * Structure returned by `zsv_get_cell()` for fetching a parsed CSV cell value
@@ -53,12 +54,12 @@ struct zsv_cell {
   /**
    * bitfield values for `quoted` flags
    */
-#  define ZSV_PARSER_QUOTE_NONE     0 /* content does not need to be quoted */
-#  define ZSV_PARSER_QUOTE_UNCLOSED 1 /* only used internally by parser */
-#  define ZSV_PARSER_QUOTE_CLOSED   2 /* value was quoted */
-#  define ZSV_PARSER_QUOTE_NEEDED   4 /* value contains delimiter or dbl-quote */
-#  define ZSV_PARSER_QUOTE_EMBEDDED 8 /* value contains dbl-quote */
-#  define ZSV_PARSER_QUOTE_PENDING 16 /* only used internally by parser */
+#define ZSV_PARSER_QUOTE_NONE 0     /* content does not need to be quoted */
+#define ZSV_PARSER_QUOTE_UNCLOSED 1 /* only used internally by parser */
+#define ZSV_PARSER_QUOTE_CLOSED 2   /* value was quoted */
+#define ZSV_PARSER_QUOTE_NEEDED 4   /* value contains delimiter or dbl-quote */
+#define ZSV_PARSER_QUOTE_EMBEDDED 8 /* value contains dbl-quote */
+#define ZSV_PARSER_QUOTE_PENDING 16 /* only used internally by parser */
   /**
    * quoted flags enable additional efficiency, in particular when input data will
    * be output as text (csv, json etc), by indicating whether the cell contents may
@@ -67,13 +68,13 @@ struct zsv_cell {
    * quoting or escaping will be required
    */
   char quoted;
-  unsigned char overwritten:1;
+  unsigned char overwritten : 1;
 };
 
-typedef size_t (*zsv_generic_write)(const void * restrict,  size_t,  size_t,  void * restrict);
-typedef size_t (*zsv_generic_read)(void * restrict, size_t n, size_t size, void * restrict);
+typedef size_t (*zsv_generic_write)(const void *restrict, size_t, size_t, void *restrict);
+typedef size_t (*zsv_generic_read)(void *restrict, size_t n, size_t size, void *restrict);
 
-# ifdef ZSV_EXTRAS
+#ifdef ZSV_EXTRAS
 /**
  * progress callback function signature
  * @param context pointer set in parser opts.progress.ctx
@@ -96,7 +97,7 @@ typedef void (*zsv_completed_callback)(void *ctx, int code);
  */
 enum zsv_overwrite_type {
   zsv_overwrite_type_unknown = 0, // do not change
-  zsv_overwrite_type_none = 1, // do not change
+  zsv_overwrite_type_none = 1,    // do not change
   zsv_overwrite_type_csv
   // to do: zsv_overwrite_type_sqlite3
 };
@@ -107,7 +108,7 @@ struct zsv_opt_overwrite {
   int (*close_ctx)(void *);
 };
 
-# endif
+#endif
 
 struct zsv_opts {
   /**
@@ -251,7 +252,7 @@ struct zsv_opts {
 #define ZSV_MALFORMED_UTF8_REMOVE -1
   char malformed_utf8_replace;
 
-# ifdef ZSV_EXTRAS
+#ifdef ZSV_EXTRAS
   struct {
     /**
      * min number of rows between progress callback calls
@@ -295,7 +296,7 @@ struct zsv_opts {
    */
   struct zsv_opt_overwrite overwrite;
 
-# endif
+#endif
 };
 
 #endif

--- a/include/zsv/common.h
+++ b/include/zsv/common.h
@@ -17,7 +17,8 @@
 #define ZSV_END_DECL /* empty */
 #endif
 
-enum zsv_status {
+enum zsv_status
+{
   zsv_status_ok = 0,
   zsv_status_cancelled,
   zsv_status_no_more_input,
@@ -95,7 +96,8 @@ typedef void (*zsv_completed_callback)(void *ctx, int code);
  *   (row, column, value) tuples
  * Supported source formats are CSV and SQLITE3
  */
-enum zsv_overwrite_type {
+enum zsv_overwrite_type
+{
   zsv_overwrite_type_unknown = 0, // do not change
   zsv_overwrite_type_none = 1,    // do not change
   zsv_overwrite_type_csv

--- a/include/zsv/common.h
+++ b/include/zsv/common.h
@@ -17,8 +17,7 @@
 #define ZSV_END_DECL /* empty */
 #endif
 
-enum zsv_status
-{
+enum zsv_status {
   zsv_status_ok = 0,
   zsv_status_cancelled,
   zsv_status_no_more_input,
@@ -96,8 +95,7 @@ typedef void (*zsv_completed_callback)(void *ctx, int code);
  *   (row, column, value) tuples
  * Supported source formats are CSV and SQLITE3
  */
-enum zsv_overwrite_type
-{
+enum zsv_overwrite_type {
   zsv_overwrite_type_unknown = 0, // do not change
   zsv_overwrite_type_none = 1,    // do not change
   zsv_overwrite_type_csv

--- a/include/zsv/ext.h
+++ b/include/zsv/ext.h
@@ -28,7 +28,8 @@ ZSV_BEGIN_DECL
  * zsv_ext_status_error, then furthermore, `zsv_ext_errstr()` will be called
  * and any non-null result displayed as an error message
  */
-enum zsv_ext_status {
+enum zsv_ext_status
+{
   zsv_ext_status_ok = 0,
   zsv_ext_status_memory,
   zsv_ext_status_unrecognized_cmd,

--- a/include/zsv/ext.h
+++ b/include/zsv/ext.h
@@ -52,12 +52,13 @@ enum zsv_ext_status {
  *   `set_ext_context()`
  *   `get_ext_context()`
  */
-typedef void * zsv_execution_context;
+typedef void *zsv_execution_context;
 
 /**
  * Signature of the function called for each implemented sub-command
  */
-typedef enum zsv_ext_status (*zsv_ext_main)(zsv_execution_context ctx, int argc, const char *argv[], struct zsv_opts *opts, const char *opts_used);
+typedef enum zsv_ext_status (*zsv_ext_main)(zsv_execution_context ctx, int argc, const char *argv[],
+                                            struct zsv_opts *opts, const char *opts_used);
 
 /**
  * ZSV callbacks structure
@@ -94,8 +95,7 @@ struct zsv_ext_callbacks {
    * To add an extension command, invoke `ext_add_command`, passing it your command's
    * handler function as a callback with a `zsv_ext_main` signature
    */
-  enum zsv_ext_status (*ext_add_command)(zsv_execution_context ctx,
-                                         const char *id, const char *help,
+  enum zsv_ext_status (*ext_add_command)(zsv_execution_context ctx, const char *id, const char *help,
                                          zsv_ext_main main);
   void (*ext_set_help)(zsv_execution_context ctx, const char *help);
   void (*ext_set_license)(zsv_execution_context ctx, const char *license);
@@ -126,9 +126,7 @@ struct zsv_ext_callbacks {
    * convenience function that calls ext_args_to_opts, allocates parser,
    * sets custom ctx, runs parser, and de-allocates parser
    */
-  enum zsv_ext_status (*ext_parse_all)(zsv_execution_context ctx,
-                                       void *user_context,
-                                       void (*row_handler)(void *ctx),
+  enum zsv_ext_status (*ext_parse_all)(zsv_execution_context ctx, void *user_context, void (*row_handler)(void *ctx),
                                        struct zsv_opts *const custom);
   /**
    * As an alternative to `ext_parse_all()`, for more granular control:

--- a/include/zsv/ext.h
+++ b/include/zsv/ext.h
@@ -28,8 +28,7 @@ ZSV_BEGIN_DECL
  * zsv_ext_status_error, then furthermore, `zsv_ext_errstr()` will be called
  * and any non-null result displayed as an error message
  */
-enum zsv_ext_status
-{
+enum zsv_ext_status {
   zsv_ext_status_ok = 0,
   zsv_ext_status_memory,
   zsv_ext_status_unrecognized_cmd,

--- a/include/zsv/ext/implementation.h
+++ b/include/zsv/ext/implementation.h
@@ -24,7 +24,7 @@
  * extension
  */
 #ifndef ZSV_EXT
-# define ZSV_EXT 1
+#define ZSV_EXT 1
 #endif
 
 ZSV_BEGIN_DECL

--- a/include/zsv/ext/implementation_private.h
+++ b/include/zsv/ext/implementation_private.h
@@ -94,7 +94,7 @@ enum zsv_ext_status zsv_ext_exit(void);
  * @param argv Arguments
  */
 ZSV_EXT_EXPORT
-const char * const *zsv_ext_help(int argc, const char *argv[]);
+const char *const *zsv_ext_help(int argc, const char *argv[]);
 
 /**
  * License message. Displayed when user enters any command beginning with
@@ -102,7 +102,7 @@ const char * const *zsv_ext_help(int argc, const char *argv[]);
  *
  */
 ZSV_EXT_EXPORT
-const char * const *zsv_ext_license(void);
+const char *const *zsv_ext_license(void);
 
 /**
  * Version message. Displayed when user enters any command beginning with
@@ -110,4 +110,4 @@ const char * const *zsv_ext_license(void);
  *
  */
 ZSV_EXT_EXPORT
-const char * const *zsv_ext_version(void);
+const char *const *zsv_ext_version(void);

--- a/include/zsv/utils/arg.h
+++ b/include/zsv/utils/arg.h
@@ -14,9 +14,7 @@
 #include <zsv/common.h>
 
 /* havearg(): case-insensitive partial arg matching */
-char havearg(const char *arg,
-             const char *form1, size_t min_len1,
-             const char *form2, size_t min_len2);
+char havearg(const char *arg, const char *form1, size_t min_len1, const char *form2, size_t min_len2);
 
 /**
  * set or get default parser options
@@ -27,7 +25,7 @@ struct zsv_opts zsv_get_default_opts(void);
 
 void zsv_clear_default_opts(void);
 
-#  ifdef ZSV_EXTRAS
+#ifdef ZSV_EXTRAS
 
 /**
  * set the default option progress callback (e.g. from wasm where `struct zsv_opts`
@@ -36,7 +34,8 @@ void zsv_clear_default_opts(void);
  * @param ctx pointer passed to callback
  * @param frequency number of rows to parse between progress calls
  */
-void zsv_set_default_progress_callback(zsv_progress_callback cb, void *ctx, size_t rows_interval, unsigned int seconds_interval);
+void zsv_set_default_progress_callback(zsv_progress_callback cb, void *ctx, size_t rows_interval,
+                                       unsigned int seconds_interval);
 
 /**
  * set the default option completed callback (e.g. from wasm where `struct zsv_opts`
@@ -46,7 +45,7 @@ void zsv_set_default_progress_callback(zsv_progress_callback cb, void *ctx, size
  */
 void zsv_set_default_completed_callback(zsv_completed_callback cb, void *ctx);
 
-#  endif
+#endif
 
 /**
  * Convert common command-line arguments to zsv_opts
@@ -76,11 +75,8 @@ void zsv_set_default_completed_callback(zsv_completed_callback cb, void *ctx);
  *                     "     q R   "
  * @return           zero on success, non-zero on error
  */
-enum zsv_status zsv_args_to_opts(int argc, const char *argv[],
-                                 int *argc_out, const char **argv_out,
-                                 struct zsv_opts *opts_out,
-                                 char *opts_used
-                                 );
+enum zsv_status zsv_args_to_opts(int argc, const char *argv[], int *argc_out, const char **argv_out,
+                                 struct zsv_opts *opts_out, char *opts_used);
 
 /**
  * Fetch the next arg, if it exists, else print an error message

--- a/include/zsv/utils/cache.h
+++ b/include/zsv/utils/cache.h
@@ -17,41 +17,32 @@
  * Cache path definitions
  */
 #ifdef _WIN32
-#define ZSV_CACHE_DIR "."ZSV_CACHE_PREFIX "\\data"
+#define ZSV_CACHE_DIR "." ZSV_CACHE_PREFIX "\\data"
 #else
-#define ZSV_CACHE_DIR "."ZSV_CACHE_PREFIX "/data"
+#define ZSV_CACHE_DIR "." ZSV_CACHE_PREFIX "/data"
 #endif
 
 #define ZSV_CACHE_PROPERTIES_NAME "props"
-
 
 /**
  * Return the folder or file path to the cache for a given data file
  * Caller must free the returned result
  */
-unsigned char *zsv_cache_path(const unsigned char *data_filepath,
-                              const unsigned char *cache_filename,
-                              char temp_file);
+unsigned char *zsv_cache_path(const unsigned char *data_filepath, const unsigned char *cache_filename, char temp_file);
 
 enum zsv_cache_type {
   zsv_cache_type_property = 1,
   zsv_cache_type_tag
 };
 
-unsigned char *zsv_cache_filepath(const unsigned char *data_filepath,
-                                  enum zsv_cache_type type, char create_dir,
+unsigned char *zsv_cache_filepath(const unsigned char *data_filepath, enum zsv_cache_type type, char create_dir,
                                   char temp_file);
 
-int zsv_cache_print(const unsigned char *filepath, enum zsv_cache_type ctype,
-                    const unsigned char *default_value);
+int zsv_cache_print(const unsigned char *filepath, enum zsv_cache_type ctype, const unsigned char *default_value);
 
 int zsv_cache_remove(const unsigned char *filepath, enum zsv_cache_type ctype);
 
-int zsv_modify_cache_file(const unsigned char *filepath,
-                          enum zsv_cache_type ctype,
-                          const unsigned char *json_value1,
-                          const unsigned char *json_value2,
-                          const unsigned char *filter
-                          );
+int zsv_modify_cache_file(const unsigned char *filepath, enum zsv_cache_type ctype, const unsigned char *json_value1,
+                          const unsigned char *json_value2, const unsigned char *filter);
 
 #endif

--- a/include/zsv/utils/cache.h
+++ b/include/zsv/utils/cache.h
@@ -30,7 +30,8 @@
  */
 unsigned char *zsv_cache_path(const unsigned char *data_filepath, const unsigned char *cache_filename, char temp_file);
 
-enum zsv_cache_type {
+enum zsv_cache_type
+{
   zsv_cache_type_property = 1,
   zsv_cache_type_tag
 };

--- a/include/zsv/utils/cache.h
+++ b/include/zsv/utils/cache.h
@@ -30,8 +30,7 @@
  */
 unsigned char *zsv_cache_path(const unsigned char *data_filepath, const unsigned char *cache_filename, char temp_file);
 
-enum zsv_cache_type
-{
+enum zsv_cache_type {
   zsv_cache_type_property = 1,
   zsv_cache_type_tag
 };

--- a/include/zsv/utils/clock.h
+++ b/include/zsv/utils/clock.h
@@ -15,17 +15,9 @@
 void zsv_clocks_begin();
 void zsv_clocks_end();
 
-size_t
-zsv_fread_clock(void *restrict ptr, size_t size, size_t nitems,
-                FILE *restrict stream);
-
-size_t
-zsv_fwrite_clock(const void *restrict ptr, size_t size, size_t nitems,
-                 FILE *restrict stream);
-
-int
-zsv_fflush_clock(FILE *stream);
-
+size_t zsv_fread_clock(void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream);
+size_t zsv_fwrite_clock(const void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream);
+int zsv_fflush_clock(FILE *stream);
 
 #if USE_CLOCK
 

--- a/include/zsv/utils/compiler.h
+++ b/include/zsv/utils/compiler.h
@@ -11,47 +11,47 @@
 
 #ifdef HAVE___BUILTIN_EXPECT
 
-# ifndef LIKELY
-# define LIKELY(x) __builtin_expect(x, 1)
-# endif
+#ifndef LIKELY
+#define LIKELY(x) __builtin_expect(x, 1)
+#endif
 
-# ifndef UNLIKELY
-# define UNLIKELY(x) __builtin_expect(x, 0)
-# endif
+#ifndef UNLIKELY
+#define UNLIKELY(x) __builtin_expect(x, 0)
+#endif
 
-# ifndef VERY_LIKELY
-#  ifdef NO___BUILTIN_EXPECT_WITH_PROBABILITY
-#   define VERY_LIKELY(x) LIKELY(x)
-#  else
-#   define VERY_LIKELY(x) __builtin_expect_with_probability(x, 1, 0.999)
-#  endif
-# endif
+#ifndef VERY_LIKELY
+#ifdef NO___BUILTIN_EXPECT_WITH_PROBABILITY
+#define VERY_LIKELY(x) LIKELY(x)
+#else
+#define VERY_LIKELY(x) __builtin_expect_with_probability(x, 1, 0.999)
+#endif
+#endif
 
-# ifndef VERY_UNLIKELY
-#  ifdef NO___BUILTIN_EXPECT_WITH_PROBABILITY
-#   define VERY_UNLIKELY(x) UNLIKELY(x)
-#  else
-#   define VERY_UNLIKELY(x) __builtin_expect_with_probability(x, 0, 0.999)
-#  endif
-# endif
+#ifndef VERY_UNLIKELY
+#ifdef NO___BUILTIN_EXPECT_WITH_PROBABILITY
+#define VERY_UNLIKELY(x) UNLIKELY(x)
+#else
+#define VERY_UNLIKELY(x) __builtin_expect_with_probability(x, 0, 0.999)
+#endif
+#endif
 
 #else
 /* no HAVE___BUILTIN_EXPECT */
-# ifndef LIKELY
-# define LIKELY(x) (x)
-# endif
+#ifndef LIKELY
+#define LIKELY(x) (x)
+#endif
 
-# ifndef UNLIKELY
-# define UNLIKELY(x) (x)
-# endif
+#ifndef UNLIKELY
+#define UNLIKELY(x) (x)
+#endif
 
-# ifndef VERY_LIKELY
-# define VERY_LIKELY(x) (x)
-# endif
+#ifndef VERY_LIKELY
+#define VERY_LIKELY(x) (x)
+#endif
 
-# ifndef VERY_UNLIKELY
-# define VERY_UNLIKELY(x) (x)
-# endif
+#ifndef VERY_UNLIKELY
+#define VERY_UNLIKELY(x) (x)
+#endif
 
 #endif /* HAVE___BUILTIN_EXPECT */
 

--- a/include/zsv/utils/dirs.h
+++ b/include/zsv/utils/dirs.h
@@ -13,16 +13,16 @@
 
 /* Maximum length of file name */
 #if !defined(FILENAME_MAX)
-#   define FILENAME_MAX MAX_PATH
+#define FILENAME_MAX MAX_PATH
 #endif
 
 /* file slash */
 #if !defined(FILESLASH)
-# ifdef _WIN32
-#  define FILESLASH '\\'
-# else
-#  define FILESLASH '/'
-# endif
+#ifdef _WIN32
+#define FILESLASH '\\'
+#else
+#define FILESLASH '/'
+#endif
 #endif
 
 /**
@@ -30,12 +30,12 @@
  * prefix should be determined at compile time e.g. /usr/local or ""
  * @return length written to buff, or 0 if failed
  */
-size_t zsv_get_config_dir(char* buff, size_t buffsize, const char *prefix);
+size_t zsv_get_config_dir(char *buff, size_t buffsize, const char *prefix);
 
 /**
  * Get the path of the current executable
  */
-size_t zsv_get_executable_path(char* buff, size_t buffsize);
+size_t zsv_get_executable_path(char *buff, size_t buffsize);
 
 /**
  * Check if a directory exists
@@ -69,12 +69,12 @@ struct zsv_foreach_dirent_handle {
   const char *parent_and_entry; /* parent + entry separated by file separator */
   const struct stat stat;       /* stat of current entry */
 
-  void *ctx;                    /* caller-provided context to pass to handler */
+  void *ctx; /* caller-provided context to pass to handler */
 
-  unsigned char verbose:1;
-  unsigned char is_dir:1;       /* non-zero if this entry is a directory */
-  unsigned char no_recurse:1;   /* set to 1 when handling a dir to prevent recursing into it */
-  unsigned char _:5;
+  unsigned char verbose : 1;
+  unsigned char is_dir : 1;     /* non-zero if this entry is a directory */
+  unsigned char no_recurse : 1; /* set to 1 when handling a dir to prevent recursing into it */
+  unsigned char _ : 5;
 };
 
 typedef int (*zsv_foreach_dirent_handler)(struct zsv_foreach_dirent_handle *h, size_t depth);
@@ -90,17 +90,14 @@ typedef int (*zsv_foreach_dirent_handler)(struct zsv_foreach_dirent_handle *h, s
  *
  * returns error
  */
-int zsv_foreach_dirent(const char *dir_path,
-                       size_t max_depth,
-                       zsv_foreach_dirent_handler handler,
-                       void *ctx,
-                       char verbose
-                       );
+int zsv_foreach_dirent(const char *dir_path, size_t max_depth, zsv_foreach_dirent_handler handler, void *ctx,
+                       char verbose);
 
 struct zsv_dir_filter {
-  zsv_foreach_dirent_handler filter; /* filter function; return 1 to process this node. if node is dir, return 0 to skip entirely */
-  size_t max_depth;                  /* max depth to recurse */
-  void *ctx;                         /* pointer to pass to filter function */
+  zsv_foreach_dirent_handler
+    filter;         /* filter function; return 1 to process this node. if node is dir, return 0 to skip entirely */
+  size_t max_depth; /* max depth to recurse */
+  void *ctx;        /* pointer to pass to filter function */
 };
 
 /**
@@ -113,11 +110,8 @@ struct zsv_dir_filter {
  * @param output_filename : file path to output to, or NULL to output to stdout
  * @param file_filter     : filter determining which files to export
  */
-int zsv_dir_to_json(const unsigned char *parent_dir,
-                    const unsigned char *output_filename,
-                    struct zsv_dir_filter *file_filter,
-                    unsigned char verbose
-                    );
+int zsv_dir_to_json(const unsigned char *parent_dir, const unsigned char *output_filename,
+                    struct zsv_dir_filter *file_filter, unsigned char verbose);
 
 /**
  * Convert a JSON stream into file and directory contents
@@ -134,12 +128,10 @@ int zsv_dir_to_json(const unsigned char *parent_dir,
  */
 
 #define ZSV_DIR_FLAG_FORCE 1 /* overwrite target files if they already exist */
-#define ZSV_DIR_FLAG_DRY   2 /* dry run, output names of files that would be created/overwritten */
+#define ZSV_DIR_FLAG_DRY 2   /* dry run, output names of files that would be created/overwritten */
 
-int zsv_dir_from_json(const unsigned char *target_dir,
-                      FILE *fsrc,
+int zsv_dir_from_json(const unsigned char *target_dir, FILE *fsrc,
                       unsigned int flags, // ZSV_DIR_FLAG_XX
-                      unsigned char verbose
-                      );
+                      unsigned char verbose);
 
 #endif

--- a/include/zsv/utils/err.h
+++ b/include/zsv/utils/err.h
@@ -9,15 +9,14 @@
 #ifndef ZSV_ERR_H
 #define ZSV_ERR_H
 
-int zsv_app_printerr(const char *appname, int eno, const char *fmt, ... );
+int zsv_app_printerr(const char *appname, int eno, const char *fmt, ...);
 
 #ifdef APPNAME
-# define zsv_printerr(... ) zsv_app_printerr(APPNAME, __VA_ARGS__)
+#define zsv_printerr(...) zsv_app_printerr(APPNAME, __VA_ARGS__)
 #else
-# pragma message("zsv_printerr defined without APPNAME")
-# pragma message("to avoid this, include err.h after defining APPNAME to quoted string")
-# define zsv_printerr(... ) zsv_app_printerr(0x0, __VA_ARGS__)
+#pragma message("zsv_printerr defined without APPNAME")
+#pragma message("to avoid this, include err.h after defining APPNAME to quoted string")
+#define zsv_printerr(...) zsv_app_printerr(0x0, __VA_ARGS__)
 #endif
-
 
 #endif

--- a/include/zsv/utils/file.h
+++ b/include/zsv/utils/file.h
@@ -12,11 +12,11 @@
 #include <stdio.h>
 
 #ifndef LINEEND
-# if defined(WIN32) || defined(_WIN64) || defined(_WIN32)
-#  define LINEEND "\r\n"
-# else
-#  define LINEEND "\n"
-# endif
+#if defined(WIN32) || defined(_WIN64) || defined(_WIN32)
+#define LINEEND "\r\n"
+#else
+#define LINEEND "\n"
+#endif
 #endif // LINEEND
 /**
  * Get a temp file name. The returned value, if any, will have been allocated
@@ -32,7 +32,7 @@ char *zsv_get_temp_filename(const char *prefix);
  * @param filename
  * @returns: true  (1) if file exists
  */
-int zsv_file_exists(const char* filename);
+int zsv_file_exists(const char *filename);
 
 /**
  * Check if a file exists and is readable (with fopen + "rb")

--- a/include/zsv/utils/jq.h
+++ b/include/zsv/utils/jq.h
@@ -15,26 +15,23 @@ size_t zsv_jq_fwrite1(void *restrict FILE_ptr, const void *restrict buff, size_t
 
 struct jv_to_json_ctx {
   size_t (*write1)(void *restrict ctx, const void *restrict buff, size_t len); // e.g. zsv_jq_fwrite1
-  void *ctx; // e.g. FILE *
-  int flags; // passed on to jv_dumpf / jv_dump_string
+  void *ctx;                                                                   // e.g. FILE *
+  int flags;                                                                   // passed on to jv_dumpf / jv_dump_string
 };
 
 void jv_to_json_w_ctx(jv value, void *jv_to_json_ctx);
 
-typedef struct zsv_jq_data * zsv_jq_handle;
+typedef struct zsv_jq_data *zsv_jq_handle;
 
-zsv_jq_handle zsv_jq_new(const unsigned char *filter,
-                       void (*func)(jv, void *), void *ctx,
-                       enum zsv_jq_status *statusp);
+zsv_jq_handle zsv_jq_new(const unsigned char *filter, void (*func)(jv, void *), void *ctx, enum zsv_jq_status *statusp);
 
 // for streaming parsing
-zsv_jq_handle zsv_jq_new_stream(const unsigned char *filter,
-                              void (*func)(jv, void *), void *ctx,
-                              enum zsv_jq_status *statusp);
+zsv_jq_handle zsv_jq_new_stream(const unsigned char *filter, void (*func)(jv, void *), void *ctx,
+                                enum zsv_jq_status *statusp);
 
 enum zsv_jq_status zsv_jq_parse_file(zsv_jq_handle h, FILE *f);
 
-enum zsv_jq_status zsv_jq_parse(zsv_jq_handle restrict h, const void * restrict s, size_t len);
+enum zsv_jq_status zsv_jq_parse(zsv_jq_handle restrict h, const void *restrict s, size_t len);
 
 size_t zsv_jq_write(const char *s, size_t n, size_t m, zsv_jq_handle h);
 

--- a/include/zsv/utils/jq.h
+++ b/include/zsv/utils/jq.h
@@ -4,8 +4,7 @@
 #include <ctype.h>
 #include <jq.h>
 
-enum zsv_jq_status
-{
+enum zsv_jq_status {
   zsv_jq_status_ok = 0,
   zsv_jq_status_compile,
   zsv_jq_status_memory,

--- a/include/zsv/utils/jq.h
+++ b/include/zsv/utils/jq.h
@@ -4,7 +4,8 @@
 #include <ctype.h>
 #include <jq.h>
 
-enum zsv_jq_status {
+enum zsv_jq_status
+{
   zsv_jq_status_ok = 0,
   zsv_jq_status_compile,
   zsv_jq_status_memory,

--- a/include/zsv/utils/os.h
+++ b/include/zsv/utils/os.h
@@ -12,11 +12,11 @@
 void zsv_perror(const char *);
 
 #ifndef _WIN32
-# define zsv_replace_file(src, dest) (rename((const char *)src, (const char *)dest))
+#define zsv_replace_file(src, dest) (rename((const char *)src, (const char *)dest))
 
 #else
 
-# include <windows.h>
+#include <windows.h>
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(array) (sizeof(array) / sizeof(array[0]))

--- a/include/zsv/utils/prop.h
+++ b/include/zsv/utils/prop.h
@@ -9,10 +9,10 @@ struct zsv_file_properties {
   unsigned int skip;
   unsigned int header_span;
 
-  /* flags used by parser only to indicate whether property was specified */
-  unsigned int skip_specified:1;
-  unsigned int header_span_specified:1;
-  unsigned int _:6;
+  // flags used by parser only to indicate whether property was specified
+  unsigned int skip_specified : 1;
+  unsigned int header_span_specified : 1;
+  unsigned int _ : 6;
 };
 
 struct zsv_prop_handler {
@@ -20,6 +20,7 @@ struct zsv_prop_handler {
   int (*handler)(void *property_parser, const char *property_name, struct json_value *value);
   void *ctx;
 };
+
 void *zsv_properties_parser_get_custom_ctx(void *property_parser);
 const unsigned char *zsv_properties_parser_get_filepath(void *property_parser);
 struct zsv_opts *zsv_properties_parser_get_opts(void *property_parser_);
@@ -33,8 +34,6 @@ struct zsv_prop_handler zsv_get_default_custom_prop_handler(void);
 
 void zsv_clear_default_custom_prop_handler(void);
 
-
-
 /**
  * Load cached file properties into a zsp_opts and/or zsv_file_properties struct
  * If cmd_opts_used is provided, then do not set any zsv_opts values, if the
@@ -47,10 +46,8 @@ void zsv_clear_default_custom_prop_handler(void);
  * @param cmd_opts_used (optional) cmd option codes to skip + warn if found
  * @return struct zsv_file_properties, with .stat set to zsv_status_ok on success
  */
-struct zsv_file_properties zsv_cache_load_props(const char *data_filepath,
-                                                struct zsv_opts *opts,
-                                                struct zsv_prop_handler *custom_prop,
-                                                const char *cmd_opts_used);
+struct zsv_file_properties zsv_cache_load_props(const char *data_filepath, struct zsv_opts *opts,
+                                                struct zsv_prop_handler *custom_prop, const char *cmd_opts_used);
 
 /**
  * Create a new properties parser
@@ -58,8 +55,7 @@ struct zsv_file_properties zsv_cache_load_props(const char *data_filepath,
 struct zsv_properties_parser;
 struct zsv_properties_parser *zsv_properties_parser_new(const unsigned char *path,
                                                         struct zsv_prop_handler *custom_prop_handler,
-                                                        struct zsv_file_properties *fp,
-                                                        struct zsv_opts *opts);
+                                                        struct zsv_file_properties *fp, struct zsv_opts *opts);
 
 /**
  * Finished parsing
@@ -84,17 +80,13 @@ enum zsv_status zsv_properties_parser_destroy(struct zsv_properties_parser *pars
  *                   param is used solely for loading properties and has no
  *                   impact on the data that is actually parsed, which is
  *                   determined by opts->stream
- * @param opts_used  string specifyig which other command-line options were
+ * @param opts_used  string specifying which other command-line options were
  *                   already used (may be useful to differentiate between
  *                   unspecified default values vs specified values)
  * @param handle_out returns zsv parser handle, or NULL on fail
  */
-enum zsv_status zsv_new_with_properties(struct zsv_opts *opts,
-                                        struct zsv_prop_handler *custom_prop,
-                                        const char *input_path,
-                                        const char *opts_used,
-                                        zsv_parser *handle_out
-                                        );
+enum zsv_status zsv_new_with_properties(struct zsv_opts *opts, struct zsv_prop_handler *custom_prop,
+                                        const char *input_path, const char *opts_used, zsv_parser *handle_out);
 
 /**
  * If you are building your own CLI and incorporating zsv CLI commands into it,
@@ -111,12 +103,8 @@ enum zsv_status zsv_new_with_properties(struct zsv_opts *opts,
 #include "dirs.h"
 
 struct zsv_dir_filter; /* opaque structure for internal use */
-struct zsv_dir_filter *
-zsv_prop_get_or_set_is_prop_file(
-                                 int (*is_prop_file)(struct zsv_foreach_dirent_handle *, size_t),
-                                 int max_depth,
-                                 char set
-                                 );
+struct zsv_dir_filter *zsv_prop_get_or_set_is_prop_file(int (*is_prop_file)(struct zsv_foreach_dirent_handle *, size_t),
+                                                        int max_depth, char set);
 
 /**
  * If you provide your own is_prop_file() function and you also want to include any

--- a/include/zsv/utils/string.h
+++ b/include/zsv/utils/string.h
@@ -65,7 +65,8 @@ size_t zsv_strwhite(unsigned char *s, size_t len, unsigned int flags);
  */
 ZSV_EXPORT
 size_t zsv_strencode(unsigned char *s, size_t n, unsigned char replace,
-                     int (*malformed_handler)(void *, const unsigned char *s, size_t n, size_t offset), void *handler_ctx);
+                     int (*malformed_handler)(void *, const unsigned char *s, size_t n, size_t offset),
+                     void *handler_ctx);
 
 size_t zsv_strip_trailing_zeros(const char *s, size_t len);
 
@@ -73,19 +74,19 @@ size_t zsv_strip_trailing_zeros(const char *s, size_t len);
  * Trim trailing whitespace
  * Returns the input string and new length
  */
-const unsigned char *zsv_strtrim_right(const char unsigned * restrict s, size_t *lenp);
+const unsigned char *zsv_strtrim_right(const char unsigned *restrict s, size_t *lenp);
 
 /**
  * Trim leading whitespace
  * Returns the pointer to the new string start and new length
  */
-const unsigned char *zsv_strtrim_left(const char unsigned * restrict s, size_t *lenp);
+const unsigned char *zsv_strtrim_left(const char unsigned *restrict s, size_t *lenp);
 
 /**
  * Trim leading and trailing whitespace
   Returns the pointer to the new string start and new length
  */
-const unsigned char *zsv_strtrim(const char unsigned * restrict s, size_t *lenp);
+const unsigned char *zsv_strtrim(const char unsigned *restrict s, size_t *lenp);
 
 /**
  * zsv_strunescape_backslash(): convert consecutive white to single space
@@ -118,12 +119,11 @@ size_t zsv_strnext_is_sign(const unsigned char *s, size_t len);
  */
 size_t zsv_strnext_is_currency(const unsigned char *s, size_t len);
 
-
 /*
  * Convert a string to a double. must convert entire string, else returns error
  * @param s     string to convert
  * @param d     pointer to converted value, on success
- *  
+ *
  * @returns     0 on success, non-zero on error
  */
 int zsv_strtod_exact(const char *s, double *d);
@@ -136,6 +136,5 @@ int zsv_strtod_exact(const char *s, double *d);
  */
 #include <zsv.h>
 struct zsv_cell zsv_get_cell_trimmed(zsv_parser parser, size_t index);
-
 
 #endif

--- a/include/zsv/utils/utf8.h
+++ b/include/zsv/utils/utf8.h
@@ -6,9 +6,11 @@
  * https://opensource.org/licenses/MIT
  */
 
+// clang-format off
+
 #ifndef ZSV_UTF8_CHARLEN_NOERR
 // ZSV_UTF8_CHARLEN_NOERR: return > 0 if valid utf8, +1 on error
-#define ZSV_UTF8_CHARLEN_NOERR(c)                     \
+#define ZSV_UTF8_CHARLEN_NOERR(c)                       \
   (!(c & 128) ? 1 :                                     \
    (c & 224) == 192 ? 2 : /* 110xxxxx */                \
    (c & 240) == 224 ? 3 : /* 1110xxxx */                \
@@ -21,16 +23,18 @@
 
 #ifndef ZSV_UTF8_CHARLEN
 // ZSV_UTF8_CHARLEN: return > 0 if valid utf8, -1 on error
-#define ZSV_UTF8_CHARLEN(c)                           \
+#define ZSV_UTF8_CHARLEN(c)                             \
   (!(c & 128) ? 1 :                                     \
    (c & 224) == 192 ? 2 : /* 110xxxxx */                \
    (c & 240) == 224 ? 3 : /* 1110xxxx */                \
    (c & 248) == 240 ? 4 : /* 11110xxx */                \
    (c & 252) == 248 ? 5 : /* 111110xx */                \
-   (c & 254) == 252 ? 6 : /* 1111110x */                 \
-   -1 /* error */                                        \
+   (c & 254) == 252 ? 6 : /* 1111110x */                \
+   -1 /* error */                                       \
    )
 #endif
+
+// clang-format on
 
 #ifndef ZSV_UTF8_SUBSEQUENT_CHAR_OK
 #define ZSV_UTF8_SUBSEQUENT_CHAR_OK(c) ((c & 192) == 128)

--- a/include/zsv/utils/win/dl.h
+++ b/include/zsv/utils/win/dl.h
@@ -16,7 +16,7 @@
 #define RTLD_LAZY 0
 void *dlopen(const char *dll_name, int flags);
 
-void *dlsym(void* handle, const char* symbol);
+void *dlsym(void *handle, const char *symbol);
 
 int dlclose(void *handle);
 

--- a/include/zsv/utils/writer.h
+++ b/include/zsv/utils/writer.h
@@ -34,20 +34,18 @@ enum zsv_writer_status {
 };
 
 struct zsv_writer_data;
-typedef struct zsv_writer_data * zsv_csv_writer;
+typedef struct zsv_writer_data *zsv_csv_writer;
 
 zsv_csv_writer zsv_writer_new(struct zsv_csv_writer_options *opts);
 enum zsv_writer_status zsv_writer_delete(zsv_csv_writer w);
 
 enum zsv_writer_status zsv_writer_flush(zsv_csv_writer w);
 
-void zsv_writer_set_temp_buff(zsv_csv_writer w, unsigned char *buff,
-                                size_t buffsize);
+void zsv_writer_set_temp_buff(zsv_csv_writer w, unsigned char *buff, size_t buffsize);
 
 enum zsv_writer_status zsv_writer_cell(zsv_csv_writer,
                                        char new_row, // ZSV_WRITER_NEW_ROW or ZSV_WRITER_SAME_ROW
-                                       const unsigned char *s, size_t len,
-                                       char check_if_needs_quoting);
+                                       const unsigned char *s, size_t len, char check_if_needs_quoting);
 
 unsigned char *zsv_writer_str_to_csv(const unsigned char *s, size_t len);
 
@@ -56,20 +54,17 @@ unsigned char *zsv_writer_str_to_csv(const unsigned char *s, size_t len);
  * @return NULL if no quoting required, `buff` if quoted value written to buff,
  * or newly-allocated memory if buff not large enough (caller must free)
  */
-unsigned char *zsv_csv_quote(const unsigned char *utf8_value, size_t len,
-                             unsigned char *buff, size_t buffsize);
-
+unsigned char *zsv_csv_quote(const unsigned char *utf8_value, size_t len, unsigned char *buff, size_t buffsize);
 
 // zsv_writer_cell convenience funcs: zsv_writer_cell_XX where XX = printf specifier
 enum zsv_writer_status zsv_writer_cell_zu(zsv_csv_writer w, char new_row, size_t zu);
 
-enum zsv_writer_status zsv_writer_cell_s(zsv_csv_writer w, char new_row,
-                                                    const unsigned char *s,
-                                                    char check_if_needs_quoting);
+enum zsv_writer_status zsv_writer_cell_s(zsv_csv_writer w, char new_row, const unsigned char *s,
+                                         char check_if_needs_quoting);
 
 enum zsv_writer_status zsv_writer_cell_Lf(zsv_csv_writer w, char new_row,
-                                                     const char *fmt_spec, // provide X in %XLf e.g. ".2" or ""
-                                                     long double ldbl);
+                                          const char *fmt_spec, // provide X in %XLf e.g. ".2" or ""
+                                          long double ldbl);
 
 // write a blank cell
 enum zsv_writer_status zsv_writer_cell_blank(zsv_csv_writer w, char new_row);

--- a/include/zsv/utils/writer.h
+++ b/include/zsv/utils/writer.h
@@ -26,8 +26,7 @@ struct zsv_csv_writer_options {
 void zsv_writer_set_default_opts(struct zsv_csv_writer_options opts);
 struct zsv_csv_writer_options zsv_writer_get_default_opts(void);
 
-enum zsv_writer_status
-{
+enum zsv_writer_status {
   zsv_writer_status_ok = 0,
   zsv_writer_status_error,
   zsv_writer_status_missing_handle,

--- a/include/zsv/utils/writer.h
+++ b/include/zsv/utils/writer.h
@@ -26,7 +26,8 @@ struct zsv_csv_writer_options {
 void zsv_writer_set_default_opts(struct zsv_csv_writer_options opts);
 struct zsv_csv_writer_options zsv_writer_get_default_opts(void);
 
-enum zsv_writer_status {
+enum zsv_writer_status
+{
   zsv_writer_status_ok = 0,
   zsv_writer_status_error,
   zsv_writer_status_missing_handle,

--- a/include/zsv/zsv_export.h
+++ b/include/zsv/zsv_export.h
@@ -2,10 +2,10 @@
 #define ZSV_EXPORT_H
 
 #ifdef __EMSCRIPTEN__
-# include <emscripten.h>
-# define ZSV_EXPORT EMSCRIPTEN_KEEPALIVE
+#include <emscripten.h>
+#define ZSV_EXPORT EMSCRIPTEN_KEEPALIVE
 #else
-# define ZSV_EXPORT
+#define ZSV_EXPORT
 #endif
 
 #endif

--- a/scripts/ci-run-clang-format.sh
+++ b/scripts/ci-run-clang-format.sh
@@ -5,18 +5,20 @@ set -e
 echo "[INF] Running $0"
 
 VERSION=$(clang-format --version | cut -d ' ' -f4 | tr -d '\n')
+MAJOR_VERSION=$(echo "$VERSION" | cut -d '.' -f1)
+REQUIRED_VERSION="14"
+
 if [ "$VERSION" = "" ]; then
   echo "[ERR] clang-format is not installed!"
+  echo "[ERR] Make sure clang-format $REQUIRED_VERSION or later is installed."
   exit 1
-fi
-
-echo "[INF] clang-format version [$VERSION]"
-
-MAJOR_VERSION=$(echo "$VERSION" | cut -d '.' -f1)
-if [ "$MAJOR_VERSION" -lt "13" ]; then
-  echo "[ERR] Installed clang-format version is $VERSION."
-  echo "[ERR] clang-format 13 or later is required!"
-  exit 1
+else
+  echo "[INF] clang-format version [$VERSION]"
+  if [ "$MAJOR_VERSION" -lt "$REQUIRED_VERSION" ]; then
+    echo "[ERR] Installed clang-format version is $VERSION."
+    echo "[ERR] clang-format $REQUIRED_VERSION or later is required!"
+    exit 1
+  fi
 fi
 
 for DIR in app examples include src; do

--- a/scripts/ci-run-clang-format.sh
+++ b/scripts/ci-run-clang-format.sh
@@ -4,8 +4,20 @@ set -e
 
 echo "[INF] Running $0"
 
-VERSION=$(clang-format --version | cut -d ' ' -f4)
+VERSION=$(clang-format --version | cut -d ' ' -f4 | tr -d '\n')
+if [ "$VERSION" = "" ]; then
+  echo "[ERR] clang-format is not installed!"
+  exit 1
+fi
+
 echo "[INF] clang-format version [$VERSION]"
+
+MAJOR_VERSION=$(echo "$VERSION" | cut -d '.' -f1)
+if [ "$MAJOR_VERSION" -lt "13" ]; then
+  echo "[ERR] Installed clang-format version is $VERSION."
+  echo "[ERR] clang-format 13 or later is required!"
+  exit 1
+fi
 
 for DIR in app examples include src; do
   echo "[INF] Running clang-format [$DIR]"

--- a/scripts/ci-run-clang-format.sh
+++ b/scripts/ci-run-clang-format.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+echo "[INF] Running $0"
+
+VERSION=$(clang-format --version | cut -d ' ' -f4)
+echo "[INF] clang-format version [$VERSION]"
+
+for DIR in app examples include src; do
+  echo "[INF] Running clang-format [$DIR]"
+  find "$DIR" \
+    ! -path "$DIR/external/*" \
+    -type f \
+    -regex '.*\.\(c\|h\|h\.in\)' \
+    -exec sh -c 'clang-format -style=file -i "$1" &' - '{}' \;
+done
+
+wait
+
+if ! git diff --exit-code -- '*.c' '*.h' '*.h.in'; then
+  git status
+  echo "[ERR] Source files are not formatted!"
+  echo "[ERR] See above diff for details."
+  echo "[ERR] Run clang-format and push again."
+  exit 1
+else
+  echo "[INF] Source files are formatted!"
+fi
+
+echo "[INF] --- [DONE] ---"

--- a/src/vector_delim.c
+++ b/src/vector_delim.c
@@ -13,46 +13,42 @@
 #include <string.h>
 
 #if VECTOR_BYTES == 64 && (defined(HAVE__BLSR_U64) || defined(HAVE___BLSR_U64))
-# if defined(HAVE__BLSR_U64)
-#  define clear_lowest_bit(n) _blsr_u64(n)
-# else
-#  define clear_lowest_bit(n) __blsr_u64(n)
-# endif
-#elif VECTOR_BYTES == 32 && (defined(HAVE__BLSR_U32) || defined(HAVE___BLSR_U32))
-# if defined(HAVE__BLSR_U32)
-#  define clear_lowest_bit(n) _blsr_u32(n)
-# else
-#  define clear_lowest_bit(n) __blsr_u32(n)
-# endif
+#if defined(HAVE__BLSR_U64)
+#define clear_lowest_bit(n) _blsr_u64(n)
 #else
-# define clear_lowest_bit(n) (n & (n - 1))
+#define clear_lowest_bit(n) __blsr_u64(n)
+#endif
+#elif VECTOR_BYTES == 32 && (defined(HAVE__BLSR_U32) || defined(HAVE___BLSR_U32))
+#if defined(HAVE__BLSR_U32)
+#define clear_lowest_bit(n) _blsr_u32(n)
+#else
+#define clear_lowest_bit(n) __blsr_u32(n)
+#endif
+#else
+#define clear_lowest_bit(n) (n & (n - 1))
 #endif
 
 // vec_delims: return bitfield of next 32 bytes that contain at least 1 token
-__attribute__((always_inline))
-static inline int vec_delims(const unsigned char *s, size_t n,
-                             zsv_uc_vector *char_match1,
-                             zsv_uc_vector *char_match2,
-                             zsv_uc_vector *char_match3,
-                             zsv_uc_vector *char_match4,
-                             zsv_mask_t *maskp
-                             ) {
-  zsv_uc_vector* pSrc1 = (zsv_uc_vector *)s;
+__attribute__((always_inline)) static inline int vec_delims(const unsigned char *s, size_t n,
+                                                            zsv_uc_vector *char_match1, zsv_uc_vector *char_match2,
+                                                            zsv_uc_vector *char_match3, zsv_uc_vector *char_match4,
+                                                            zsv_mask_t *maskp) {
+  zsv_uc_vector *pSrc1 = (zsv_uc_vector *)s;
   zsv_uc_vector str_simd;
 
   unsigned j = n / sizeof(str_simd); // VECTOR_BYTES;
   zsv_mask_t mask = 0;
   unsigned total_bytes = 0;
 
-  for(unsigned i = 0; i < j; i++) {
-    memcpy(&str_simd, s + i*sizeof(str_simd), sizeof(str_simd));
+  for (unsigned i = 0; i < j; i++) {
+    memcpy(&str_simd, s + i * sizeof(str_simd), sizeof(str_simd));
     zsv_uc_vector vtmp = str_simd == *char_match1;
     vtmp += (str_simd == *char_match2);
     vtmp += (str_simd == *char_match3);
     vtmp += (str_simd == *char_match4);
     mask = movemask_pseudo(vtmp);
 
-    if(LIKELY(mask != 0)) { // check if we found one of the 4 chars
+    if (LIKELY(mask != 0)) { // check if we found one of the 4 chars
       *maskp = mask;
       return total_bytes;
     } else {

--- a/src/zsv.c
+++ b/src/zsv.c
@@ -40,9 +40,9 @@ const char *zsv_lib_version(void) {
 // __attribute__((always_inline))
 inline static size_t scanner_pre_parse(struct zsv_scanner *scanner) {
   scanner->last = '\0';
-  if(VERY_LIKELY(scanner->old_bytes_read)) {
-    scanner->last = scanner->buff.buff[scanner->old_bytes_read-1];
-    if(scanner->row_start < scanner->old_bytes_read) {
+  if (VERY_LIKELY(scanner->old_bytes_read)) {
+    scanner->last = scanner->buff.buff[scanner->old_bytes_read - 1];
+    if (scanner->row_start < scanner->old_bytes_read) {
       size_t len = scanner->old_bytes_read - scanner->row_start;
       memmove(scanner->buff.buff, scanner->buff.buff + scanner->row_start, len);
       scanner->partial_row_length = len;
@@ -52,7 +52,7 @@ inline static size_t scanner_pre_parse(struct zsv_scanner *scanner) {
       zsv_clear_cell(scanner);
     }
     scanner->cell_start -= scanner->row_start;
-    for(size_t i2 = 0; i2 < scanner->row.used; i2++)
+    for (size_t i2 = 0; i2 < scanner->row.used; i2++)
       scanner->row.cells[i2].str -= scanner->row_start;
     scanner->row_start = 0;
     scanner->old_bytes_read = 0;
@@ -61,13 +61,13 @@ inline static size_t scanner_pre_parse(struct zsv_scanner *scanner) {
   scanner->cum_scanned_length += scanner->scanned_length - scanner->partial_row_length;
 
   size_t capacity = scanner->buff.size - scanner->partial_row_length;
-  if(VERY_UNLIKELY(capacity == 0)) {
+  if (VERY_UNLIKELY(capacity == 0)) {
     // our row size was too small to fit a single row of data
     fprintf(stderr, "Warning: row %zu truncated\n", scanner->data_row_count);
-    if(scanner->mode == ZSV_MODE_FIXED) {
-      if(VERY_UNLIKELY(row_fx(scanner, scanner->buff.buff, 0, scanner->buff.size)))
+    if (scanner->mode == ZSV_MODE_FIXED) {
+      if (VERY_UNLIKELY(row_fx(scanner, scanner->buff.buff, 0, scanner->buff.size)))
         return zsv_status_cancelled;
-    } else if(VERY_UNLIKELY(row_dl(scanner)))
+    } else if (VERY_UNLIKELY(row_dl(scanner)))
       return zsv_status_cancelled;
 
     // throw away the next row end
@@ -88,10 +88,10 @@ static enum zsv_status zsv_insert_string(struct zsv_scanner *scanner) {
   // to do: replace below with
   // return parse_bytes(scanner, bytes, len);
   size_t len = strlen(scanner->insert_string);
-  if(len > scanner->buff.size - scanner->partial_row_length)
+  if (len > scanner->buff.size - scanner->partial_row_length)
     len = scanner->buff.size - 1; // to do: throw an error instead
   memcpy(scanner->buff.buff + scanner->partial_row_length, scanner->insert_string, len);
-  if(scanner->buff.buff[len] != '\n')
+  if (scanner->buff.buff[len] != '\n')
     scanner->buff.buff[len] = '\n';
   enum zsv_status stat = zsv_scan(scanner, scanner->buff.buff, len + 1);
   scanner->insert_string = NULL;
@@ -104,37 +104,35 @@ static enum zsv_status zsv_insert_string(struct zsv_scanner *scanner) {
  */
 ZSV_EXPORT
 enum zsv_status zsv_parse_more(struct zsv_scanner *scanner) {
-  if(VERY_UNLIKELY(scanner->insert_string != NULL))
+  if (VERY_UNLIKELY(scanner->insert_string != NULL))
     zsv_insert_string(scanner);
 
   size_t capacity = scanner_pre_parse(scanner);
   size_t bytes_read;
-  if(VERY_UNLIKELY(scanner->checked_bom == 0)) {
+  if (VERY_UNLIKELY(scanner->checked_bom == 0)) {
 #ifdef ZSV_EXTRAS
     // initialize progress timer
-    if(scanner->opts.progress.seconds_interval)
+    if (scanner->opts.progress.seconds_interval)
       scanner->progress.last_time = time(NULL);
 #endif
     size_t bom_len = strlen(ZSV_BOM);
     scanner->checked_bom = 1;
-    if((bytes_read = scanner->read(scanner->buff.buff, 1, bom_len, scanner->in)) == bom_len
-       && !memcmp(scanner->buff.buff, ZSV_BOM, bom_len)) {
+    if ((bytes_read = scanner->read(scanner->buff.buff, 1, bom_len, scanner->in)) == bom_len &&
+        !memcmp(scanner->buff.buff, ZSV_BOM, bom_len)) {
       // have bom. disregard what we just read
       bytes_read = scanner->read(scanner->buff.buff, 1, capacity, scanner->in);
       scanner->had_bom = 1;
     } else { // no BOM. keep the bytes we just read
       // bytes_read = bom_len + scanner->read(scanner->buff.buff + bom_len, 1, capacity - bom_len, scanner->in);
-      if(bytes_read == bom_len) // maybe we only read < 3 bytes
+      if (bytes_read == bom_len) // maybe we only read < 3 bytes
         bytes_read += scanner->read(scanner->buff.buff + bom_len, 1, capacity - bom_len, scanner->in);
     }
   } else // already checked bom. read as usual
-    bytes_read = scanner->read(scanner->buff.buff + scanner->partial_row_length, 1,
-                               capacity, scanner->in);
+    bytes_read = scanner->read(scanner->buff.buff + scanner->partial_row_length, 1, capacity, scanner->in);
   scanner->started = 1;
-  if(VERY_UNLIKELY(scanner->filter != NULL))
-    bytes_read = scanner->filter(scanner->filter_ctx,
-                                 scanner->buff.buff + scanner->partial_row_length, bytes_read);
-  if(VERY_LIKELY(bytes_read))
+  if (VERY_UNLIKELY(scanner->filter != NULL))
+    bytes_read = scanner->filter(scanner->filter_ctx, scanner->buff.buff + scanner->partial_row_length, bytes_read);
+  if (VERY_LIKELY(bytes_read))
     return zsv_scan(scanner, scanner->buff.buff, bytes_read);
 
   scanner->scanned_length = scanner->partial_row_length;
@@ -163,35 +161,35 @@ static void zsv_pull_row(void *ctx) {
  */
 ZSV_EXPORT
 enum zsv_status zsv_next_row(zsv_parser parser) {
-  if(VERY_UNLIKELY(!parser->pull.regs)) {
-    if(parser->started)
+  if (VERY_UNLIKELY(!parser->pull.regs)) {
+    if (parser->started)
       return zsv_status_error; // error: already started a push parser
-    if(!(parser->pull.regs = calloc(1, sizeof(*parser->pull.regs))))
+    if (!(parser->pull.regs = calloc(1, sizeof(*parser->pull.regs))))
       return zsv_status_memory;
     parser->mode = ZSV_MODE_DELIM_PULL;
     zsv_set_row_handler(parser, zsv_pull_row);
     zsv_set_context(parser, parser);
-    if(parser->insert_string != NULL)
+    if (parser->insert_string != NULL)
       parser->pull.stat = zsv_insert_string(parser);
-    if(parser->pull.stat == zsv_status_row)
+    if (parser->pull.stat == zsv_status_row)
       return parser->pull.stat;
   }
-  if(VERY_LIKELY(parser->pull.stat == zsv_status_row))
+  if (VERY_LIKELY(parser->pull.stat == zsv_status_row))
     parser->pull.stat = zsv_scan_delim_pull(parser, parser->pull.buff, parser->pull.bytes_read);
-  if(VERY_UNLIKELY(parser->pull.stat == zsv_status_ok)) {
+  if (VERY_UNLIKELY(parser->pull.stat == zsv_status_ok)) {
     do {
       parser->pull.stat = zsv_parse_more(parser); // should return zsv_status_row or zsv_status_no_more_input
-    } while(parser->pull.stat == zsv_status_ok);
-    if(VERY_LIKELY(parser->pull.stat == zsv_status_row))
+    } while (parser->pull.stat == zsv_status_ok);
+    if (VERY_LIKELY(parser->pull.stat == zsv_status_row))
       return parser->pull.stat;
   }
 
-  if(VERY_UNLIKELY(parser->pull.stat == zsv_status_no_more_input)) {
+  if (VERY_UNLIKELY(parser->pull.stat == zsv_status_no_more_input)) {
     parser->pull.now = 0;
     zsv_finish(parser);
 
     parser->pull.stat = zsv_status_done;
-    if(parser->pull.now) {
+    if (parser->pull.now) {
       parser->pull.now = 0;
       parser->row.used = parser->pull.row_used;
       return zsv_status_row;
@@ -208,21 +206,20 @@ size_t zsv_cell_count(zsv_parser parser) {
 
 ZSV_EXPORT
 void zsv_set_row_handler(zsv_parser parser, void (*row_handler)(void *ctx)) {
-  if(parser->opts.row_handler == parser->opts_orig.row_handler)
+  if (parser->opts.row_handler == parser->opts_orig.row_handler)
     parser->opts.row_handler = row_handler;
   parser->opts_orig.row_handler = row_handler;
 }
 
 ZSV_EXPORT
 void zsv_set_context(zsv_parser parser, void *ctx) {
-  if(parser->opts.ctx == parser->opts_orig.ctx)
+  if (parser->opts.ctx == parser->opts_orig.ctx)
     parser->opts.ctx = ctx;
   parser->opts_orig.ctx = ctx;
 }
 
 ZSV_EXPORT
-void zsv_set_read(zsv_parser parser,
-                  size_t (*read_func)(void * restrict, size_t n, size_t size, void * restrict)) {
+void zsv_set_read(zsv_parser parser, size_t (*read_func)(void *restrict, size_t n, size_t size, void *restrict)) {
   parser->read = read_func;
 }
 
@@ -237,10 +234,10 @@ char zsv_quoted(zsv_parser parser) {
 }
 
 static struct zsv_cell zsv_get_cell_1(zsv_parser parser, size_t ix) {
-  if(VERY_LIKELY(ix < parser->row.used))
+  if (VERY_LIKELY(ix < parser->row.used))
     return parser->row.cells[ix];
 
-  struct zsv_cell c = { 0, 0, 0, 0 };
+  struct zsv_cell c = {0, 0, 0, 0};
   return c;
 }
 
@@ -256,7 +253,7 @@ struct zsv_cell zsv_get_cell(zsv_parser parser, size_t ix) {
  */
 ZSV_EXPORT
 size_t zsv_get_cell_len(zsv_parser parser, size_t ix) {
-  if(ix < parser->row.used)
+  if (ix < parser->row.used)
     return parser->row.cells[ix].len;
   return 0;
 }
@@ -268,39 +265,37 @@ unsigned char *zsv_get_cell_str(zsv_parser parser, size_t ix) {
 }
 
 ZSV_EXPORT enum zsv_status zsv_set_fixed_offsets(zsv_parser parser, size_t count, size_t *offsets) {
-  if(!count) {
+  if (!count) {
     fprintf(stderr, "Fixed offset count must be greater than zero\n");
     return zsv_status_invalid_option;
   }
-  if(offsets[0] == 0)
+  if (offsets[0] == 0)
     fprintf(stderr, "Warning: first cell width is zero\n");
-  for(size_t i = 1; i < count; i++) {
-    if(offsets[i-1] > offsets[i]) {
-      fprintf(stderr, "Invalid offset %zu may not exceed prior offset %zu\n",
-              offsets[i], offsets[i-1]);
+  for (size_t i = 1; i < count; i++) {
+    if (offsets[i - 1] > offsets[i]) {
+      fprintf(stderr, "Invalid offset %zu may not exceed prior offset %zu\n", offsets[i], offsets[i - 1]);
       return zsv_status_invalid_option;
-    } else if(offsets[i-1] == offsets[i])
-      fprintf(stderr, "Warning: offset %zu repeated, will always yield empty cell\n",
-              offsets[i-1]);
+    } else if (offsets[i - 1] == offsets[i])
+      fprintf(stderr, "Warning: offset %zu repeated, will always yield empty cell\n", offsets[i - 1]);
   }
 
-  if(offsets[count-1] > parser->buff.size) {
-    fprintf(stderr, "Offset %zu exceeds total buffer size %zu\n", offsets[count-1], parser->buff.size);
+  if (offsets[count - 1] > parser->buff.size) {
+    fprintf(stderr, "Offset %zu exceeds total buffer size %zu\n", offsets[count - 1], parser->buff.size);
     return zsv_status_invalid_option;
   }
-  if(parser->cum_scanned_length) {
+  if (parser->cum_scanned_length) {
     fprintf(stderr, "Scanner mode cannot be changed after parsing has begun\n");
     return zsv_status_invalid_option;
   }
 
   free(parser->fixed.offsets);
   parser->fixed.offsets = calloc(count, sizeof(*parser->fixed.offsets));
-  if(!parser->fixed.offsets) {
+  if (!parser->fixed.offsets) {
     fprintf(stderr, "Out of memory!\n");
     return zsv_status_memory;
   }
   parser->fixed.count = count;
-  for(unsigned i = 0; i < count; i++)
+  for (unsigned i = 0; i < count; i++)
     parser->fixed.offsets[i] = offsets[i];
 
   parser->mode = ZSV_MODE_FIXED;
@@ -313,8 +308,8 @@ ZSV_EXPORT enum zsv_status zsv_set_fixed_offsets(zsv_parser parser, size_t count
 
 ZSV_EXPORT
 int zsv_peek(zsv_parser z) {
-  if(z->scanned_length + 1 < z->buff.size)
-    return z->buff.buff[z->scanned_length+1];
+  if (z->scanned_length + 1 < z->buff.size)
+    return z->buff.buff[z->scanned_length + 1];
   return -1;
 }
 
@@ -326,22 +321,22 @@ int zsv_peek(zsv_parser z) {
 ZSV_EXPORT
 zsv_parser zsv_new(struct zsv_opts *opts) {
   struct zsv_opts tmp;
-  if(!opts) {
+  if (!opts) {
     opts = &tmp;
     memset(opts, 0, sizeof(*opts));
   }
 
-  if(!opts->max_row_size)
+  if (!opts->max_row_size)
     opts->max_row_size = ZSV_ROW_MAX_SIZE_DEFAULT;
-  if(!opts->max_columns)
+  if (!opts->max_columns)
     opts->max_columns = ZSV_MAX_COLS_DEFAULT;
-  if(opts->delimiter == '\n' || opts->delimiter == '\r' || opts->delimiter == '"') {
+  if (opts->delimiter == '\n' || opts->delimiter == '\r' || opts->delimiter == '"') {
     fprintf(stderr, "Invalid delimiter\n");
     return NULL;
   }
   struct zsv_scanner *scanner = calloc(1, sizeof(*scanner));
-  if(scanner) {
-    if(zsv_scanner_init(scanner, opts)) {
+  if (scanner) {
+    if (zsv_scanner_init(scanner, opts)) {
       zsv_delete(scanner);
       scanner = NULL;
     }
@@ -352,23 +347,22 @@ zsv_parser zsv_new(struct zsv_opts *opts) {
 ZSV_EXPORT
 enum zsv_status zsv_finish(struct zsv_scanner *scanner) {
   enum zsv_status stat = zsv_status_ok;
-  if(!scanner)
+  if (!scanner)
     return zsv_status_error;
-  if(!scanner->abort) {
-    if(scanner->mode == ZSV_MODE_FIXED) {
-      if(scanner->partial_row_length && memchr("\n\r", scanner->buff.buff[scanner->partial_row_length-1], 2))
+  if (!scanner->abort) {
+    if (scanner->mode == ZSV_MODE_FIXED) {
+      if (scanner->partial_row_length && memchr("\n\r", scanner->buff.buff[scanner->partial_row_length - 1], 2))
         scanner->partial_row_length--;
-      if(scanner->partial_row_length)
+      if (scanner->partial_row_length)
         return row_fx(scanner, scanner->buff.buff, 0, scanner->partial_row_length);
       return zsv_status_ok;
     }
 
-    if((scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED)
-       && scanner->partial_row_length > scanner->cell_start) {
+    if ((scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) && scanner->partial_row_length > scanner->cell_start) {
       int quote = '"';
       scanner->quoted |= ZSV_PARSER_QUOTE_CLOSED;
       scanner->quoted -= ZSV_PARSER_QUOTE_UNCLOSED;
-      if(scanner->last == quote)
+      if (scanner->last == quote)
         scanner->quote_close_position = scanner->partial_row_length - scanner->cell_start;
       else {
         scanner->quote_close_position = scanner->partial_row_length - scanner->cell_start;
@@ -377,20 +371,19 @@ enum zsv_status zsv_finish(struct zsv_scanner *scanner) {
     }
   }
 
-  if(!scanner->finished) {
+  if (!scanner->finished) {
     scanner->finished = 1;
-    if(!scanner->abort) {
-      if(scanner->scanned_length > 0 && scanner->scanned_length >= scanner->cell_start)
-        cell_dl(scanner, scanner->buff.buff + scanner->cell_start,
-                scanner->scanned_length - scanner->cell_start);
-      if(scanner->have_cell) {
-        if(row_dl(scanner))
+    if (!scanner->abort) {
+      if (scanner->scanned_length > 0 && scanner->scanned_length >= scanner->cell_start)
+        cell_dl(scanner, scanner->buff.buff + scanner->cell_start, scanner->scanned_length - scanner->cell_start);
+      if (scanner->have_cell) {
+        if (row_dl(scanner))
           stat = zsv_status_cancelled;
       }
     } else
       stat = zsv_status_cancelled;
 #ifdef ZSV_EXTRAS
-    if(scanner->opts.completed.callback)
+    if (scanner->opts.completed.callback)
       scanner->opts.completed.callback(scanner->opts.completed.ctx, stat);
 #endif
   }
@@ -399,8 +392,8 @@ enum zsv_status zsv_finish(struct zsv_scanner *scanner) {
 
 ZSV_EXPORT
 enum zsv_status zsv_delete(zsv_parser parser) {
-  if(parser) {
-    if(parser->free_buff && parser->buff.buff)
+  if (parser) {
+    if (parser->free_buff && parser->buff.buff)
       free(parser->buff.buff);
 
     free(parser->row.cells);
@@ -409,10 +402,10 @@ enum zsv_status zsv_delete(zsv_parser parser) {
     free(parser->pull.regs);
 
 #ifdef ZSV_EXTRAS
-  if(parser->overwrite.ctx && parser->overwrite.close_ctx)
-    parser->overwrite.close_ctx(parser->overwrite.ctx);
-  if(parser->overwrite.reader && parser->overwrite.close_reader)
-    parser->overwrite.close_reader(parser->overwrite.reader);
+    if (parser->overwrite.ctx && parser->overwrite.close_ctx)
+      parser->overwrite.close_ctx(parser->overwrite.ctx);
+    if (parser->overwrite.reader && parser->overwrite.close_reader)
+      parser->overwrite.close_reader(parser->overwrite.reader);
 #endif
 
     free(parser);
@@ -422,9 +415,9 @@ enum zsv_status zsv_delete(zsv_parser parser) {
 
 ZSV_EXPORT
 const unsigned char *zsv_parse_status_desc(enum zsv_status status) {
-  switch(status) {
+  switch (status) {
   case zsv_status_ok:
-    return (unsigned char *) "OK";
+    return (unsigned char *)"OK";
   case zsv_status_cancelled:
     return (unsigned char *)"User cancelled";
   case zsv_status_no_more_input:
@@ -454,9 +447,8 @@ size_t zsv_scanned_length(zsv_parser parser) {
 
 ZSV_EXPORT
 size_t zsv_cum_scanned_length(zsv_parser parser) {
-  return parser->cum_scanned_length +
-    (parser->finished ? 0 : parser->scanned_length) +
-    (parser->had_bom ? strlen(ZSV_BOM) : 0);
+  return parser->cum_scanned_length + (parser->finished ? 0 : parser->scanned_length) +
+         (parser->had_bom ? strlen(ZSV_BOM) : 0);
 }
 
 ZSV_EXPORT
@@ -470,22 +462,19 @@ size_t zsv_row_length_raw_bytes(zsv_parser parser) {
  *               the parser buffer!
  * @param len    length of the input to parse
  */
-enum zsv_status zsv_parse_bytes(struct zsv_scanner *scanner,
-                                const unsigned char *bytes,
-                                size_t len) {
+enum zsv_status zsv_parse_bytes(struct zsv_scanner *scanner, const unsigned char *bytes, size_t len) {
   enum zsv_status stat = zsv_status_ok;
   const unsigned char *cursor = bytes;
-  while(len && stat == zsv_status_ok) {
+  while (len && stat == zsv_status_ok) {
     size_t capacity = scanner_pre_parse(scanner);
     size_t this_chunk_size = len > capacity ? capacity : len;
     memcpy(scanner->buff.buff + scanner->partial_row_length, cursor, this_chunk_size);
     cursor += this_chunk_size;
     len -= this_chunk_size;
-    if(scanner->filter)
-      this_chunk_size = scanner->filter(scanner->filter_ctx,
-                                   scanner->buff.buff + scanner->partial_row_length,
-                                   this_chunk_size);
-    if(this_chunk_size)
+    if (scanner->filter)
+      this_chunk_size =
+        scanner->filter(scanner->filter_ctx, scanner->buff.buff + scanner->partial_row_length, this_chunk_size);
+    if (this_chunk_size)
       stat = zsv_scan(scanner, scanner->buff.buff, this_chunk_size);
   }
   return stat;

--- a/src/zsv_internal.c
+++ b/src/zsv_internal.c
@@ -183,7 +183,7 @@ struct zsv_scanner {
     union {
       struct zsv_scan_delim_regs delim;
       struct zsv_scan_fixed_regs fixed;
-    } *regs;
+    } * regs;
     enum zsv_status stat; // last status
     unsigned char *buff;
     size_t bytes_read;
@@ -420,8 +420,8 @@ __attribute__((always_inline)) static inline enum zsv_status cell_and_row_dl(str
 #include <arm_neon.h>
 static inline zsv_mask_t movemask_pseudo(zsv_uc_vector v) {
   // see https://stackoverflow.com/questions/11870910/
-  static const uint8_t
-    __attribute__((aligned(16))) _powers[16] = {1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128};
+  static const uint8_t __attribute__((aligned(16)))
+  _powers[16] = {1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128};
   uint8x16_t mm_powers = vld1q_u8(_powers);
 
   // compute the mask from the input

--- a/src/zsv_internal.c
+++ b/src/zsv_internal.c
@@ -21,41 +21,41 @@
 #include <zsv/utils/string.h>
 
 #if !defined(__AVX2__) // -mavx2 compiler flag not present
-# define ZSV_NO_AVX
-# define zsv_mask_t uint16_t
-# define VECTOR_BYTES 16
-# define NEXT_BIT __builtin_ffs
-# if defined(__AVX__)
-#  include <emmintrin.h>
-#  define zsv_mask_t uint16_t
-#  define VECTOR_BYTES 16
-#  define NEXT_BIT __builtin_ffs
-#  define movemask_pseudo(x) _mm_movemask_epi8 ((__m128i) x)
-# endif
+#define ZSV_NO_AVX
+#define zsv_mask_t uint16_t
+#define VECTOR_BYTES 16
+#define NEXT_BIT __builtin_ffs
+#if defined(__AVX__)
+#include <emmintrin.h>
+#define zsv_mask_t uint16_t
+#define VECTOR_BYTES 16
+#define NEXT_BIT __builtin_ffs
+#define movemask_pseudo(x) _mm_movemask_epi8((__m128i)x)
+#endif
 #elif defined(HAVE_AVX512)
-# ifndef __AVX512BW__
-#  error AVX512 requested, but __AVX512BW__ macro not defined
-# else
-#  include <immintrin.h>
-#  define VECTOR_BYTES 64
-#  define zsv_mask_t uint64_t
-#  define movemask_pseudo(x) _mm512_movepi8_mask((__m512i)x)
-#  define NEXT_BIT __builtin_ffsl
-# endif
-#elif defined(__AVX2__) // have avx2, not avx512
-# include <immintrin.h>
-# define VECTOR_BYTES 32
-# define zsv_mask_t uint32_t
-# define movemask_pseudo(x) _mm256_movemask_epi8((__m256i)x)
-# define NEXT_BIT __builtin_ffs
+#ifndef __AVX512BW__
+#error AVX512 requested, but __AVX512BW__ macro not defined
 #else
-# define ZSV_NO_AVX
-# define zsv_mask_t uint16_t
-# define VECTOR_BYTES 16
-# define NEXT_BIT __builtin_ffs
+#include <immintrin.h>
+#define VECTOR_BYTES 64
+#define zsv_mask_t uint64_t
+#define movemask_pseudo(x) _mm512_movepi8_mask((__m512i)x)
+#define NEXT_BIT __builtin_ffsl
+#endif
+#elif defined(__AVX2__) // have avx2, not avx512
+#include <immintrin.h>
+#define VECTOR_BYTES 32
+#define zsv_mask_t uint32_t
+#define movemask_pseudo(x) _mm256_movemask_epi8((__m256i)x)
+#define NEXT_BIT __builtin_ffs
+#else
+#define ZSV_NO_AVX
+#define zsv_mask_t uint16_t
+#define VECTOR_BYTES 16
+#define NEXT_BIT __builtin_ffs
 #endif
 
-typedef unsigned char zsv_uc_vector __attribute__ ((vector_size (VECTOR_BYTES)));
+typedef unsigned char zsv_uc_vector __attribute__((vector_size(VECTOR_BYTES)));
 
 struct zsv_row {
   size_t used, allocated, overflow;
@@ -118,21 +118,21 @@ struct zsv_scanner {
   char last;
   struct {
     unsigned char *buff; // provided by caller
-    size_t size; // provided by caller
+    size_t size;         // provided by caller
   } buff;
 
   size_t cell_start;
-  unsigned char quoted:7; // bitfield of ZSV_PARSER_QUOTE_XXX flags
-  unsigned char buffer_exceeded:1;
+  unsigned char quoted : 7; // bitfield of ZSV_PARSER_QUOTE_XXX flags
+  unsigned char buffer_exceeded : 1;
 
-  unsigned char waiting_for_end:1;
-  unsigned char checked_bom:1;
-  unsigned char free_buff:1;
-  unsigned char finished:1;
-  unsigned char had_bom:1;
-  unsigned char abort:1;
-  unsigned char have_cell:1;
-  unsigned char started:1;
+  unsigned char waiting_for_end : 1;
+  unsigned char checked_bom : 1;
+  unsigned char free_buff : 1;
+  unsigned char finished : 1;
+  unsigned char had_bom : 1;
+  unsigned char abort : 1;
+  unsigned char have_cell : 1;
+  unsigned char started : 1;
 
   size_t quote_close_position;
   struct zsv_opts opts;
@@ -165,7 +165,7 @@ struct zsv_scanner {
   unsigned char mode;
   struct {
     unsigned *offsets; // 0-based position of each cell end. offset[0] = end of first cell
-    unsigned count; // number of offsets
+    unsigned count;    // number of offsets
   } fixed;
 
   struct collate_header *collate_header;
@@ -197,7 +197,7 @@ struct zsv_scanner {
 };
 
 void collate_header_destroy(struct collate_header **chp) {
-  if(*chp) {
+  if (*chp) {
     struct collate_header *ch = *chp;
     free(ch->buff.buff);
     free(ch->lengths);
@@ -208,10 +208,10 @@ void collate_header_destroy(struct collate_header **chp) {
 
 /* collate_header_append(): return err */
 static int collate_header_append(struct zsv_scanner *scanner, struct collate_header **chp) {
-  if(!*chp) {
-    if((*chp = calloc(1, sizeof(struct collate_header))))
+  if (!*chp) {
+    if ((*chp = calloc(1, sizeof(struct collate_header))))
       (*chp)->lengths = calloc(scanner->row.allocated, sizeof(*(*chp)->lengths));
-    if(!(*chp) || !(*chp)->lengths) {
+    if (!(*chp) || !(*chp)->lengths) {
       free(*chp);
       fprintf(stderr, "Out of memory!\n");
       return -1;
@@ -220,14 +220,14 @@ static int collate_header_append(struct zsv_scanner *scanner, struct collate_hea
   struct collate_header *ch = *chp;
   size_t this_row_size = 0;
   size_t column_count = zsv_cell_count(scanner);
-  for(size_t i = 0, j = column_count; i < j; i++) {
+  for (size_t i = 0, j = column_count; i < j; i++) {
     struct zsv_cell c = zsv_get_cell_1(scanner, i);
-    if(c.len)
+    if (c.len)
       this_row_size += c.len + 1; // +1: terminating null or delim
   }
   size_t new_row_size = ch->buff.used + this_row_size;
   unsigned char *new_row = realloc(ch->buff.buff, new_row_size);
-  if(!new_row) {
+  if (!new_row) {
     fprintf(stderr, "Out of memory!\n");
     return -1;
   }
@@ -248,29 +248,27 @@ static int collate_header_append(struct zsv_scanner *scanner, struct collate_hea
   size_t old_row_end = ch->buff.used;
   ch->buff.used += this_row_size;
   ch->buff.buff = new_row;
-  for(size_t i = column_count; i > 0; i--) {
-    struct zsv_cell c = zsv_get_cell_1(scanner, i-1);
+  for (size_t i = column_count; i > 0; i--) {
+    struct zsv_cell c = zsv_get_cell_1(scanner, i - 1);
     // copy new row's cell value to end
-    if(c.len) {
+    if (c.len) {
       memcpy(new_row + new_row_end - c.len - 1, c.str, c.len);
-      new_row[new_row_end-1] = ' ';
+      new_row[new_row_end - 1] = ' ';
       new_row_end = new_row_end - c.len - 1;
     }
 
     // move prior cell value
-    size_t old_cell_len = ch->lengths[i-1]; // old_cell_len includes delim
-    if(old_cell_len) {
+    size_t old_cell_len = ch->lengths[i - 1]; // old_cell_len includes delim
+    if (old_cell_len) {
       // need memmove, not memcpy
-      memmove(new_row + new_row_end - old_cell_len,
-              new_row + old_row_end - old_cell_len,
-              old_cell_len);
+      memmove(new_row + new_row_end - old_cell_len, new_row + old_row_end - old_cell_len, old_cell_len);
       old_row_end -= old_cell_len;
       new_row_end -= old_cell_len;
     }
-    if(c.len)
-      ch->lengths[i-1] += c.len + 1;
+    if (c.len)
+      ch->lengths[i - 1] += c.len + 1;
   }
-  if(column_count > ch->column_count)
+  if (column_count > ch->column_count)
     ch->column_count = column_count;
   return 0;
 }
@@ -280,11 +278,11 @@ __attribute__((always_inline)) static inline void zsv_clear_cell(struct zsv_scan
 }
 
 // always_inline has a noticeable impact. do not remove without benchmarking!
-__attribute__((always_inline)) static inline void cell_dl(struct zsv_scanner * scanner, unsigned char * s, size_t n) {
+__attribute__((always_inline)) static inline void cell_dl(struct zsv_scanner *scanner, unsigned char *s, size_t n) {
   // handle quoting
-  if(UNLIKELY(scanner->quoted > 0)) {
-    if(LIKELY(scanner->quote_close_position + 1 == n)) {
-      if(LIKELY((scanner->quoted & ZSV_PARSER_QUOTE_EMBEDDED) == 0)) {
+  if (UNLIKELY(scanner->quoted > 0)) {
+    if (LIKELY(scanner->quote_close_position + 1 == n)) {
+      if (LIKELY((scanner->quoted & ZSV_PARSER_QUOTE_EMBEDDED) == 0)) {
         // this is the easy and usual case: no embedded double-quotes
         // just remove surrounding quotes from content
         s++;
@@ -293,9 +291,9 @@ __attribute__((always_inline)) static inline void cell_dl(struct zsv_scanner * s
         s++;
         n--;
         // remove dbl-quotes. TO DO: consider adding option to skip this
-        for(size_t i = 0; i + 1 < n; i++) {
-          if(s[i] == '"' && s[i+1] == '"') {
-            if(n > i + 2)
+        for (size_t i = 0; i + 1 < n; i++) {
+          if (s[i] == '"' && s[i + 1] == '"') {
+            if (n > i + 2)
               memmove(s + i + 1, s + i + 2, n - i - 2);
             n--;
           }
@@ -303,7 +301,7 @@ __attribute__((always_inline)) static inline void cell_dl(struct zsv_scanner * s
         n--;
       }
     } else {
-      if(scanner->quote_close_position) {
+      if (scanner->quote_close_position) {
         // the first char was a quote, and we have content after the closing quote
         // the solution below is a generalized on that will work
         // for the easy and usual case, but by handling separately
@@ -311,11 +309,11 @@ __attribute__((always_inline)) static inline void cell_dl(struct zsv_scanner * s
         memmove(s + 1, s, scanner->quote_close_position);
         s += 2;
         n -= 2;
-        if(UNLIKELY((scanner->quoted & ZSV_PARSER_QUOTE_EMBEDDED) != 0)) {
+        if (UNLIKELY((scanner->quoted & ZSV_PARSER_QUOTE_EMBEDDED) != 0)) {
           // remove dbl-quotes
-          for(size_t i = 0; i + 1 < n; i++) {
-            if(s[i] == '"' && s[i+1] == '"') {
-              if(n > i + 2)
+          for (size_t i = 0; i + 1 < n; i++) {
+            if (s[i] == '"' && s[i + 1] == '"') {
+              if (n > i + 2)
                 memmove(s + i + 1, s + i + 2, n - i - 2);
               n--;
             }
@@ -323,24 +321,24 @@ __attribute__((always_inline)) static inline void cell_dl(struct zsv_scanner * s
         }
       }
     }
-  } else if(UNLIKELY(scanner->opts.delimiter != ',')) {
-    if(memchr(s, ',', n))
+  } else if (UNLIKELY(scanner->opts.delimiter != ',')) {
+    if (memchr(s, ',', n))
       scanner->quoted = ZSV_PARSER_QUOTE_NEEDED;
   }
   // end quote handling
 
-  if(scanner->opts.malformed_utf8_replace) {
-    if(scanner->opts.malformed_utf8_replace < 0)
+  if (scanner->opts.malformed_utf8_replace) {
+    if (scanner->opts.malformed_utf8_replace < 0)
       n = zsv_strencode(s, n, 0, NULL, NULL);
     else
       n = zsv_strencode(s, n, scanner->opts.malformed_utf8_replace, NULL, NULL);
   }
 
-  if(UNLIKELY(scanner->opts.cell_handler != NULL))
+  if (UNLIKELY(scanner->opts.cell_handler != NULL))
     scanner->opts.cell_handler(scanner->opts.ctx, s, n);
-  if(VERY_LIKELY(scanner->row.used < scanner->row.allocated)) {
+  if (VERY_LIKELY(scanner->row.used < scanner->row.allocated)) {
     struct zsv_row *row = &scanner->row;
-    struct zsv_cell c = { s, n, scanner->opts.no_quotes ? 1 : scanner->quoted, 0 };
+    struct zsv_cell c = {s, n, scanner->opts.no_quotes ? 1 : scanner->quoted, 0};
     row->cells[row->used++] = c;
   } else
     scanner->row.overflow++;
@@ -350,60 +348,59 @@ __attribute__((always_inline)) static inline void cell_dl(struct zsv_scanner * s
 }
 
 __attribute__((always_inline)) static inline enum zsv_status row_dl(struct zsv_scanner *scanner) {
-  if(VERY_UNLIKELY(scanner->row.overflow)) {
+  if (VERY_UNLIKELY(scanner->row.overflow)) {
     fprintf(stderr, "Warning: number of columns (%zu) exceeds row max (%zu)\n",
             scanner->row.allocated + scanner->row.overflow, scanner->row.allocated);
     scanner->row.overflow = 0;
   }
-  if(VERY_LIKELY(scanner->opts.row_handler != NULL)) // TO DO: disallow row_handler to be null; if null, set to dummy
+  if (VERY_LIKELY(scanner->opts.row_handler != NULL)) // TO DO: disallow row_handler to be null; if null, set to dummy
     scanner->opts.row_handler(scanner->opts.ctx);
-  // Note: scanner->data_row_count will be incremented AFTER this call
-  //       in order to accommodate pull parsing, in which case incrementing here
-  //       would be too early
-# ifdef ZSV_EXTRAS
+    // Note: scanner->data_row_count will be incremented AFTER this call
+    //       in order to accommodate pull parsing, in which case incrementing here
+    //       would be too early
+#ifdef ZSV_EXTRAS
   scanner->progress.cum_row_count++;
-  if(VERY_UNLIKELY(scanner->opts.progress.rows_interval
-                   && scanner->progress.cum_row_count % scanner->opts.progress.rows_interval == 0)) {
+  if (VERY_UNLIKELY(scanner->opts.progress.rows_interval &&
+                    scanner->progress.cum_row_count % scanner->opts.progress.rows_interval == 0)) {
     char ok;
-    if(!scanner->opts.progress.seconds_interval)
+    if (!scanner->opts.progress.seconds_interval)
       ok = 1;
     else {
       // using timer_create() would be better, but is not currently supported on
       // all platforms, so the fallback is to poll
       time_t now = time(NULL);
-      if(now > scanner->progress.last_time &&
-         (unsigned int)(now - scanner->progress.last_time) >=
-         scanner->opts.progress.seconds_interval) {
+      if (now > scanner->progress.last_time &&
+          (unsigned int)(now - scanner->progress.last_time) >= scanner->opts.progress.seconds_interval) {
         ok = 1;
         scanner->progress.last_time = now;
       } else
         ok = 0;
     }
-    if(ok && scanner->opts.progress.callback)
+    if (ok && scanner->opts.progress.callback)
       scanner->abort = scanner->opts.progress.callback(scanner->opts.progress.ctx, scanner->progress.cum_row_count);
 #ifndef NDEBUG
-    if(scanner->abort)
+    if (scanner->abort)
       fprintf(stderr, "ZSV parsing aborted at %zu\n", scanner->progress.cum_row_count);
 #endif
   }
-  if(VERY_UNLIKELY(scanner->progress.max_rows > 0)) {
-    if(VERY_UNLIKELY(scanner->progress.cum_row_count == scanner->progress.max_rows)) {
+  if (VERY_UNLIKELY(scanner->progress.max_rows > 0)) {
+    if (VERY_UNLIKELY(scanner->progress.cum_row_count == scanner->progress.max_rows)) {
       scanner->abort = 1;
       scanner->row.used = 0;
       return zsv_status_max_rows_read;
     }
   }
 
-# endif
-  if(VERY_UNLIKELY(scanner->abort))
+#endif
+  if (VERY_UNLIKELY(scanner->abort))
     return zsv_status_cancelled;
   scanner->have_cell = 0;
   scanner->row.used = 0;
   return zsv_status_ok;
 }
 
-__attribute__((always_inline))
-static inline enum zsv_status cell_and_row_dl(struct zsv_scanner *scanner, unsigned char *s, size_t n) {
+__attribute__((always_inline)) static inline enum zsv_status cell_and_row_dl(struct zsv_scanner *scanner,
+                                                                             unsigned char *s, size_t n) {
   cell_dl(scanner, s, n);
   return row_dl(scanner);
 }
@@ -415,44 +412,44 @@ static inline enum zsv_status cell_and_row_dl(struct zsv_scanner *scanner, unsig
   only for each corresponding non-zero highest-bit value in the vector)
 */
 
-# if defined(__EMSCRIPTEN__) && defined(__SSE2__)
+#if defined(__EMSCRIPTEN__) && defined(__SSE2__)
 #include <wasm_simd128.h>
 #define movemask_pseudo(x) wasm_i8x16_bitmask(x)
 
-# elif defined(__ARM_NEON) || defined(__ARM_NEON__)
-#  include <arm_neon.h>
+#elif defined(__ARM_NEON) || defined(__ARM_NEON__)
+#include <arm_neon.h>
 static inline zsv_mask_t movemask_pseudo(zsv_uc_vector v) {
   // see https://stackoverflow.com/questions/11870910/
-  static const uint8_t __attribute__ ((aligned (16))) _powers[16]=
-    { 1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128 };
+  static const uint8_t
+    __attribute__((aligned(16))) _powers[16] = {1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128};
   uint8x16_t mm_powers = vld1q_u8(_powers);
 
   // compute the mask from the input
-  uint64x2_t imask= vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vandq_u8(v, mm_powers))));
+  uint64x2_t imask = vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vandq_u8(v, mm_powers))));
 
   // Get the resulting bytes
   uint16_t mask;
-  vst1q_lane_u8((uint8_t*)&mask + 0, (uint8x16_t)imask, 0);
-  vst1q_lane_u8((uint8_t*)&mask + 1, (uint8x16_t)imask, 8);
+  vst1q_lane_u8((uint8_t *)&mask + 0, (uint8x16_t)imask, 0);
+  vst1q_lane_u8((uint8_t *)&mask + 1, (uint8x16_t)imask, 8);
   return mask;
 }
 
-# elif defined(__SSE2__)
+#elif defined(__SSE2__)
 
-typedef char zsv_c_vector __attribute__ ((vector_size (VECTOR_BYTES)));
-#  define movemask_pseudo(x) __builtin_ia32_pmovmskb128((zsv_c_vector)x)
+typedef char zsv_c_vector __attribute__((vector_size(VECTOR_BYTES)));
+#define movemask_pseudo(x) __builtin_ia32_pmovmskb128((zsv_c_vector)x)
 
-# else
+#else
 
 // slow path
-# if defined(__EMSCRIPTEN__)
-# warning "Compiling with emscripten, without using SIMD. To use SIMD, compile with -msse2 -msimd128 -experimental-wasm-simd and -I/path/to/emsdk/upstream/lib/clang/16.0.0/include"
-# endif
-
+#if defined(__EMSCRIPTEN__)
+#warning                                                                                                               \
+  "Compiling with emscripten, without using SIMD. To use SIMD, compile with -msse2 -msimd128 -experimental-wasm-simd and -I/path/to/emsdk/upstream/lib/clang/16.0.0/include"
+#endif
 
 static inline zsv_mask_t movemask_pseudo(zsv_uc_vector v) {
   zsv_mask_t mask = 0, tmp = 1;
-  for(size_t i = 0; i < sizeof(zsv_uc_vector); i++) {
+  for (size_t i = 0; i < sizeof(zsv_uc_vector); i++) {
     mask |= (v[i] ? tmp : 0);
     tmp <<= 1;
   }
@@ -460,10 +457,10 @@ static inline zsv_mask_t movemask_pseudo(zsv_uc_vector v) {
   return mask;
 }
 
-# endif // __EMSCRIPTEN__
+#endif // __EMSCRIPTEN__
 #endif // ndef movemask_pseudo
 
-# include "vector_delim.c"
+#include "vector_delim.c"
 
 #ifdef ZSV_SUPPORT_PULL_PARSER
 #undef ZSV_SUPPORT_PULL_PARSER
@@ -479,15 +476,12 @@ static inline zsv_mask_t movemask_pseudo(zsv_uc_vector v) {
 
 #include "zsv_scan_fixed.c"
 
-static enum zsv_status zsv_scan(struct zsv_scanner *scanner,
-                         unsigned char *buff,
-                         size_t bytes_read
-                         ) {
-  switch(scanner->mode) {
+static enum zsv_status zsv_scan(struct zsv_scanner *scanner, unsigned char *buff, size_t bytes_read) {
+  switch (scanner->mode) {
   case ZSV_MODE_FIXED:
     return zsv_scan_fixed(scanner, buff, bytes_read);
   case ZSV_MODE_DELIM_PULL:
-     // return zsv_status_row or zsv_status_ok (next call to parse_more)
+    // return zsv_status_row or zsv_status_ok (next call to parse_more)
     return zsv_scan_delim_pull(scanner, buff, bytes_read);
   default:
     return zsv_scan_delim(scanner, buff, bytes_read);
@@ -501,21 +495,17 @@ static enum zsv_status zsv_scan(struct zsv_scanner *scanner,
 // but may not be larger than the original number of bytes, and any data modification
 // must be done in-place to *buff
 enum zsv_status zsv_set_scan_filter(struct zsv_scanner *scanner,
-                                    size_t (*filter)(void *ctx,
-                                                     unsigned char *buff,
-                                                     size_t bytes_read),
-                                    void *ctx
-                                    ) {
+                                    size_t (*filter)(void *ctx, unsigned char *buff, size_t bytes_read), void *ctx) {
   scanner->filter = filter;
   scanner->filter_ctx = ctx;
   return zsv_status_ok;
 }
 
 static void apply_callbacks(struct zsv_scanner *scanner) {
-  if(UNLIKELY(scanner->opts.cell_handler != NULL)) {
+  if (UNLIKELY(scanner->opts.cell_handler != NULL)) {
     // call the user-provided cell() callback on each cell
     unsigned char saved_quoted = scanner->quoted;
-    for(size_t i = 0, j = zsv_cell_count(scanner); i < j; i++) {
+    for (size_t i = 0, j = zsv_cell_count(scanner); i < j; i++) {
       struct zsv_cell c = zsv_get_cell_1(scanner, i);
       scanner->quoted = c.quoted;
       scanner->opts.cell_handler(scanner->opts.ctx, c.str, c.len);
@@ -523,27 +513,26 @@ static void apply_callbacks(struct zsv_scanner *scanner) {
     scanner->quoted = saved_quoted;
   }
   // call the user-provided row() callback
-  if(VERY_LIKELY(scanner->opts.row_handler != NULL))
+  if (VERY_LIKELY(scanner->opts.row_handler != NULL))
     scanner->opts.row_handler(scanner->opts.ctx);
 }
 
 static void set_callbacks(struct zsv_scanner *scanner);
 
 static char zsv_internal_row_is_blank(zsv_parser parser) {
-  for(unsigned int i = 0; i < parser->row.used; i++)
-    if(parser->row.cells[i].len)
+  for (unsigned int i = 0; i < parser->row.used; i++)
+    if (parser->row.cells[i].len)
       return 0;
   return 1;
 }
 
 static void skip_to_first_row_w_data(void *ctx) {
   struct zsv_scanner *scanner = ctx;
-  if(LIKELY(zsv_internal_row_is_blank(scanner) == 0)) {
+  if (LIKELY(zsv_internal_row_is_blank(scanner) == 0)) {
     scanner->opts.keep_empty_header_rows = 1;
-    if(scanner->empty_header_rows) {
+    if (scanner->empty_header_rows) {
       fprintf(stderr, "Warning: skipped %zu empty header rows; suggest using:\n  --skip-head %zu\n",
-              scanner->empty_header_rows,
-              scanner->empty_header_rows + scanner->opts_orig.rows_to_ignore);
+              scanner->empty_header_rows, scanner->empty_header_rows + scanner->opts_orig.rows_to_ignore);
     }
     set_callbacks(scanner);
     apply_callbacks(scanner);
@@ -553,39 +542,40 @@ static void skip_to_first_row_w_data(void *ctx) {
 
 static void ignore_header_rows(void *ctx) {
   struct zsv_scanner *scanner = ctx;
-  if(scanner->opts.rows_to_ignore)
+  if (scanner->opts.rows_to_ignore)
     scanner->opts.rows_to_ignore--;
-  if(!scanner->opts.rows_to_ignore)
+  if (!scanner->opts.rows_to_ignore)
     set_callbacks(scanner);
 }
 
 static void collate_header_row(void *ctx) {
   struct zsv_scanner *scanner = ctx;
-  if(scanner->opts.header_span) {
+  if (scanner->opts.header_span) {
     --scanner->opts.header_span;
 
     // save this row
 
     // first, make sure this row has at least as many cells as the largest prior row
-    if(scanner->collate_header) {
-      for(size_t i = zsv_cell_count(scanner); i < scanner->row.allocated && i < scanner->collate_header->column_count; i++)
+    if (scanner->collate_header) {
+      for (size_t i = zsv_cell_count(scanner); i < scanner->row.allocated && i < scanner->collate_header->column_count;
+           i++)
         memset(&scanner->row.cells[i], 0, sizeof(scanner->row.cells[i]));
       scanner->row.used = scanner->collate_header->column_count;
     }
 
-    if(collate_header_append(scanner, &scanner->collate_header))
+    if (collate_header_append(scanner, &scanner->collate_header))
       scanner->abort = 1;
   }
 
-  if(!scanner->opts.header_span) {
+  if (!scanner->opts.header_span) {
     // finished with header; combine all rows into a single row
     set_callbacks(scanner);
-    if(scanner->collate_header) {
+    if (scanner->collate_header) {
       size_t offset = 0;
-      for(size_t i = 0; i < scanner->collate_header->column_count; i++) {
+      for (size_t i = 0; i < scanner->collate_header->column_count; i++) {
         size_t len_plus1 = scanner->collate_header->lengths[i];
         scanner->row.cells[i].str = scanner->collate_header->buff.buff + offset;
-        if(len_plus1) {
+        if (len_plus1) {
           scanner->row.cells[i].len = len_plus1 - 1;
           scanner->row.cells[i].quoted = 1;
         } else
@@ -595,26 +585,26 @@ static void collate_header_row(void *ctx) {
     }
 
     apply_callbacks(scanner);
-    if(scanner->mode != ZSV_MODE_DELIM_PULL)
+    if (scanner->mode != ZSV_MODE_DELIM_PULL)
       collate_header_destroy(&scanner->collate_header);
   }
 }
 
 static void set_callbacks(struct zsv_scanner *scanner) {
-  if(scanner->opts.rows_to_ignore) {
+  if (scanner->opts.rows_to_ignore) {
     scanner->opts.row_handler = ignore_header_rows;
     scanner->opts.cell_handler = NULL;
     scanner->opts.ctx = scanner;
-  } else if(scanner->mode != ZSV_MODE_FIXED && !scanner->opts.keep_empty_header_rows) {
+  } else if (scanner->mode != ZSV_MODE_FIXED && !scanner->opts.keep_empty_header_rows) {
     scanner->opts.row_handler = skip_to_first_row_w_data;
     scanner->opts.cell_handler = NULL;
     scanner->opts.ctx = scanner;
-  } else if(scanner->opts.header_span > 1) {
+  } else if (scanner->opts.header_span > 1) {
     scanner->opts.row_handler = collate_header_row;
     scanner->opts.cell_handler = NULL;
     scanner->opts.ctx = scanner;
   } else {
-    if(scanner->overwrite.have)
+    if (scanner->overwrite.have)
       scanner->get_cell = zsv_get_cell_with_overwrite;
     else
       scanner->get_cell = zsv_get_cell_1;
@@ -627,8 +617,8 @@ static void set_callbacks(struct zsv_scanner *scanner) {
 
 static void zsv_throwaway_row(void *ctx) {
   struct zsv_scanner *scanner = ctx;
-  if(scanner->opts.overflow_row_handler != NULL) {
-    if(zsv_cell_count(scanner) > 1 || zsv_get_cell_1(scanner, 0).len > 0)
+  if (scanner->opts.overflow_row_handler != NULL) {
+    if (zsv_cell_count(scanner) > 1 || zsv_get_cell_1(scanner, 0).len > 0)
       scanner->opts.overflow_row_handler(ctx);
   }
   scanner->buffer_exceeded = 0;
@@ -640,8 +630,7 @@ static int zsv_delete_v(void *p) {
   return zsv_delete((zsv_parser)p);
 }
 
-static void zsv_next_overwrite_csv(struct zsv_overwrite *overwrite,
-                                   struct zsv_overwrite_data *data) {
+static void zsv_next_overwrite_csv(struct zsv_overwrite *overwrite, struct zsv_overwrite_data *data) {
   // row, column, value
   data->row = zsv_get_cell_1(overwrite->reader, 0);
   data->col = zsv_get_cell_1(overwrite->reader, 1);
@@ -650,13 +639,13 @@ static void zsv_next_overwrite_csv(struct zsv_overwrite *overwrite,
 
 // TO DO: consolidate with zsv_echo_get_next_overwrite()
 static void zsv_next_overwrite(struct zsv_overwrite *overwrite) {
-  if(overwrite->have) {
-    if(zsv_next_row(overwrite->reader) != zsv_status_row)
+  if (overwrite->have) {
+    if (zsv_next_row(overwrite->reader) != zsv_status_row)
       overwrite->have = 0;
     else {
       struct zsv_overwrite_data data;
       overwrite->next(overwrite, &data);
-      if(data.row.len && data.col.len) {
+      if (data.row.len && data.col.len) {
         char *end = (char *)(data.row.str + data.row.len);
         char **endp = &end;
         overwrite->row_ix = strtoumax((char *)data.row.str, endp, 10);
@@ -673,39 +662,33 @@ static void zsv_next_overwrite(struct zsv_overwrite *overwrite) {
 }
 
 static enum zsv_status zsv_init_overwrites(zsv_parser parser, struct zsv_opt_overwrite *overwrite_opts) {
-  if(overwrite_opts->type <= zsv_overwrite_type_none)
+  if (overwrite_opts->type <= zsv_overwrite_type_none)
     return zsv_status_ok;
   struct zsv_overwrite *overwrite = &parser->overwrite;
-  switch(overwrite_opts->type) {
-  case zsv_overwrite_type_csv:
-    {
-      struct zsv_opts opts = { 0 };
-      overwrite->ctx = opts.stream = overwrite_opts->ctx;
-      overwrite->close_ctx = overwrite_opts->close_ctx;
-      if(!(overwrite->reader = zsv_new(&opts)))
-        return zsv_status_memory;
-      overwrite->close_reader = zsv_delete_v;
-      overwrite->next = zsv_next_overwrite_csv;
-    }
-    break;
+  switch (overwrite_opts->type) {
+  case zsv_overwrite_type_csv: {
+    struct zsv_opts opts = {0};
+    overwrite->ctx = opts.stream = overwrite_opts->ctx;
+    overwrite->close_ctx = overwrite_opts->close_ctx;
+    if (!(overwrite->reader = zsv_new(&opts)))
+      return zsv_status_memory;
+    overwrite->close_reader = zsv_delete_v;
+    overwrite->next = zsv_next_overwrite_csv;
+  } break;
   default:
     fprintf(stderr, "Unrecognized overwrite type\n");
     return zsv_status_error;
   }
 
   overwrite->have = 0;
-  if(zsv_next_row(overwrite->reader) == zsv_status_row) {
+  if (zsv_next_row(overwrite->reader) == zsv_status_row) {
     // to do: check that column names are row, col, value
     struct zsv_overwrite_data data;
     overwrite->next(overwrite, &data);
-    if(data.row.len < 3 || memcmp(data.row.str, "row", 3)
-       || data.col.len < 3 || memcmp(data.col.str, "col", 3)
-       || data.val.len < 3 || memcmp(data.val.str, "val", 3))
-      fprintf(stderr, "Warning! overwrite expects 'row,col,value' header, got '%.*s,%.*s,%.*s'\n",
-              (int)data.row.len, data.row.str,
-              (int)data.col.len, data.col.str,
-              (int)data.val.len, data.val.str
-              );
+    if (data.row.len < 3 || memcmp(data.row.str, "row", 3) || data.col.len < 3 || memcmp(data.col.str, "col", 3) ||
+        data.val.len < 3 || memcmp(data.val.str, "val", 3))
+      fprintf(stderr, "Warning! overwrite expects 'row,col,value' header, got '%.*s,%.*s,%.*s'\n", (int)data.row.len,
+              data.row.str, (int)data.col.len, data.col.str, (int)data.val.len, data.val.str);
     overwrite->have = 1;
     zsv_next_overwrite(overwrite);
   }
@@ -714,67 +697,66 @@ static enum zsv_status zsv_init_overwrites(zsv_parser parser, struct zsv_opt_ove
 
 static int zsv_have_overwrite(zsv_parser parser, size_t row_ix, size_t col_ix) {
   struct zsv_overwrite *overwrite = &parser->overwrite;
-  while(overwrite->have && overwrite->row_ix < row_ix)
+  while (overwrite->have && overwrite->row_ix < row_ix)
     zsv_next_overwrite(overwrite);
-  while(overwrite->have && overwrite->row_ix == row_ix && overwrite->col_ix < col_ix)
+  while (overwrite->have && overwrite->row_ix == row_ix && overwrite->col_ix < col_ix)
     zsv_next_overwrite(overwrite);
-  if(!overwrite->have)
+  if (!overwrite->have)
     parser->get_cell = zsv_get_cell_1;
   return overwrite->have && overwrite->row_ix == row_ix && overwrite->col_ix == col_ix;
 }
 
 static struct zsv_cell zsv_get_cell_with_overwrite(zsv_parser parser, size_t col_ix) {
-  if(VERY_LIKELY(col_ix < parser->row.used)) {
+  if (VERY_LIKELY(col_ix < parser->row.used)) {
     size_t row_ix = parser->data_row_count;
-    if(!zsv_have_overwrite(parser, row_ix, col_ix))
+    if (!zsv_have_overwrite(parser, row_ix, col_ix))
       return parser->row.cells[col_ix];
 
     struct zsv_cell c = parser->overwrite.val;
     c.overwritten = 1;
     return c;
   }
-  struct zsv_cell c = { 0, 0, 0, 0 };
+  struct zsv_cell c = {0, 0, 0, 0};
   return c;
 }
 #endif
 
-static int zsv_scanner_init(struct zsv_scanner *scanner,
-                              struct zsv_opts *opts) {
+static int zsv_scanner_init(struct zsv_scanner *scanner, struct zsv_opts *opts) {
   size_t need_buff_size = 0;
-  if(opts->malformed_utf8_replace == ZSV_MALFORMED_UTF8_DO_NOT_REPLACE)
+  if (opts->malformed_utf8_replace == ZSV_MALFORMED_UTF8_DO_NOT_REPLACE)
     opts->malformed_utf8_replace = 0;
-  if(opts->buffsize < opts->max_row_size * 2)
+  if (opts->buffsize < opts->max_row_size * 2)
     need_buff_size = opts->max_row_size * 2;
   opts->delimiter = opts->delimiter ? opts->delimiter : ',';
-  if(opts->delimiter == '\n' || opts->delimiter == '\r' || opts->delimiter == '"') {
+  if (opts->delimiter == '\n' || opts->delimiter == '\r' || opts->delimiter == '"') {
     fprintf(stderr, "warning: ignoring illegal delimiter\n");
     opts->delimiter = ',';
   }
 
-  if(opts->insert_header_row)
+  if (opts->insert_header_row)
     scanner->insert_string = opts->insert_header_row;
 
-  if(need_buff_size < ZSV_MIN_SCANNER_BUFFSIZE)
+  if (need_buff_size < ZSV_MIN_SCANNER_BUFFSIZE)
     need_buff_size = ZSV_MIN_SCANNER_BUFFSIZE;
-  if(opts->buffsize < need_buff_size) {
-    if(opts->buffsize > 0) {
-      if(need_buff_size == ZSV_MIN_SCANNER_BUFFSIZE)
+  if (opts->buffsize < need_buff_size) {
+    if (opts->buffsize > 0) {
+      if (need_buff_size == ZSV_MIN_SCANNER_BUFFSIZE)
         fprintf(stderr, "Increasing --buff-size to minimum %zu\n", need_buff_size);
       else
-        fprintf(stderr, "Increasing --buff-size to %zu to accommmodate max-row-size of %u\n",
-                need_buff_size, opts->max_row_size);
+        fprintf(stderr, "Increasing --buff-size to %zu to accommmodate max-row-size of %u\n", need_buff_size,
+                opts->max_row_size);
     }
     opts->buffsize = need_buff_size;
   }
-  if(opts->buffsize == 0)
+  if (opts->buffsize == 0)
     opts->buffsize = ZSV_DEFAULT_SCANNER_BUFFSIZE;
-  else if(opts->buffsize < ZSV_MIN_SCANNER_BUFFSIZE)
+  else if (opts->buffsize < ZSV_MIN_SCANNER_BUFFSIZE)
     opts->buffsize = ZSV_MIN_SCANNER_BUFFSIZE;
 
   scanner->in = opts->stream;
-  if(!opts->read) {
+  if (!opts->read) {
     scanner->read = (zsv_generic_read)fread;
-    if(!opts->stream)
+    if (!opts->stream)
       scanner->in = stdin;
   } else {
     scanner->read = opts->read;
@@ -783,27 +765,27 @@ static int zsv_scanner_init(struct zsv_scanner *scanner,
   scanner->buff.buff = opts->buff;
   scanner->buff.size = opts->buffsize;
 
-  if(opts->buffsize && !opts->buff) {
+  if (opts->buffsize && !opts->buff) {
     scanner->buff.buff = malloc(opts->buffsize);
     scanner->free_buff = 1;
   }
 
-# ifdef ZSV_EXTRAS
-  if(opts->max_rows)
+#ifdef ZSV_EXTRAS
+  if (opts->max_rows)
     scanner->progress.max_rows = opts->max_rows;
-# endif
-  if(scanner->buff.buff) {
+#endif
+  if (scanner->buff.buff) {
     scanner->opts = *opts;
     scanner->opts_orig = *opts;
-    if(!scanner->opts.max_columns)
+    if (!scanner->opts.max_columns)
       scanner->opts.max_columns = 1024;
     set_callbacks(scanner);
-    if((scanner->row.allocated = scanner->opts.max_columns)
-       && (scanner->row.cells = calloc(scanner->row.allocated, sizeof(*scanner->row.cells))))
-# ifdef ZSV_EXTRAS
+    if ((scanner->row.allocated = scanner->opts.max_columns) &&
+        (scanner->row.cells = calloc(scanner->row.allocated, sizeof(*scanner->row.cells))))
+#ifdef ZSV_EXTRAS
       // initialize overwrites
-      if(zsv_init_overwrites(scanner, &scanner->opts.overwrite) == zsv_status_ok)
-# endif
+      if (zsv_init_overwrites(scanner, &scanner->opts.overwrite) == zsv_status_ok)
+#endif
         return 0;
   }
   return 1;

--- a/src/zsv_scan_delim.c
+++ b/src/zsv_scan_delim.c
@@ -1,47 +1,46 @@
 #ifdef ZSV_SUPPORT_PULL_PARSER
 
 #define zsv_internal_save_reg(x) scanner->pull.regs->delim.x = x
-#define zsv_internal_save_regs(loc) do {      \
-    scanner->pull.regs->delim.location = loc; \
-    scanner->pull.buff = buff;                \
-    scanner->pull.bytes_read = bytes_read;    \
-    zsv_internal_save_reg(i);                 \
-    zsv_internal_save_reg(bytes_chunk_end);   \
-    zsv_internal_save_reg(bytes_read);        \
-    zsv_internal_save_reg(delimiter);         \
-    zsv_internal_save_reg(c);                 \
-    zsv_internal_save_reg(skip_next_delim);   \
-    zsv_internal_save_reg(quote);             \
-    zsv_internal_save_reg(mask_total_offset); \
-    zsv_internal_save_reg(mask);              \
-    zsv_internal_save_reg(mask_last_start);   \
-  } while(0)
+#define zsv_internal_save_regs(loc)                                                                                    \
+  do {                                                                                                                 \
+    scanner->pull.regs->delim.location = loc;                                                                          \
+    scanner->pull.buff = buff;                                                                                         \
+    scanner->pull.bytes_read = bytes_read;                                                                             \
+    zsv_internal_save_reg(i);                                                                                          \
+    zsv_internal_save_reg(bytes_chunk_end);                                                                            \
+    zsv_internal_save_reg(bytes_read);                                                                                 \
+    zsv_internal_save_reg(delimiter);                                                                                  \
+    zsv_internal_save_reg(c);                                                                                          \
+    zsv_internal_save_reg(skip_next_delim);                                                                            \
+    zsv_internal_save_reg(quote);                                                                                      \
+    zsv_internal_save_reg(mask_total_offset);                                                                          \
+    zsv_internal_save_reg(mask);                                                                                       \
+    zsv_internal_save_reg(mask_last_start);                                                                            \
+  } while (0)
 
 #define zsv_internal_restore_reg(x) x = scanner->pull.regs->delim.x
-#define zsv_internal_restore_regs() do {         \
-    buff = scanner->pull.buff;                   \
-    bytes_read = scanner->pull.bytes_read;       \
-    zsv_internal_restore_reg(i);                 \
-    zsv_internal_restore_reg(bytes_chunk_end);   \
-    zsv_internal_restore_reg(bytes_read);        \
-    zsv_internal_restore_reg(delimiter);         \
-    zsv_internal_restore_reg(c);                 \
-    zsv_internal_restore_reg(skip_next_delim);   \
-    zsv_internal_restore_reg(quote);             \
-    zsv_internal_restore_reg(mask_total_offset); \
-    zsv_internal_restore_reg(mask);              \
-    zsv_internal_restore_reg(mask_last_start);   \
-    memset(&v.dl, scanner->opts.delimiter, sizeof(zsv_uc_vector));      \
-    memset(&v.nl, '\n', sizeof(zsv_uc_vector)); \
-    memset(&v.cr, '\r', sizeof(zsv_uc_vector)); \
-    memset(&v.qt, scanner->opts.no_quotes > 0 ? 0 : '"', sizeof(v.qt)); \
-  } while(0)
+#define zsv_internal_restore_regs()                                                                                    \
+  do {                                                                                                                 \
+    buff = scanner->pull.buff;                                                                                         \
+    bytes_read = scanner->pull.bytes_read;                                                                             \
+    zsv_internal_restore_reg(i);                                                                                       \
+    zsv_internal_restore_reg(bytes_chunk_end);                                                                         \
+    zsv_internal_restore_reg(bytes_read);                                                                              \
+    zsv_internal_restore_reg(delimiter);                                                                               \
+    zsv_internal_restore_reg(c);                                                                                       \
+    zsv_internal_restore_reg(skip_next_delim);                                                                         \
+    zsv_internal_restore_reg(quote);                                                                                   \
+    zsv_internal_restore_reg(mask_total_offset);                                                                       \
+    zsv_internal_restore_reg(mask);                                                                                    \
+    zsv_internal_restore_reg(mask_last_start);                                                                         \
+    memset(&v.dl, scanner->opts.delimiter, sizeof(zsv_uc_vector));                                                     \
+    memset(&v.nl, '\n', sizeof(zsv_uc_vector));                                                                        \
+    memset(&v.cr, '\r', sizeof(zsv_uc_vector));                                                                        \
+    memset(&v.qt, scanner->opts.no_quotes > 0 ? 0 : '"', sizeof(v.qt));                                                \
+  } while (0)
 #endif
 
-static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
-                                      unsigned char *buff,
-                                      size_t bytes_read
-                                      ) {
+static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner, unsigned char *buff, size_t bytes_read) {
   struct {
     zsv_uc_vector dl;
     zsv_uc_vector nl;
@@ -60,9 +59,9 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
   int mask_last_start;
 
 #ifdef ZSV_SUPPORT_PULL_PARSER
-  if(scanner->pull.regs->delim.location) {
+  if (scanner->pull.regs->delim.location) {
     zsv_internal_restore_regs();
-    if(scanner->pull.regs->delim.location == 1)
+    if (scanner->pull.regs->delim.location == 1)
       goto zsv_cell_and_row_dl_1;
     goto zsv_cell_and_row_dl_2;
   }
@@ -76,13 +75,13 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
 
   // to do: move into one-time execution code?
   // (but, will also locate away from function stack)
-  quote = scanner->opts.no_quotes > 0 ? -1 : '"'; // ascii code 34
-  memset(&v.dl, delimiter, sizeof(zsv_uc_vector)); // ascii 44
-  memset(&v.nl, '\n', sizeof(zsv_uc_vector)); // ascii code 10
-  memset(&v.cr, '\r', sizeof(zsv_uc_vector)); // ascii code 13
+  quote = scanner->opts.no_quotes > 0 ? -1 : '"';  // ascii code 34
+  memset(&v.dl, delimiter, sizeof(zsv_uc_vector)); // ascii code 44
+  memset(&v.nl, '\n', sizeof(zsv_uc_vector));      // ascii code 10
+  memset(&v.cr, '\r', sizeof(zsv_uc_vector));      // ascii code 13
   memset(&v.qt, scanner->opts.no_quotes > 0 ? 0 : '"', sizeof(v.qt));
 
-  if(scanner->quoted & ZSV_PARSER_QUOTE_PENDING) {
+  if (scanner->quoted & ZSV_PARSER_QUOTE_PENDING) {
     // if we're here, then the last chunk we read ended with a lone quote char inside
     // a quoted cell, and we are waiting to find out whether it is followed by
     // another dbl-quote e.g. if the end of the last chunk is |, we had:
@@ -90,7 +89,7 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
     //   ...,"hel"|,...
     //   ...,"hel"|p,...
     scanner->quoted -= ZSV_PARSER_QUOTE_PENDING;
-    if(buff[i] != quote) {
+    if (buff[i] != quote) {
       scanner->quoted |= ZSV_PARSER_QUOTE_CLOSED;
       scanner->quoted -= ZSV_PARSER_QUOTE_UNCLOSED;
       scanner->quote_close_position = i - scanner->cell_start - 1;
@@ -101,38 +100,32 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
     }
   }
 
-#define scanner_last (i ? buff[i-1] : scanner->last)
+#define scanner_last (i ? buff[i - 1] : scanner->last)
 
   mask_total_offset = 0;
   mask = 0;
   scanner->buffer_end = bytes_read;
-  for(; i < bytes_read; i++) {
-    if(UNLIKELY(mask == 0)) {
+  for (; i < bytes_read; i++) {
+    if (UNLIKELY(mask == 0)) {
       mask_last_start = i;
-      if(VERY_LIKELY(i < bytes_chunk_end)) {
+      if (VERY_LIKELY(i < bytes_chunk_end)) {
         // keep going until we get a delim or we are at the eof
-        mask_total_offset = vec_delims(buff + i,
-                                       bytes_read - i,
-                                       &v.dl,
-                                       &v.nl,
-                                       &v.cr,
-                                       &v.qt,
-                                       &mask);
-        if(LIKELY(mask_total_offset != 0)) {
+        mask_total_offset = vec_delims(buff + i, bytes_read - i, &v.dl, &v.nl, &v.cr, &v.qt, &mask);
+        if (LIKELY(mask_total_offset != 0)) {
           i += mask_total_offset;
-          if(VERY_UNLIKELY(mask == 0 && i == bytes_read))
+          if (VERY_UNLIKELY(mask == 0 && i == bytes_read))
             break; // vector processing ended on exactly our buffer end
         }
-      } else if(skip_next_delim) {
+      } else if (skip_next_delim) {
         skip_next_delim = 0;
         continue;
       }
     }
-    if(VERY_LIKELY(mask)) {
+    if (VERY_LIKELY(mask)) {
       size_t next_offset = NEXT_BIT(mask);
       i = mask_last_start + next_offset - 1;
       mask = clear_lowest_bit(mask);
-      if(VERY_UNLIKELY(skip_next_delim)) {
+      if (VERY_UNLIKELY(skip_next_delim)) {
         skip_next_delim = 0;
         continue;
       }
@@ -140,8 +133,8 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
 
     // to do: consolidate csv and tsv/scanner->delimiter parsers
     c = buff[i];
-    if(LIKELY(c == delimiter)) { // case ',':
-      if((scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) == 0) {
+    if (LIKELY(c == delimiter)) { // case ',':
+      if ((scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) == 0) {
         scanner->scanned_length = i;
         cell_dl(scanner, buff + scanner->cell_start, i - scanner->cell_start);
         scanner->cell_start = i + 1;
@@ -150,15 +143,14 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
       } else
         // we are inside an open quote, which is needed to escape this char
         scanner->quoted |= ZSV_PARSER_QUOTE_NEEDED;
-    } else if(UNLIKELY(c == '\r')) {
-      if((scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) == 0) {
+    } else if (UNLIKELY(c == '\r')) {
+      if ((scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) == 0) {
         scanner->scanned_length = i;
-        enum zsv_status stat = cell_and_row_dl(scanner, buff + scanner->cell_start,
-                                               i - scanner->cell_start);
-        if(VERY_UNLIKELY(stat))
+        enum zsv_status stat = cell_and_row_dl(scanner, buff + scanner->cell_start, i - scanner->cell_start);
+        if (VERY_UNLIKELY(stat))
           return stat;
 #ifdef ZSV_SUPPORT_PULL_PARSER
-        if(scanner->pull.now) {
+        if (scanner->pull.now) {
           scanner->pull.now = 0;
           scanner->row.used = scanner->pull.row_used;
           zsv_internal_save_regs(1);
@@ -175,27 +167,26 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
       } else
         // we are inside an open quote, which is needed to escape this char
         scanner->quoted |= ZSV_PARSER_QUOTE_NEEDED;
-    } else if(UNLIKELY(c == '\n')) {
-      if((scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) == 0) {
-        if(scanner_last == '\r') { // ignore; we are outside a cell and last char was rowend
+    } else if (UNLIKELY(c == '\n')) {
+      if ((scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) == 0) {
+        if (scanner_last == '\r') { // ignore; we are outside a cell and last char was rowend
           scanner->cell_start = i + 1;
           scanner->row_start = i + 1;
         } else {
           // this is a row end
           scanner->scanned_length = i;
-          enum zsv_status stat = cell_and_row_dl(scanner, buff + scanner->cell_start,
-                                                 i - scanner->cell_start);
-          if(VERY_UNLIKELY(stat))
+          enum zsv_status stat = cell_and_row_dl(scanner, buff + scanner->cell_start, i - scanner->cell_start);
+          if (VERY_UNLIKELY(stat))
             return stat;
 #ifdef ZSV_SUPPORT_PULL_PARSER
-          if(scanner->pull.now) {
+          if (scanner->pull.now) {
             scanner->pull.now = 0;
             scanner->row.used = scanner->pull.row_used;
             zsv_internal_save_regs(2);
             return zsv_status_row;
           }
         zsv_cell_and_row_dl_2:
-          scanner->row.used= 0;
+          scanner->row.used = 0;
           scanner->pull.regs->delim.location = 0;
 #endif
           scanner->cell_start = i + 1;
@@ -206,15 +197,15 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
       } else
         // we are inside an open quote, which is needed to escape this char
         scanner->quoted |= ZSV_PARSER_QUOTE_NEEDED;
-    } else if(LIKELY(c == quote)) {
-      if(i == scanner->cell_start && !scanner->buffer_exceeded) {
+    } else if (LIKELY(c == quote)) {
+      if (i == scanner->cell_start && !scanner->buffer_exceeded) {
         scanner->quoted = ZSV_PARSER_QUOTE_UNCLOSED;
         scanner->quote_close_position = 0;
         c = 0;
-      } else if(scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) {
+      } else if (scanner->quoted & ZSV_PARSER_QUOTE_UNCLOSED) {
         // the cell started with a quote that is not yet closed
-        if(VERY_LIKELY(i + 1 < bytes_read)) {
-          if(LIKELY(buff[i+1] != quote)) {
+        if (VERY_LIKELY(i + 1 < bytes_read)) {
+          if (LIKELY(buff[i + 1] != quote)) {
             // buff[i] is the closing quote (not an escaped quote)
             scanner->quoted |= ZSV_PARSER_QUOTE_CLOSED;
             scanner->quoted -= ZSV_PARSER_QUOTE_UNCLOSED;
@@ -222,7 +213,7 @@ static enum zsv_status ZSV_SCAN_DELIM(struct zsv_scanner *scanner,
             // keep track of closing quote position to handle the edge case
             // where content follows the closing quote e.g. cell content is:
             //  "this-cell"-did-not-need-quotes
-            if(LIKELY(scanner->quote_close_position == 0))
+            if (LIKELY(scanner->quote_close_position == 0))
               scanner->quote_close_position = i - scanner->cell_start;
           } else {
             // next char is also '"'

--- a/src/zsv_scan_fixed.c
+++ b/src/zsv_scan_fixed.c
@@ -1,30 +1,24 @@
-static inline char row_fx(struct zsv_scanner *scanner,
-                          unsigned char *buff,
-                          size_t row_start,
-                          size_t row_end) {
+static inline char row_fx(struct zsv_scanner *scanner, unsigned char *buff, size_t row_start, size_t row_end) {
   size_t cell_start = row_start;
   size_t row_length = row_end - row_start;
-  for(unsigned i = 0; i < scanner->fixed.count; i++) {
+  for (unsigned i = 0; i < scanner->fixed.count; i++) {
     size_t cell_end = row_start + (scanner->fixed.offsets[i] > row_length ? row_length : scanner->fixed.offsets[i]);
     size_t cell_length = cell_end - cell_start;
     unsigned char *s = buff + cell_start;
-    if(UNLIKELY(scanner->opts.cell_handler != NULL))
+    if (UNLIKELY(scanner->opts.cell_handler != NULL))
       scanner->opts.cell_handler(scanner->opts.ctx, s, cell_length);
-    struct zsv_cell c = { s, cell_length, 1, 0 };
+    struct zsv_cell c = {s, cell_length, 1, 0};
     scanner->row.cells[scanner->row.used++] = c;
 
     cell_start = cell_end;
   }
-  if(VERY_LIKELY(scanner->opts.row_handler != NULL))
+  if (VERY_LIKELY(scanner->opts.row_handler != NULL))
     scanner->opts.row_handler(scanner->opts.ctx);
   scanner->row.used = 0;
   return scanner->abort;
 }
 
-static enum zsv_status zsv_scan_fixed(struct zsv_scanner *scanner,
-                                      unsigned char *buff,
-                                      size_t bytes_read
-                                      ) {
+static enum zsv_status zsv_scan_fixed(struct zsv_scanner *scanner, unsigned char *buff, size_t bytes_read) {
   bytes_read += scanner->partial_row_length;
   unsigned char c;
   size_t bytes_chunk_end = bytes_read >= sizeof(zsv_uc_vector) ? bytes_read - sizeof(zsv_uc_vector) + 1 : 0;
@@ -32,30 +26,33 @@ static enum zsv_status zsv_scan_fixed(struct zsv_scanner *scanner,
   scanner->partial_row_length = 0;
 
   // dl_v and qt_v are unused, we just leave them to reuse vec_delims()
-  zsv_uc_vector dl_v; memset(&dl_v, 0, sizeof(zsv_uc_vector));
-  zsv_uc_vector nl_v; memset(&nl_v, '\n', sizeof(zsv_uc_vector));
-  zsv_uc_vector cr_v; memset(&cr_v, '\r', sizeof(zsv_uc_vector));
-  zsv_uc_vector qt_v; memset(&qt_v, 0, sizeof(zsv_uc_vector));
+  zsv_uc_vector dl_v;
+  memset(&dl_v, 0, sizeof(zsv_uc_vector));
+  zsv_uc_vector nl_v;
+  memset(&nl_v, '\n', sizeof(zsv_uc_vector));
+  zsv_uc_vector cr_v;
+  memset(&cr_v, '\r', sizeof(zsv_uc_vector));
+  zsv_uc_vector qt_v;
+  memset(&qt_v, 0, sizeof(zsv_uc_vector));
   size_t mask_total_offset = 0;
   zsv_mask_t mask = 0;
   int mask_last_start;
 
   scanner->buffer_end = bytes_read;
-  for(size_t i = scanner->partial_row_length; ; i++) {
-    if(UNLIKELY(mask == 0)) {
+  for (size_t i = scanner->partial_row_length;; i++) {
+    if (UNLIKELY(mask == 0)) {
       mask_last_start = i;
-      if(LIKELY(i < bytes_chunk_end)) {
+      if (LIKELY(i < bytes_chunk_end)) {
         // keep going until we get a delim or we are at the eof
-        mask_total_offset = vec_delims(buff + i, bytes_read - i, &dl_v, &nl_v, &cr_v, &qt_v,
-                                       &mask);
-        if(mask_total_offset)
+        mask_total_offset = vec_delims(buff + i, bytes_read - i, &dl_v, &nl_v, &cr_v, &qt_v, &mask);
+        if (mask_total_offset)
           i += mask_total_offset;
       } else { // we only have a few bytes left, so manually parse
-        for(unsigned i2 = i; i2 < bytes_read; i2++)
-          if(strchr("\n\r", buff[i2]))
+        for (unsigned i2 = i; i2 < bytes_read; i2++)
+          if (strchr("\n\r", buff[i2]))
             mask += 1 << (i2 - i);
       }
-      if(UNLIKELY(mask == 0))
+      if (UNLIKELY(mask == 0))
         break;
     }
 
@@ -64,19 +61,19 @@ static enum zsv_status zsv_scan_fixed(struct zsv_scanner *scanner,
     mask = clear_lowest_bit(mask);
 
     c = buff[i];
-    if(LIKELY(c == '\n')) {
-      if(scanner_last == '\r') { // ignore; we are outside a cell and last char was rowend
+    if (LIKELY(c == '\n')) {
+      if (scanner_last == '\r') { // ignore; we are outside a cell and last char was rowend
         scanner->row_start = i + 1;
       } else {
         // this is a row end
         scanner->scanned_length = i;
-        if(VERY_UNLIKELY(row_fx(scanner, buff, scanner->row_start, i)))
+        if (VERY_UNLIKELY(row_fx(scanner, buff, scanner->row_start, i)))
           return zsv_status_cancelled; // abort
         scanner->row_start = i + 1;
       }
-    } else if(UNLIKELY(c == '\r')) {
+    } else if (UNLIKELY(c == '\r')) {
       scanner->scanned_length = i;
-      if(VERY_UNLIKELY(row_fx(scanner, buff, scanner->row_start, i)))
+      if (VERY_UNLIKELY(row_fx(scanner, buff, scanner->row_start, i)))
         return zsv_status_cancelled;
       scanner->row_start = i + 1;
     }

--- a/src/zsv_strencode.c
+++ b/src/zsv_strencode.c
@@ -8,36 +8,38 @@
 
 #include <zsv/utils/utf8.h>
 #include <zsv/utils/compiler.h>
+
 /**
  * Ensure valid UTF8 encoding by, if needed, replacing malformed bytes
  */
 ZSV_EXPORT
 size_t zsv_strencode(unsigned char *s, size_t n, unsigned char replace,
-                     int (*malformed_handler)(void *, const unsigned char *s, size_t n, size_t offset), void *handler_ctx) {
+                     int (*malformed_handler)(void *, const unsigned char *s, size_t n, size_t offset),
+                     void *handler_ctx) {
   size_t new_len = 0;
   int clen;
-  for(size_t i2 = 0; i2 < n; i2 += (size_t)clen) {
+  for (size_t i2 = 0; i2 < n; i2 += (size_t)clen) {
     clen = ZSV_UTF8_CHARLEN(s[i2]);
-    if(LIKELY(clen == 1))
+    if (LIKELY(clen == 1))
       s[new_len++] = s[i2];
-    else if(UNLIKELY(clen < 0) || UNLIKELY(i2 + clen > n)) {
-      if(malformed_handler)
+    else if (UNLIKELY(clen < 0) || UNLIKELY(i2 + clen > n)) {
+      if (malformed_handler)
         malformed_handler(handler_ctx, s, n, new_len);
-      if(replace)
+      if (replace)
         s[new_len++] = replace;
       clen = 1;
     } else { /* might be valid multi-byte utf8; check */
       unsigned char valid_n;
-      for(valid_n = 1; valid_n < clen; valid_n++)
-        if(!ZSV_UTF8_SUBSEQUENT_CHAR_OK(s[i2 + valid_n]))
+      for (valid_n = 1; valid_n < clen; valid_n++)
+        if (!ZSV_UTF8_SUBSEQUENT_CHAR_OK(s[i2 + valid_n]))
           break;
-      if(valid_n == clen) { /* valid_n utf8; copy it */
+      if (valid_n == clen) { /* valid_n utf8; copy it */
         memmove(s + new_len, s + i2, clen);
         new_len += clen;
       } else { /* invalid; valid_n smaller than expected */
-        if(malformed_handler)
+        if (malformed_handler)
           malformed_handler(handler_ctx, s, n, new_len);
-        if(replace) {
+        if (replace) {
           memset(s + new_len, replace, valid_n);
           new_len += valid_n;
         }


### PR DESCRIPTION
- Add `.clang-format` based on Microsoft style guide
  - [Microsoft's style guide](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options)
  - clang-format 14 or later is required.
  - `ubnutu-latest` (Ubuntu 22.04) runner has [Clang-format: 13.0.1, 14.0.0, 15.0.7](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime) preinstalled on it.
    - The default is **14.0.0** and it seems to be working well for our code base.
- Add shell script to run `clang-format`
- Update CI accordingly to integrate `clang-format`
  - CI will break for formatting errors in `.c`/`.h`/`.h.in` files.
  - Add separate job `format` to run `clang-format`
  - Add separate job `tag` to set `TAG` output parameter for `ci` job
- Format all existing C/Markdown/JS/JSON source files for future conformance
- Fix usage text
  - Update tests accordingly

- Fixes #154
- Fixes #185 

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>