### PR TITLE
Add overwrite functionality to sheet

### DIFF
--- a/app/sheet.c
+++ b/app/sheet.c
@@ -17,7 +17,11 @@
 #include <zsv.h>
 
 #if defined(WIN32) || defined(_WIN32)
+#ifdef HAVE_NCURSESW
+#include <ncursesw/ncurses.h>
+#else
 #include <ncurses/ncurses.h>
+#endif // HAVE_NCURSESW
 #else
 #if __has_include(<curses.h>)
 #include <curses.h>
@@ -95,6 +99,19 @@ void get_subcommand(const char *prompt, char *buff, size_t buffsize, int footer_
     // Ignore other keys
   }
 }
+
+char zsvsheet_replace_cell(zsvsheet_buffer_t buffer, size_t row, size_t col, char *str) {
+  size_t str_s = strlen(str); 
+  if(str_s >= buffer->opts.cell_buff_len) {
+    // TO-DO: long-cell support
+    return 0;
+  }
+  size_t offset = buffer_data_offset(buffer, row, col);
+  memset(&buffer->data[offset], '\0', buffer->opts.cell_buff_len);
+  memcpy(&buffer->data[offset], str, strlen(str));
+  return 1;
+}
+
 
 size_t zsvsheet_get_input_raw_row(struct zsvsheet_rowcol *input_offset, struct zsvsheet_rowcol *buff_offset,
                                   size_t cursor_row) {
@@ -267,8 +284,10 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
   int ch;
   while ((zsvsheetch = zsvsheet_key_binding((ch = getch()))) != zsvsheet_key_quit) {
+
     zsvsheet_set_status(&display_dims, 1, "");
     int update_buffer = 0;
+
     switch (zsvsheetch) {
     case zsvsheet_key_resize:
       display_dims = get_display_dimensions(1, 1);
@@ -399,6 +418,15 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         continue;
       break;
     }
+    case zsvsheet_key_replace: { 
+      if(current_ui_buffer->cursor_col > 0) {
+        get_subcommand("Replace", cmdbuff, sizeof(cmdbuff), (int)(display_dims.rows - display_dims.footer_span));
+        if (*cmdbuff != '\0')
+          if(!zsvsheet_replace_cell(current_ui_buffer->buffer, current_ui_buffer->cursor_row, current_ui_buffer->cursor_col, cmdbuff))
+            zsvsheet_set_status(&display_dims, 1, "long-cells not supported ");
+      }
+    } 
+    break;
     default: {
       struct zsvsheet_key_handler_data *zkhd = zsvsheet_get_registered_key_handler(ch, NULL, zsvsheet_key_handlers);
       if (zkhd && zsvsheet_key_handler(zkhd, ch, cmdbuff, sizeof(cmdbuff), &ui_buffers, &current_ui_buffer,
@@ -421,6 +449,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   }
 
   endwin();
+
   free(find);
   zsvsheet_ui_buffers_delete(ui_buffers);
   zsvsheet_key_handlers_delete(&zsvsheet_key_handlers, &zsvsheet_next_key_handler);

--- a/app/sheet.c
+++ b/app/sheet.c
@@ -101,8 +101,8 @@ void get_subcommand(const char *prompt, char *buff, size_t buffsize, int footer_
 }
 
 char zsvsheet_replace_cell(zsvsheet_buffer_t buffer, size_t row, size_t col, char *str) {
-  size_t str_s = strlen(str); 
-  if(str_s >= buffer->opts.cell_buff_len) {
+  size_t str_s = strlen(str);
+  if (str_s >= buffer->opts.cell_buff_len) {
     // TO-DO: long-cell support
     return 0;
   }
@@ -111,7 +111,6 @@ char zsvsheet_replace_cell(zsvsheet_buffer_t buffer, size_t row, size_t col, cha
   memcpy(&buffer->data[offset], str, strlen(str));
   return 1;
 }
-
 
 size_t zsvsheet_get_input_raw_row(struct zsvsheet_rowcol *input_offset, struct zsvsheet_rowcol *buff_offset,
                                   size_t cursor_row) {
@@ -418,15 +417,15 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         continue;
       break;
     }
-    case zsvsheet_key_replace: { 
-      if(current_ui_buffer->cursor_col > 0) {
+    case zsvsheet_key_replace: {
+      if (current_ui_buffer->cursor_col > 0) {
         get_subcommand("Replace", cmdbuff, sizeof(cmdbuff), (int)(display_dims.rows - display_dims.footer_span));
         if (*cmdbuff != '\0')
-          if(!zsvsheet_replace_cell(current_ui_buffer->buffer, current_ui_buffer->cursor_row, current_ui_buffer->cursor_col, cmdbuff))
+          if (!zsvsheet_replace_cell(current_ui_buffer->buffer, current_ui_buffer->cursor_row,
+                                     current_ui_buffer->cursor_col, cmdbuff))
             zsvsheet_set_status(&display_dims, 1, "long-cells not supported ");
       }
-    } 
-    break;
+    } break;
     default: {
       struct zsvsheet_key_handler_data *zkhd = zsvsheet_get_registered_key_handler(ch, NULL, zsvsheet_key_handlers);
       if (zkhd && zsvsheet_key_handler(zkhd, ch, cmdbuff, sizeof(cmdbuff), &ui_buffers, &current_ui_buffer,

--- a/app/sheet/key-bindings.c
+++ b/app/sheet/key-bindings.c
@@ -26,6 +26,7 @@ static int zsvsheet_key_bindings[] = {
   zsvsheet_key_find, '/',
   zsvsheet_key_quit, 'q',
   zsvsheet_key_resize, KEY_RESIZE,
+  zsvsheet_key_replace, 'r',
   -1,
   -1
 };

--- a/app/sheet/key-bindings.h
+++ b/app/sheet/key-bindings.h
@@ -19,7 +19,8 @@ enum zsvsheet_key {
   zsvsheet_key_find,
   zsvsheet_key_find_next,
   zsvsheet_key_open_file,
-  zsvsheet_key_resize
+  zsvsheet_key_resize,
+  zsvsheet_key_replace
 };
 
 #endif


### PR DESCRIPTION
Additions:
Add `zsvsheet_replace_cell` function.
Add `zsvsheet_key_replace` keybind, currently bound to `r`.

Currently, if the replace key is pressed, it will prompt the user to input the new value of the cell (by calling the `get_subcommand` function). It will then replace the contents of the cell with the user-inputted contents. 

I have not implemented support for long-cells yet, so if the text is too long it will report that to the user using the `zsvsheet_set_status` function, and not replace the cell contents.

Attached is a video demo of the functionality.
https://github.com/user-attachments/assets/2714b0cd-78e4-4528-9840-98b853c652d3