### PR TITLE
[CI] Separate job for BSD build + other cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,6 +539,8 @@ jobs:
 
     - name: Build and push (on release)
       uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_RECORD_UPLOAD: false
       with:
         platforms: linux/amd64
         push: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
       TAG: ${{ steps.tag.outputs.TAG }}
 
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/ci-set-tag-output-parameter.sh
+
     - name: Set TAG output parameter
       id: tag
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,16 @@ defaults:
     shell: bash
 
 env:
+  AMD64_LINUX_GCC: amd64-linux-gcc
+  AMD64_LINUX_CLANG: amd64-linux-clang
+  AMD64_LINUX_MUSL: amd64-linux-musl
+  AMD64_WINDOWS_MINGW: amd64-windows-mingw
+  AMD64_MACOSX_GCC: amd64-macosx-gcc
+  ARM64_MACOSX_GCC: arm64-macosx-gcc
+  AMD64_FREEBSD_GCC: amd64-freebsd-gcc
+  ARTIFACT_DIR: .artifacts
   ARTIFACT_RETENTION_DAYS: 5
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   tag:
@@ -25,18 +34,11 @@ jobs:
       TAG: ${{ steps.tag.outputs.TAG }}
 
     steps:
-    - name: Set TAG
+    - name: Set TAG output parameter
       id: tag
       env:
         TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
-      run: |
-        if [[ -z $TAG ]]; then
-          TAG="$(git ls-remote --tags --refs https://github.com/liquidaty/zsv | cut -d '/' -f3 | tail -n1)"
-        fi
-        if [[ $TAG == "v"* ]]; then
-          TAG="${TAG:1}"
-        fi
-        echo "TAG=$TAG" | tee -a "$GITHUB_OUTPUT"
+      run: ./scripts/ci-set-tag-output-parameter.sh
 
   clang-format:
     runs-on: ubuntu-22.04
@@ -98,14 +100,6 @@ jobs:
 
     env:
       TAG: ${{ needs.tag.outputs.TAG }}
-      AMD64_LINUX_GCC: amd64-linux-gcc
-      AMD64_LINUX_CLANG: amd64-linux-clang
-      AMD64_LINUX_MUSL: amd64-linux-musl
-      AMD64_WINDOWS_MINGW: amd64-windows-mingw
-      AMD64_MACOSX_GCC: amd64-macosx-gcc
-      ARM64_MACOSX_GCC: arm64-macosx-gcc
-      AMD64_FREEBSD_GCC: amd64-freebsd-gcc
-      ARTIFACT_DIR: .artifacts
 
     steps:
     - name: Checkout
@@ -125,24 +119,6 @@ jobs:
         brew uninstall jq
 
     # --- Build ---
-
-    - name: Build on Linux (${{ env.AMD64_FREEBSD_GCC }})
-      if: runner.os == 'Linux'
-      uses: cross-platform-actions/action@v0.25.0
-      env:
-        PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
-        CC: gcc
-        MAKE: gmake
-        RUN_TESTS: false
-      with:
-        memory: 2048
-        shell: sh
-        operating_system: freebsd
-        version: '13.2'
-        environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
-        run: |
-          ./scripts/ci-freebsd-setup.sh
-          ./scripts/ci-build.sh
 
     - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
       if: runner.os == 'Linux'
@@ -205,9 +181,7 @@ jobs:
         CC: gcc-13
         MAKE: make
         RUN_TESTS: false
-      run: |
-        ./scripts/ci-build.sh
-        ./$PREFIX/bin/zsv version
+      run: ./scripts/ci-build.sh
 
     - name: Build on macOS (${{ env.ARM64_MACOSX_GCC }})
       if: matrix.os == 'macos-14'
@@ -216,29 +190,22 @@ jobs:
         CC: gcc-13
         MAKE: make
         RUN_TESTS: false
-      run: |
-        ./scripts/ci-build.sh
-        ./$PREFIX/bin/zsv version
+      run: ./scripts/ci-build.sh
 
     # --- Upload build artifacts ---
 
     - name: Prepare build artifacts for upload
       run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-    - name: Attest build artifacts
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/attest-build-provenance@v1
       with:
         subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-    - name: Verify attested artifacts
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        for ARTIFACT in "$ARTIFACT_DIR"/*; do
-          echo "[INF] Verifying artifact... [$ARTIFACT]"
-          gh attestation verify "$ARTIFACT" --repo "$GITHUB_REPOSITORY"
-          echo "[INF] Verified successfully! [$ARTIFACT]"
-        done
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
 
     - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
       if: runner.os == 'Linux'
@@ -383,17 +350,6 @@ jobs:
         retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
         if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
     - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
       if: runner.os == 'Linux'
       uses: actions/upload-artifact@v4
@@ -460,8 +416,78 @@ jobs:
         retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
         if-no-files-found: error
 
+    # --- Upload release artifacts ---
+
+    - name: Upload release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-upload-release-artifacts.sh
+
+    # --- Update homebrew tap ---
+
+    - name: Update homebrew tap (liquidaty/homebrew-zsv)
+      if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.os == 'macos-13' }}
+      env:
+        HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+        TAG: ${{ env.TAG }}
+        TRIPLET: ${{ env.AMD64_MACOSX_GCC }}
+      run: ./scripts/ci-update-homebrew-tap.sh
+
+  ci-bsd:
+    needs: [tag, clang-format, cppcheck]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build on Linux (${{ env.AMD64_FREEBSD_GCC }})
+      uses: cross-platform-actions/action@v0.25.0
+      env:
+        PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
+        CC: gcc
+        MAKE: gmake
+        RUN_TESTS: false
+      with:
+        operating_system: freebsd
+        version: '13.2'
+        environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
+        shell: sh
+        run: |
+          ./scripts/ci-freebsd-setup.sh
+          ./scripts/ci-build.sh
+
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
     - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
-      if: runner.os == 'Linux'
       uses: actions/upload-artifact@v4
       env:
         ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
@@ -475,27 +501,7 @@ jobs:
 
     - name: Upload release artifacts
       if: startsWith(github.ref, 'refs/tags/v')
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        for ARTIFACT in "$ARTIFACT_DIR"/*.{zip,tar.gz,deb,rpm,nupkg}; do
-          if [[ -f $ARTIFACT ]]; then
-            echo "[INF] Uploading $ARTIFACT"
-            gh release upload "$GITHUB_REF_NAME" "$ARTIFACT"
-            echo "[INF] Artifact uploaded successfully! [$ARTIFACT]"
-          fi
-        done
-
-    # --- Update homebrew tap ---
-
-    - name: Update homebrew tap (liquidaty/homebrew-zsv)
-      if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.os == 'macos-13' }}
-      env:
-        HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
-        TAG: ${{ env.TAG }}
-        TRIPLET: ${{ env.AMD64_MACOSX_GCC }}
-      run: |
-        ./scripts/ci-update-homebrew-tap.sh
+      run: ./scripts/ci-upload-release-artifacts.sh
 
   ghcr:
     needs: [tag]

--- a/scripts/ci-run-cppcheck.sh
+++ b/scripts/ci-run-cppcheck.sh
@@ -73,7 +73,8 @@ if [ "$CI" = true ]; then
   CWE_LINK="[{cwe}](https://cwe.mitre.org/data/definitions/{cwe}.html)"
   TEMPLATE="| $SOURCE_LINK | {column} | {severity} | {id} | {message} | $CWE_LINK |"
   {
-    echo "# Cppcheck Static Analysis Summary"
+    echo "<details>"
+    echo "<summary>Cppcheck Static Analysis Summary</summary>"
     echo "| File:Line | Column | Severity |  ID   | Message |  CWE  |"
     echo "| :-------: | :----: | :------: | :---: | :-----: | :---: |"
     cppcheck \
@@ -82,6 +83,7 @@ if [ "$CI" = true ]; then
       --project="$CPPCHECK_PROJECT_FILE" \
       --template="$TEMPLATE" \
       2>&1
+    echo "</details>"
   } >>"$GITHUB_STEP_SUMMARY"
 fi
 

--- a/scripts/ci-run-cppcheck.sh
+++ b/scripts/ci-run-cppcheck.sh
@@ -75,6 +75,7 @@ if [ "$CI" = true ]; then
   {
     echo "<details>"
     echo "<summary>Cppcheck Static Analysis Summary</summary>"
+    echo
     echo "| File:Line | Column | Severity |  ID   | Message |  CWE  |"
     echo "| :-------: | :----: | :------: | :---: | :-----: | :---: |"
     cppcheck \

--- a/scripts/ci-set-tag-output-parameter.sh
+++ b/scripts/ci-set-tag-output-parameter.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+echo "[INF] Running $0"
+
+if [ "$TAG" = "" ]; then
+  echo "[INF] TAG env var is not set!"
+  echo "[INF] Setting TAG from the latest release..."
+  TAG="$(gh release list --repo liquidaty/zsv --limit 1 --json tagName --jq '.[].tagName')"
+  echo "[INF] TAG env var set from the latest release successfully! [$TAG]"
+else
+  echo "[INF] TAG env var is set! [$TAG]"
+fi
+
+TAG="$(echo "$TAG" | sed 's/^v//')"
+echo "[INF] TAG: $TAG"
+
+echo "TAG=$TAG" >>"$GITHUB_OUTPUT"
+
+echo "[INF] --- [DONE] ---"

--- a/scripts/ci-upload-release-artifacts.sh
+++ b/scripts/ci-upload-release-artifacts.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+echo "[INF] Running $0"
+
+if [ "$ARTIFACT_DIR" = "" ]; then
+  echo "[ERR] Set ARTIFACT_DIR before running $0 script."
+  exit 1
+fi
+
+for ARTIFACT in "$ARTIFACT_DIR"/*; do
+  if [ -f "$ARTIFACT" ]; then
+    echo "[INF] Uploading artifact... [$ARTIFACT]"
+    gh release upload "$GITHUB_REF_NAME" "$ARTIFACT"
+    echo "[INF] Artifact uploaded successfully! [$ARTIFACT]"
+  fi
+done
+
+echo "[INF] --- [DONE] ---"

--- a/scripts/ci-verify-attestations.sh
+++ b/scripts/ci-verify-attestations.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+echo "[INF] Running $0"
+
+if [ "$ARTIFACT_DIR" = "" ]; then
+  echo "[ERR] Set ARTIFACT_DIR before running $0 script."
+  exit 1
+fi
+
+for ARTIFACT in "$ARTIFACT_DIR"/*; do
+  echo "[INF] Verifying attestations... [$ARTIFACT]"
+  gh attestation verify "$ARTIFACT" --repo "liquidaty/zsv"
+  echo "[INF] Verified successfully! [$ARTIFACT]"
+done
+
+echo "[INF] --- [DONE] ---"


### PR DESCRIPTION
- Separate job for BSD build to run it in parallel
  - Should save ~2 minutes
- Move inline scrips to their respective files
- Make Cppcheck table output collapsible
- Attest release artifacts only
- Minor cleanup

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>