### PR TITLE
[CI] Integrate Cppcheck for static code analysis

### DIFF
--- a/.cppcheck
+++ b/.cppcheck
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="1">
+    <builddir>cppcheck-build-dir</builddir>
+    <analyze-all-vs-configs>false</analyze-all-vs-configs>
+    <check-headers>true</check-headers>
+    <check-unused-templates>false</check-unused-templates>
+    <max-ctu-depth>2</max-ctu-depth>
+    <includedir>
+        <dir name="include/" />
+    </includedir>
+    <paths>
+        <dir name="src" />
+        <dir name="app" />
+        <dir name="examples" />
+    </paths>
+    <exclude>
+        <path name="app/external/" />
+    </exclude>
+    <libraries>
+        <library>cppcheck-lib</library>
+        <library>emscripten</library>
+        <library>posix</library>
+        <library>sqlite3</library>
+        <library>windows</library>
+    </libraries>
+    <suppressions>
+        <suppression>missingInclude</suppression>
+        <suppression>missingIncludeSystem</suppression>
+        <suppression>unmatchedSuppression</suppression>
+    </suppressions>
+</project>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,11 @@ on:
   release:
     types: [published]
 
+env:
+  ARTIFACT_RETENTION_DAYS: 5
+
 jobs:
   tag:
-    name: tag
     runs-on: ubuntu-latest
 
     outputs:
@@ -32,8 +34,7 @@ jobs:
         echo "TAG: $TAG"
         echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
 
-  format:
-    name: format
+  clang-format:
     runs-on: ubuntu-latest
 
     steps:
@@ -45,9 +46,40 @@ jobs:
         sudo ln -sf /usr/bin/clang-format-15 /usr/bin/clang-format
         ./scripts/ci-run-clang-format.sh
 
+  cppcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install cppcheck
+      run: |
+        sudo apt update
+        sudo apt install -y cppcheck
+        cppcheck --version
+
+    - name: Run cppcheck
+      run: ./scripts/ci-run-cppcheck.sh
+
+    - name: Upload (${{ env.CPPCHECK_XML_ARTIFACT_NAME }})
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
+        path: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (${{ env.CPPCHECK_HTML_ARTIFACT_NAME }})
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
+        path: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
   ci:
-    name: ci
-    needs: [format, tag]
+    needs: [tag, clang-format, cppcheck]
 
     strategy:
       matrix:
@@ -69,7 +101,6 @@ jobs:
       ARM64_MACOSX_GCC: arm64-macosx-gcc
       AMD64_FREEBSD_GCC: amd64-freebsd-gcc
       ARTIFACT_DIR: .artifacts
-      ARTIFACT_RETENTION_DAYS: 5
 
     steps:
     - name: Checkout
@@ -191,7 +222,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         for ARTIFACT in "$ARTIFACT_DIR"/*; do
-          echo "[INF] Veriyfing artifact... [$ARTIFACT]"
+          echo "[INF] Verifying artifact... [$ARTIFACT]"
           gh attestation verify "$ARTIFACT" --repo "$GITHUB_REPOSITORY"
           echo "[INF] Verified successfully! [$ARTIFACT]"
         done

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ amd64-freebsd-gcc
 jq
 nuget-feed
 homebrew-zsv
+cppcheck*

--- a/Makefile
+++ b/Makefile
@@ -68,4 +68,4 @@ clean:
 	@${MAKE} -C app clean-all CONFIGFILE=${CONFIGFILEPATH}
 	@rm -rf ${THIS_MAKEFILE_DIR}/build
 
-.PHONY: help build install uninstall uninstall clean check test
+.PHONY: help build install uninstall clean check test

--- a/app/utils/dirs.c
+++ b/app/utils/dirs.c
@@ -197,9 +197,7 @@ size_t zsv_get_executable_path(char *buff, size_t buffsize) {
   return buffsize;
 }
 #else
-
-to do: add support for this OS!;
-
+// TODO: Add support for this OS!
 #endif /* end of: #if defined(_WIN32) */
 
 struct dir_path {

--- a/scripts/ci-run-cppcheck.sh
+++ b/scripts/ci-run-cppcheck.sh
@@ -57,13 +57,25 @@ if [ "$CI" = true ]; then
   } >>"$GITHUB_ENV"
 
   echo "[INF] Generating Markdown step summary..."
-  SOURCE_LINK="[{file}:{line}](https://github.com/liquidaty/zsv/blob/$GITHUB_HEAD_REF/{file}#L{line}):{column}"
+
+  BRANCH=
+  if [ "$GITHUB_REF_TYPE" = "branch" ]; then
+    if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+      BRANCH="$GITHUB_REF_NAME"
+    elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+      BRANCH="$GITHUB_HEAD_REF"
+    fi
+  elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
+    BRANCH="main"
+  fi
+
+  SOURCE_LINK="[{file}:{line}](https://github.com/liquidaty/zsv/blob/$BRANCH/{file}#L{line})"
   CWE_LINK="[{cwe}](https://cwe.mitre.org/data/definitions/{cwe}.html)"
-  TEMPLATE="| $SOURCE_LINK | {severity} | {id} | {message} | $CWE_LINK |"
+  TEMPLATE="| $SOURCE_LINK | {column} | {severity} | {id} | {message} | $CWE_LINK |"
   {
     echo "# Cppcheck Static Analysis Summary"
-    echo "| File:Line:Column | Severity |  ID   | Message |  CWE  |"
-    echo "| :--------------: | :------: | :---: | :-----: | :---: |"
+    echo "| File:Line | Column | Severity |  ID   | Message |  CWE  |"
+    echo "| :-------: | :----: | :------: | :---: | :-----: | :---: |"
     cppcheck \
       --quiet \
       --enable=all \

--- a/scripts/ci-run-cppcheck.sh
+++ b/scripts/ci-run-cppcheck.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+set -e
+
+echo "[INF] Running $0"
+
+if ! which cppcheck >/dev/null; then
+  echo "[ERR] cppcheck is not installed!"
+  exit 1
+fi
+
+VERSION=$(cppcheck --version | sed 's/^[^0-9]*//g' | sed 's/ .*$//g')
+echo "[INF] cppcheck version [$VERSION]"
+
+CPPCHECK_PROJECT_FILE=".cppcheck"
+CPPCHECK_BUILD_DIR="cppcheck-build-dir"
+CPPCHECK_XML_OUTPUT_FILE="cppcheck.xml"
+CPPCHECK_HTML_REPORT_DIR="cppcheck-html-report-dir"
+
+echo "[INF] CPPCHECK_PROJECT_FILE: $CPPCHECK_PROJECT_FILE"
+echo "[INF] CPPCHECK_BUILD_DIR: $CPPCHECK_BUILD_DIR"
+echo "[INF] CPPCHECK_XML_OUTPUT_FILE: $CPPCHECK_XML_OUTPUT_FILE"
+echo "[INF] CPPCHECK_HTML_REPORT_DIR: $CPPCHECK_HTML_REPORT_DIR"
+
+mkdir -p "$CPPCHECK_BUILD_DIR"
+
+echo "[INF] Generating XML report..."
+cppcheck \
+  --quiet \
+  --enable=all \
+  --project="$CPPCHECK_PROJECT_FILE" \
+  --xml 2>"$CPPCHECK_XML_OUTPUT_FILE"
+
+ls -Gghl "$CPPCHECK_XML_OUTPUT_FILE"
+
+echo "[INF] Generating HTML report..."
+cppcheck-htmlreport \
+  --title="zsv" \
+  --file="$CPPCHECK_XML_OUTPUT_FILE" \
+  --report-dir="$CPPCHECK_HTML_REPORT_DIR" \
+  --source-dir="$PWD"
+
+# GitHub Actions
+if [ "$CI" = true ]; then
+  CPPCHECK_XML_ARTIFACT_NAME="zsv-cppcheck-xml-report-$(date "+%s").zip"
+  CPPCHECK_HTML_ARTIFACT_NAME="zsv-cppcheck-html-report-$(date "+%s").zip"
+
+  echo "[INF] Generating ZIP archive (XML)... [$CPPCHECK_XML_ARTIFACT_NAME]"
+  zip "$CPPCHECK_XML_ARTIFACT_NAME" "$CPPCHECK_XML_OUTPUT_FILE"
+
+  echo "[INF] Generating ZIP archive (HTML)... [$CPPCHECK_HTML_ARTIFACT_NAME]"
+  zip -r "$CPPCHECK_HTML_ARTIFACT_NAME" "$CPPCHECK_HTML_REPORT_DIR"
+
+  {
+    echo "CPPCHECK_XML_ARTIFACT_NAME=$CPPCHECK_XML_ARTIFACT_NAME"
+    echo "CPPCHECK_HTML_ARTIFACT_NAME=$CPPCHECK_HTML_ARTIFACT_NAME"
+  } >>"$GITHUB_ENV"
+fi
+
+echo "[INF] --- [DONE] ---"

--- a/scripts/ci-run-cppcheck.sh
+++ b/scripts/ci-run-cppcheck.sh
@@ -68,8 +68,9 @@ if [ "$CI" = true ]; then
       --quiet \
       --enable=all \
       --project="$CPPCHECK_PROJECT_FILE" \
-      --template="$TEMPLATE"
-  } 2>>"$GITHUB_STEP_SUMMARY"
+      --template="$TEMPLATE" \
+      2>&1
+  } >>"$GITHUB_STEP_SUMMARY"
 fi
 
 echo "[INF] --- [DONE] ---"

--- a/scripts/ci-run-cppcheck.sh
+++ b/scripts/ci-run-cppcheck.sh
@@ -57,11 +57,11 @@ if [ "$CI" = true ]; then
   } >>"$GITHUB_ENV"
 
   echo "[INF] Generating Markdown step summary..."
-  SOURCE_LINK="[{file}:{line}](https://github.com/liquidaty/zsv/blob/$GITHUB_REF_NAME/{file}#L{line}):{column}"
+  SOURCE_LINK="[{file}:{line}](https://github.com/liquidaty/zsv/blob/$GITHUB_HEAD_REF/{file}#L{line}):{column}"
   CWE_LINK="[{cwe}](https://cwe.mitre.org/data/definitions/{cwe}.html)"
-  TEMPLATE="| $SOURCE_LINK | {severity} | \`{id}\` | {message} | $CWE_LINK |"
+  TEMPLATE="| $SOURCE_LINK | {severity} | {id} | {message} | $CWE_LINK |"
   {
-    echo "### Cppcheck Static Analysis Summary"
+    echo "# Cppcheck Static Analysis Summary"
     echo "| File:Line:Column | Severity |  ID   | Message |  CWE  |"
     echo "| :--------------: | :------: | :---: | :-----: | :---: |"
     cppcheck \

--- a/scripts/ci-run-cppcheck.sh
+++ b/scripts/ci-run-cppcheck.sh
@@ -42,8 +42,8 @@ cppcheck-htmlreport \
 
 # GitHub Actions
 if [ "$CI" = true ]; then
-  CPPCHECK_XML_ARTIFACT_NAME="zsv-cppcheck-xml-report-$(date "+%s").zip"
-  CPPCHECK_HTML_ARTIFACT_NAME="zsv-cppcheck-html-report-$(date "+%s").zip"
+  CPPCHECK_XML_ARTIFACT_NAME="zsv-cppcheck-xml-report-$GITHUB_RUN_ID.zip"
+  CPPCHECK_HTML_ARTIFACT_NAME="zsv-cppcheck-html-report-$GITHUB_RUN_ID.zip"
 
   echo "[INF] Generating ZIP archive (XML)... [$CPPCHECK_XML_ARTIFACT_NAME]"
   zip "$CPPCHECK_XML_ARTIFACT_NAME" "$CPPCHECK_XML_OUTPUT_FILE"

--- a/scripts/ci-run-cppcheck.sh
+++ b/scripts/ci-run-cppcheck.sh
@@ -55,6 +55,21 @@ if [ "$CI" = true ]; then
     echo "CPPCHECK_XML_ARTIFACT_NAME=$CPPCHECK_XML_ARTIFACT_NAME"
     echo "CPPCHECK_HTML_ARTIFACT_NAME=$CPPCHECK_HTML_ARTIFACT_NAME"
   } >>"$GITHUB_ENV"
+
+  echo "[INF] Generating Markdown step summary..."
+  SOURCE_LINK="[{file}:{line}](https://github.com/liquidaty/zsv/blob/$GITHUB_REF_NAME/{file}#L{line}):{column}"
+  CWE_LINK="[{cwe}](https://cwe.mitre.org/data/definitions/{cwe}.html)"
+  TEMPLATE="| $SOURCE_LINK | {severity} | \`{id}\` | {message} | $CWE_LINK |"
+  {
+    echo "### Cppcheck Static Analysis Summary"
+    echo "| File:Line:Column | Severity |  ID   | Message |  CWE  |"
+    echo "| :--------------: | :------: | :---: | :-----: | :---: |"
+    cppcheck \
+      --quiet \
+      --enable=all \
+      --project="$CPPCHECK_PROJECT_FILE" \
+      --template="$TEMPLATE"
+  } 2>>"$GITHUB_STEP_SUMMARY"
 fi
 
 echo "[INF] --- [DONE] ---"


### PR DESCRIPTION
- Add `.cppcheck` file for project configuration
  - Cppcheck manual: https://github.com/danmar/cppcheck/blob/main/man/manual.md
- Add shell script to run `cppcheck` and generate XML and HTML reports
- Configure CI workflow to run cppcheck script
  - Upload XML and HTML reports as artifacts
  - Add navigable Cppcheck summary in the CI's step summary as Markdown
- Update `.gitignore`
- Resolves #195

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>
