### PR TITLE
minor cleanup for code scan

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ IndentWidth: 2
 SortIncludes: false
 TabWidth: 2
 UseTab: Never
+PointerAlignment: Right

--- a/.clang-format
+++ b/.clang-format
@@ -5,4 +5,3 @@ IndentWidth: 2
 SortIncludes: false
 TabWidth: 2
 UseTab: Never
-PointerAlignment: Right

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run clang-format
-      run: ./scripts/ci-run-clang-format.sh
+      run: |
+        sudo ln -sf /usr/bin/clang-format-15 /usr/bin/clang-format
+        ./scripts/ci-run-clang-format.sh
 
   ci:
     name: ci

--- a/app/pretty.c
+++ b/app/pretty.c
@@ -238,7 +238,7 @@ static size_t is_newline(const unsigned char *utf8, int wchar_len) {
 }
 
 // utf8_bytes_up_to_max_width: return number of bytes used up to a maximum screen width
-// max will be set to the actual width used
+// set to the actual width used
 static size_t utf8_bytes_up_to_max_width_and_replace_newlines(unsigned char *str1, size_t len1, size_t max_width,
                                                               size_t *used_width, int *err) {
   utf8proc_int32_t codepoint1;

--- a/app/rm.c
+++ b/app/rm.c
@@ -95,7 +95,7 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
           printf("Are you sure you want to remove the file %s%s?\n", filepath,
                  remove_cache ? " and all of its cache contents" : "");
         char buff[64];
-        if (fscanf(stdin, "%60s", buff) && strchr("Yy", buff[0]))
+        if (fscanf(stdin, "%60s", buff) == 1 && strchr("Yy", buff[0]))
           ok = 1;
       }
 #endif

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -64,7 +64,7 @@ struct zsv_select_data {
     struct {         // merge data: only used with --merge
       struct zsv_select_uint_list *indexes, **last_index;
     } merge;
-  } * out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
+  } *out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
 
   unsigned int output_cols_count; // total count of output columns
 
@@ -352,13 +352,13 @@ static enum zsv_select_column_index_selection_type zsv_select_column_index_selec
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if(k == 2 && n == (int)strlen((const char *)arg)) {
-      if(i > 0)
+    if (k == 2 && n == (int)strlen((const char *)arg)) {
+      if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if(k == 2 && n == (int)strlen((const char *)arg)) {
-        if(i > 0) {
+      if (k == 2 && n == (int)strlen((const char *)arg)) {
+        if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;
         }
@@ -704,17 +704,19 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       double d;
       if (!(arg_i < argc))
         stat = zsv_printerr(1, "--sample-pct option requires a value");
-      else if(!(d = atof(argv[arg_i])) && d > 0 && d < 100)
-        stat = zsv_printerr(-1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5%% of the data");
+      else if (!(d = atof(argv[arg_i])) && d > 0 && d < 100)
+        stat = zsv_printerr(
+          -1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5%% of the data");
       else
         data.sample_pct = d;
-    } else if(!strcmp(argv[arg_i], "--prepend-header"))
+    } else if (!strcmp(argv[arg_i], "--prepend-header"))
       data.prepend_header = zsv_next_arg(++arg_i, argc, argv, &err);
-    else if(!strcmp(argv[arg_i], "--no-header"))
+    else if (!strcmp(argv[arg_i], "--no-header"))
       data.no_header = 1;
-    else if(!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
-      if(!(arg_i + 1 < argc && atoi(argv[arg_i+1]) >= 0))
-        stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i], arg_i + 1 < argc ? argv[arg_i+1] : "");
+    else if (!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
+      if (!(arg_i + 1 < argc && atoi(argv[arg_i + 1]) >= 0))
+        stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i],
+                            arg_i + 1 < argc ? argv[arg_i + 1] : "");
       else
         data.data_rows_limit = atoi(argv[++arg_i]) + 1;
     } else if (!strcmp(argv[arg_i], "-D") || !strcmp(argv[arg_i], "--skip-data")) {

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -352,12 +352,12 @@ static enum zsv_select_column_index_selection_type zsv_select_column_index_selec
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if (k == 2 && n == (int)strlen((const char *)arg)) {
+    if (k && n == (int)strlen((const char *)arg)) {
       if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if (k == 2 && n == (int)strlen((const char *)arg)) {
+      if (k && n == (int)strlen((const char *)arg)) {
         if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -344,23 +344,23 @@ static enum zsv_select_column_index_selection_type zsv_select_column_index_selec
                                                                                      unsigned *lo, unsigned *hi) {
   enum zsv_select_column_index_selection_type result = zsv_select_column_index_selection_type_none;
 
-  unsigned int i, j, k;
-  int n = 0;
-  k = sscanf((const char *)arg, "%u-%u%n", &i, &j, &n);
+  unsigned int i = 0;
+  unsigned int j = 0;
+  size_t n = 0;
+  int k = sscanf((const char *)arg, "%u-%u%n", &i, &j, &n);
   if (k == 2) {
-    if (n == (int)strlen((const char *)arg) && i > 0 && j >= i)
+    if (n == strlen((const char *)arg) && i > 0 && j >= i)
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if (k && n == (int)strlen((const char *)arg)) {
+    if (k == 1 && n == strlen((const char *)arg)) {
       if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if (k && n == (int)strlen((const char *)arg)) {
+      if (k == 1 && n == strlen((const char *)arg)) {
         if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
-          j = 0;
         }
       }
     }

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -617,6 +617,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     return zsv_status_ok;
   }
 
+  int err = 0;
   struct zsv_select_data data = {0};
   data.opts = opts;
   const char *input_path = NULL;

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -346,19 +346,19 @@ static enum zsv_select_column_index_selection_type zsv_select_column_index_selec
 
   unsigned int i = 0;
   unsigned int j = 0;
-  size_t n = 0;
+  int n = 0;
   int k = sscanf((const char *)arg, "%u-%u%n", &i, &j, &n);
   if (k == 2) {
-    if (n == strlen((const char *)arg) && i > 0 && j >= i)
+    if (n >= 0 && (size_t)n == strlen((const char *)arg) && i > 0 && j >= i)
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if (k == 1 && n == strlen((const char *)arg)) {
+    if (k == 1 && n >= 0 && (size_t)n == strlen((const char *)arg)) {
       if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if (k == 1 && n == strlen((const char *)arg)) {
+      if (k == 1 && n >= 0 && (size_t)n == strlen((const char *)arg)) {
         if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
         }

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -24,6 +24,7 @@
 #include <zsv/utils/utf8.h>
 #include <zsv/utils/string.h>
 #include <zsv/utils/mem.h>
+#include <zsv/utils/arg.h>
 
 struct zsv_select_search_str {
   struct zsv_select_search_str *next;
@@ -348,12 +349,12 @@ zsv_select_column_index_selection(const unsigned char *arg, unsigned *lo, unsign
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if(k && n == (int)strlen((const char *)arg)) {
+    if(k == 2 && n == (int)strlen((const char *)arg)) {
       if(i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if(k && n == (int)strlen((const char *)arg)) {
+      if(k == 2 && n == (int)strlen((const char *)arg)) {
         if(i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;
@@ -695,17 +696,14 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       if(!(arg_i < argc))
         stat = zsv_printerr(1, "--sample-pct option requires a value");
       else if(!(d = atof(argv[arg_i])) && d > 0 && d < 100)
-        stat = zsv_printerr(-1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5% of the data");
+        stat = zsv_printerr(-1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5%% of the data");
       else
         data.sample_pct = d;
-    } else if(!strcmp(argv[arg_i], "--prepend-header")) {
-      if(!(arg_i + 1 < argc))
-        stat = zsv_printerr(1, "%s option requires a value");
-      else
-        data.prepend_header = argv[++arg_i];
-    } else if(!strcmp(argv[arg_i], "--no-header")) {
+    } else if(!strcmp(argv[arg_i], "--prepend-header"))
+      data.prepend_header = zsv_next_arg(++arg_i, argc, argv, &err);
+    else if(!strcmp(argv[arg_i], "--no-header"))
       data.no_header = 1;
-    } else if(!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
+    else if(!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
       if(!(arg_i + 1 < argc && atoi(argv[arg_i+1]) >= 0))
         stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i], arg_i + 1 < argc ? argv[arg_i+1] : "");
       else

--- a/app/select.c
+++ b/app/select.c
@@ -354,20 +354,21 @@ static enum zsv_select_column_index_selection_type zsv_select_column_index_selec
                                                                                      unsigned *lo, unsigned *hi) {
   enum zsv_select_column_index_selection_type result = zsv_select_column_index_selection_type_none;
 
-  unsigned int i, j, k;
-  int n = 0;
-  k = sscanf((const char *)arg, "%u-%u%n", &i, &j, &n);
+  unsigned int i = 0;
+  unsigned int j = 0;
+  size_t n = 0;
+  int k = sscanf((const char *)arg, "%u-%u%n", &i, &j, &n);
   if (k == 2) {
-    if (n == (int)strlen((const char *)arg) && i > 0 && j >= i)
+    if (n == strlen((const char *)arg) && i > 0 && j >= i)
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if (k && n == (int)strlen((const char *)arg)) {
+    if (k == 1 && n == strlen((const char *)arg)) {
       if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if (k && n == (int)strlen((const char *)arg)) {
+      if (k == 1 && n == strlen((const char *)arg)) {
         if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;

--- a/app/select.c
+++ b/app/select.c
@@ -70,7 +70,7 @@ struct zsv_select_data {
     struct {         // merge data: only used with --merge
       struct zsv_select_uint_list *indexes, **last_index;
     } merge;
-  } * out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
+  } *out2in; // array of .output_cols_count length; out2in[x] = y where x = output ix, y = input info
 
   unsigned int output_cols_count; // total count of output columns
 
@@ -362,13 +362,13 @@ static enum zsv_select_column_index_selection_type zsv_select_column_index_selec
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if(k == 2 && n == (int)strlen((const char *)arg)) {
-      if(i > 0)
+    if (k == 2 && n == (int)strlen((const char *)arg)) {
+      if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if(k == 2 && n == (int)strlen((const char *)arg)) {
-        if(i > 0) {
+      if (k == 2 && n == (int)strlen((const char *)arg)) {
+        if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;
         }
@@ -784,15 +784,15 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
           if (*s == ',')
             data.fixed.count++;
         free(data.fixed.offsets);
-        if(!(data.fixed.offsets = malloc(data.fixed.count * sizeof(*data.fixed.offsets)))) {
+        if (!(data.fixed.offsets = malloc(data.fixed.count * sizeof(*data.fixed.offsets)))) {
           stat = zsv_printerr(1, "Out of memory!\n");
           break;
         }
         size_t count = 0;
         const char *start = argv[arg_i];
-        for(const char *end = argv[arg_i]; ; end++) {
-          if(*end == ',' || *end == '\0') {
-            if(sscanf(start, "%zu,", &data.fixed.offsets[count++]) != 1) {
+        for (const char *end = argv[arg_i];; end++) {
+          if (*end == ',' || *end == '\0') {
+            if (sscanf(start, "%zu,", &data.fixed.offsets[count++]) != 1) {
               stat = zsv_printerr(1, "Invalid offset: %.*s\n", end - start, start);
               break;
             } else if (*end == '\0')
@@ -852,17 +852,19 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       double d;
       if (!(arg_i < argc))
         stat = zsv_printerr(1, "--sample-pct option requires a value");
-      else if(!(d = atof(argv[arg_i])) && d > 0 && d < 100)
-        stat = zsv_printerr(-1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5%% of the data");
+      else if (!(d = atof(argv[arg_i])) && d > 0 && d < 100)
+        stat = zsv_printerr(
+          -1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5%% of the data");
       else
         data.sample_pct = d;
-    } else if(!strcmp(argv[arg_i], "--prepend-header"))
+    } else if (!strcmp(argv[arg_i], "--prepend-header"))
       data.prepend_header = zsv_next_arg(++arg_i, argc, argv, &err);
-    else if(!strcmp(argv[arg_i], "--no-header"))
+    else if (!strcmp(argv[arg_i], "--no-header"))
       data.no_header = 1;
-    else if(!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
-      if(!(arg_i + 1 < argc && atoi(argv[arg_i+1]) >= 0))
-        stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i], arg_i + 1 < argc ? argv[arg_i+1] : "");
+    else if (!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
+      if (!(arg_i + 1 < argc && atoi(argv[arg_i + 1]) >= 0))
+        stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i],
+                            arg_i + 1 < argc ? argv[arg_i + 1] : "");
       else
         data.data_rows_limit = atoi(argv[++arg_i]) + 1;
     } else if (!strcmp(argv[arg_i], "-D") || !strcmp(argv[arg_i], "--skip-data")) {
@@ -897,16 +899,16 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       input_path = argv[arg_i];
   }
 
-  if(stat == zsv_status_ok) {
-    if(data.sample_pct)
+  if (stat == zsv_status_ok) {
+    if (data.sample_pct)
       srand(time(0));
 
-    if(data.use_header_indexes && stat == zsv_status_ok)
+    if (data.use_header_indexes && stat == zsv_status_ok)
       stat = zsv_select_check_exclusions_are_indexes(&data);
   }
 
-  if(stat == zsv_status_ok) {
-    if(!data.opts->stream) {
+  if (stat == zsv_status_ok) {
+    if (!data.opts->stream) {
 #ifdef NO_STDIN
       stat = zsv_printerr(1, "Please specify an input file");
 #else
@@ -914,18 +916,19 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #endif
     }
 
-    if(stat == zsv_status_ok && fixed_auto) {
-      if(data.fixed.offsets)
+    if (stat == zsv_status_ok && fixed_auto) {
+      if (data.fixed.offsets)
         stat = zsv_printerr(zsv_status_error, "Please specify either --fixed-auto or --fixed, but not both");
-      else if(data.opts->insert_header_row)
+      else if (data.opts->insert_header_row)
         stat = zsv_printerr(zsv_status_error, "--fixed-auto can not be specified together with --header-row");
       else {
-        size_t buffsize = 1024*256; // read the first
+        size_t buffsize = 1024 * 256; // read the first
         preview_buff = calloc(buffsize, sizeof(*preview_buff));
-        if(!preview_buff)
+        if (!preview_buff)
           stat = zsv_printerr(zsv_status_memory, "Out of memory!");
         else
-          stat = auto_detect_fixed_column_sizes(&data.fixed, data.opts, preview_buff, buffsize, &preview_buff_len, opts->verbose);
+          stat = auto_detect_fixed_column_sizes(&data.fixed, data.opts, preview_buff, buffsize, &preview_buff_len,
+                                                opts->verbose);
       }
     }
   }

--- a/app/select.c
+++ b/app/select.c
@@ -758,7 +758,6 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     return zsv_status_ok;
   }
 
-  int err = 0;
   char fixed_auto = 0;
   struct zsv_select_data data = {0};
   data.opts = opts;

--- a/app/select.c
+++ b/app/select.c
@@ -865,7 +865,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     } else if (!strcmp(argv[arg_i], "--prepend-header")) {
       int err = 0;
       data.prepend_header = zsv_next_arg(++arg_i, argc, argv, &err);
-      if(err)
+      if (err)
         stat = zsv_status_error;
     } else if (!strcmp(argv[arg_i], "--no-header"))
       data.no_header = 1;

--- a/app/select.c
+++ b/app/select.c
@@ -786,7 +786,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
           if (*s == ',')
             data.fixed.count++;
         free(data.fixed.offsets);
-        if (!(data.fixed.offsets = malloc(data.fixed.count * sizeof(*data.fixed.offsets)))) {
+        data.fixed.offsets = malloc(data.fixed.count * sizeof(*data.fixed.offsets));
+        if (!data.fixed.offsets) {
           stat = zsv_printerr(1, "Out of memory!\n");
           break;
         }
@@ -806,7 +807,6 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
             }
           }
         }
-      }
     } else if (!strcmp(argv[arg_i], "--distinct"))
       data.distinct = 1;
     else if (!strcmp(argv[arg_i], "--merge"))

--- a/app/select.c
+++ b/app/select.c
@@ -807,6 +807,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
             }
           }
         }
+      }
     } else if (!strcmp(argv[arg_i], "--distinct"))
       data.distinct = 1;
     else if (!strcmp(argv[arg_i], "--merge"))

--- a/app/select.c
+++ b/app/select.c
@@ -24,6 +24,7 @@
 #include <zsv/utils/utf8.h>
 #include <zsv/utils/string.h>
 #include <zsv/utils/mem.h>
+#include <zsv/utils/arg.h>
 
 struct zsv_select_search_str {
   struct zsv_select_search_str *next;
@@ -358,12 +359,12 @@ zsv_select_column_index_selection(const unsigned char *arg, unsigned *lo, unsign
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if(k && n == (int)strlen((const char *)arg)) {
+    if(k == 2 && n == (int)strlen((const char *)arg)) {
       if(i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if(k && n == (int)strlen((const char *)arg)) {
+      if(k == 2 && n == (int)strlen((const char *)arg)) {
         if(i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;
@@ -775,12 +776,15 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
           if(*s == ',')
             data.fixed.count++;
         free(data.fixed.offsets);
-        data.fixed.offsets = malloc(data.fixed.count * sizeof(*data.fixed.offsets));
+        if(!(data.fixed.offsets = malloc(data.fixed.count * sizeof(*data.fixed.offsets)))) {
+          stat = zsv_printerr(1, "Out of memory!\n");
+          break;
+        }
         size_t count = 0;
         const char *start = argv[arg_i];
         for(const char *end = argv[arg_i]; ; end++) {
           if(*end == ',' || *end == '\0') {
-            if(!sscanf(start, "%zu,", &data.fixed.offsets[count++])) {
+            if(sscanf(start, "%zu,", &data.fixed.offsets[count++]) != 1) {
               stat = zsv_printerr(1, "Invalid offset: %.*s\n", end - start, start);
               break;
             } else if(*end == '\0')
@@ -841,17 +845,14 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       if(!(arg_i < argc))
         stat = zsv_printerr(1, "--sample-pct option requires a value");
       else if(!(d = atof(argv[arg_i])) && d > 0 && d < 100)
-        stat = zsv_printerr(-1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5% of the data");
+        stat = zsv_printerr(-1, "--sample-pct value should be a number between 0 and 100 (e.g. 1.5 for a sample of 1.5%% of the data");
       else
         data.sample_pct = d;
-    } else if(!strcmp(argv[arg_i], "--prepend-header")) {
-      if(!(arg_i + 1 < argc))
-        stat = zsv_printerr(1, "%s option requires a value");
-      else
-        data.prepend_header = argv[++arg_i];
-    } else if(!strcmp(argv[arg_i], "--no-header")) {
-        data.no_header = 1;
-    } else if(!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
+    } else if(!strcmp(argv[arg_i], "--prepend-header"))
+      data.prepend_header = zsv_next_arg(++arg_i, argc, argv, &err);
+    else if(!strcmp(argv[arg_i], "--no-header"))
+      data.no_header = 1;
+    else if(!strcmp(argv[arg_i], "-H") || !strcmp(argv[arg_i], "--head")) {
       if(!(arg_i + 1 < argc && atoi(argv[arg_i+1]) >= 0))
         stat = zsv_printerr(1, "%s option value invalid: should be positive integer; got %s", argv[arg_i], arg_i + 1 < argc ? argv[arg_i+1] : "");
       else
@@ -888,32 +889,36 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       input_path = argv[arg_i];
   }
 
-  if(data.sample_pct)
-    srand(time(0));
+  if(stat == zsv_status_ok) {
+    if(data.sample_pct)
+      srand(time(0));
 
-  if(data.use_header_indexes && stat == zsv_status_ok)
-    stat = zsv_select_check_exclusions_are_indexes(&data);
-
-  if(!data.opts->stream) {
-#ifdef NO_STDIN
-    stat = zsv_printerr(1, "Please specify an input file");
-#else
-    data.opts->stream = stdin;
-#endif
+    if(data.use_header_indexes && stat == zsv_status_ok)
+      stat = zsv_select_check_exclusions_are_indexes(&data);
   }
 
-  if(stat == zsv_status_ok && fixed_auto) {
-    if(data.fixed.offsets)
-      stat = zsv_printerr(zsv_status_error, "Please specify either --fixed-auto or --fixed, but not both");
-    else if(data.opts->insert_header_row)
-      stat = zsv_printerr(zsv_status_error, "--fixed-auto can not be specified together with --header-row");
-    else {
-      size_t buffsize = 1024*256; // read the first
-      preview_buff = calloc(buffsize, sizeof(*preview_buff));
-      if(!preview_buff)
-        stat = zsv_printerr(zsv_status_memory, "Out of memory!");
-      else
-        stat = auto_detect_fixed_column_sizes(&data.fixed, data.opts, preview_buff, buffsize, &preview_buff_len, opts->verbose);
+  if(stat == zsv_status_ok) {
+    if(!data.opts->stream) {
+#ifdef NO_STDIN
+      stat = zsv_printerr(1, "Please specify an input file");
+#else
+      data.opts->stream = stdin;
+#endif
+    }
+
+    if(stat == zsv_status_ok && fixed_auto) {
+      if(data.fixed.offsets)
+        stat = zsv_printerr(zsv_status_error, "Please specify either --fixed-auto or --fixed, but not both");
+      else if(data.opts->insert_header_row)
+        stat = zsv_printerr(zsv_status_error, "--fixed-auto can not be specified together with --header-row");
+      else {
+        size_t buffsize = 1024*256; // read the first
+        preview_buff = calloc(buffsize, sizeof(*preview_buff));
+        if(!preview_buff)
+          stat = zsv_printerr(zsv_status_memory, "Out of memory!");
+        else
+          stat = auto_detect_fixed_column_sizes(&data.fixed, data.opts, preview_buff, buffsize, &preview_buff_len, opts->verbose);
+      }
     }
   }
 

--- a/app/select.c
+++ b/app/select.c
@@ -362,12 +362,12 @@ static enum zsv_select_column_index_selection_type zsv_select_column_index_selec
       result = zsv_select_column_index_selection_type_range;
   } else {
     k = sscanf((const char *)arg, "%u%n", &i, &n);
-    if (k == 2 && n == (int)strlen((const char *)arg)) {
+    if (k && n == (int)strlen((const char *)arg)) {
       if (i > 0)
         result = zsv_select_column_index_selection_type_single;
     } else {
       k = sscanf((const char *)arg, "%u-%n", &i, &n);
-      if (k == 2 && n == (int)strlen((const char *)arg)) {
+      if (k && n == (int)strlen((const char *)arg)) {
         if (i > 0) {
           result = zsv_select_column_index_selection_type_lower_bounded;
           j = 0;

--- a/app/select.c
+++ b/app/select.c
@@ -756,6 +756,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     return zsv_status_ok;
   }
 
+  int err = 0;
   char fixed_auto = 0;
   struct zsv_select_data data = {0};
   data.opts = opts;

--- a/app/sql.c
+++ b/app/sql.c
@@ -392,7 +392,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
           for (char *ix_str = data.join_indexes; !err && ix_str && *ix_str && *(++ix_str);
                ix_str = strchr(ix_str + 1, ',')) {
             unsigned int next_ix;
-            if (sscanf(ix_str, "%u,", &next_ix)) {
+            if (sscanf(ix_str, "%u,", &next_ix) == 1) {
               if (next_ix == 0)
                 fprintf(stderr, "--join-indexes index must be greater than zero\n");
               else if (next_ix > (unsigned)col_count)

--- a/scripts/ci-run-clang-format.sh
+++ b/scripts/ci-run-clang-format.sh
@@ -6,7 +6,7 @@ echo "[INF] Running $0"
 
 VERSION=$(clang-format --version | cut -d ' ' -f4 | tr -d '\n')
 MAJOR_VERSION=$(echo "$VERSION" | cut -d '.' -f1)
-REQUIRED_VERSION="14"
+REQUIRED_VERSION="15"
 
 if [ "$VERSION" = "" ]; then
   echo "[ERR] clang-format is not installed!"
@@ -27,7 +27,7 @@ for DIR in app examples include src; do
     ! -path "$DIR/external/*" \
     -type f \
     -regex '.*\.\(c\|h\|h\.in\)' \
-    -exec sh -c 'clang-format -style=file -i "$1" &' - '{}' \;
+    -exec sh -c 'clang-format-15 -style=file -i "$1" &' - '{}' \;
 done
 
 wait

--- a/scripts/ci-run-clang-format.sh
+++ b/scripts/ci-run-clang-format.sh
@@ -16,7 +16,7 @@ else
   echo "[INF] clang-format version [$VERSION]"
   if [ "$MAJOR_VERSION" -lt "$REQUIRED_VERSION" ]; then
     echo "[ERR] Installed clang-format version is $VERSION."
-    echo "[ERR] clang-format $REQUIRED_VERSION or later is required!"
+    echo "[ERR] clang-format-$REQUIRED_VERSION or later is required!"
     exit 1
   fi
 fi
@@ -27,7 +27,7 @@ for DIR in app examples include src; do
     ! -path "$DIR/external/*" \
     -type f \
     -regex '.*\.\(c\|h\|h\.in\)' \
-    -exec sh -c 'clang-format-15 -style=file -i "$1" &' - '{}' \;
+    -exec sh -c 'clang-format -style=file -i "$1" &' - '{}' \;
 done
 
 wait

--- a/scripts/ci-run-clang-format.sh
+++ b/scripts/ci-run-clang-format.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "[INF] Running $0"
 
-VERSION=$(clang-format --version | cut -d ' ' -f4 | tr -d '\n')
+VERSION=$(clang-format --version | sed 's/^[^0-9]*//g' | sed 's/ .*$//g')
 MAJOR_VERSION=$(echo "$VERSION" | cut -d '.' -f1)
 REQUIRED_VERSION="15"
 

--- a/src/zsv_internal.c
+++ b/src/zsv_internal.c
@@ -183,7 +183,7 @@ struct zsv_scanner {
     union {
       struct zsv_scan_delim_regs delim;
       struct zsv_scan_fixed_regs fixed;
-    } * regs;
+    } *regs;
     enum zsv_status stat; // last status
     unsigned char *buff;
     size_t bytes_read;


### PR DESCRIPTION
- Minor cleanup for code scan
- Use `clang-format-15`
- Format source files if required (missing ones)