### PR TITLE
Cleanup and modularize index

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -150,7 +150,7 @@ CFLAGS+= -I${PREFIX}/include
 THIS_LIB_BASE=$(shell cd .. && pwd)
 INCLUDE_DIR=${THIS_LIB_BASE}/include
 BUILD_DIR=${THIS_LIB_BASE}/build/${BUILD_SUBDIR}/${CCBN}
-UTILS1=writer file err signal mem clock arg dl string dirs prop cache jq os overwrite
+UTILS1=writer file err signal mem clock arg dl string dirs prop cache jq os overwrite index
 
 ZSV_EXTRAS ?=
 

--- a/app/sheet/index.c
+++ b/app/sheet/index.c
@@ -3,85 +3,51 @@
 #include <unistd.h>
 #include <zsv.h>
 #include <zsv/utils/prop.h>
+#include <zsv/utils/index.h>
+#include <zsv/utils/file.h>
+#include <zsv/utils/writer.h>
 
 #include "index.h"
-#include "zsv/utils/file.h"
-#include "zsv/utils/writer.h"
-
-static struct zsvsheet_index *add_line_end(struct zsvsheet_index *ix, uint64_t end) {
-  size_t len = ix->line_end_len, cap = ix->line_end_capacity;
-
-  if (len >= cap) {
-    cap *= 2;
-    ix = realloc(ix, sizeof(*ix) + cap * sizeof(ix->line_ends[0]));
-    if (!ix)
-      return NULL;
-
-    ix->line_end_capacity = cap;
-  }
-
-  ix->line_ends[len] = end;
-  ix->line_end_len++;
-
-  return ix;
-}
 
 static void build_memory_index_row_handler(void *ctx) {
   struct zsvsheet_indexer *ixr = ctx;
-  struct zsvsheet_index *ix = ixr->ix;
-  uint64_t line_end = zsv_cum_scanned_length(ixr->parser) + 1;
-  size_t col_count = zsv_cell_count(ixr->parser);
+  struct zsv_index *ix = ixr->ix;
+  zsv_parser parser = ixr->parser;
+  size_t col_count = zsv_cell_count(parser);
 
   if (ixr->filter) {
     if (col_count == 0)
       return;
 
     if (ixr->ix->header_line_end) {
-      struct zsv_cell first_cell = zsv_get_cell(ixr->parser, 0);
-      struct zsv_cell last_cell = zsv_get_cell(ixr->parser, col_count - 1);
+      struct zsv_cell first_cell = zsv_get_cell(parser, 0);
+      struct zsv_cell last_cell = zsv_get_cell(parser, col_count - 1);
 
       if (!memmem(first_cell.str, last_cell.str - first_cell.str + last_cell.len, ixr->filter, ixr->filter_len))
         return;
     }
 
     for (size_t i = 0; i < col_count; i++) {
-      struct zsv_cell cell = zsv_get_cell(ixr->parser, i);
+      struct zsv_cell cell = zsv_get_cell(parser, i);
       zsv_writer_cell(ixr->writer, i == 0, cell.str, cell.len, cell.quoted);
     }
   }
 
-  if (!ixr->ix->header_line_end) {
-    ix->header_line_end = line_end;
-  } else if ((ix->row_count & (LINE_END_N - 1)) == 0) {
-    if (ixr->filter) {
-      if (zsv_writer_flush(ixr->writer) != zsv_writer_status_ok) {
-        zsv_abort(ixr->parser);
-        return;
-      }
-      line_end = ftell(ixr->filter_stream);
-    }
-
-    ix = add_line_end(ix, line_end);
-    if (!ix) {
-      zsv_abort(ixr->parser);
-      return;
-    }
-
-    ixr->ix = ix;
-  }
-
-  ix->row_count++;
+  if (zsv_index_add_row(ix, parser) != zsv_index_status_ok)
+    zsv_abort(parser);
 }
 
-enum zsvsheet_index_status build_memory_index(struct zsvsheet_index_opts *optsp) {
+enum zsv_index_status build_memory_index(struct zsvsheet_index_opts *optsp) {
   struct zsvsheet_indexer ixr = {0};
   ixr.filter = optsp->row_filter;
   ixr.filter_len = optsp->row_filter ? strlen(optsp->row_filter) : 0;
 
-  enum zsvsheet_index_status ret = zsvsheet_index_status_error;
+  enum zsv_index_status ret = zsv_index_status_error;
   struct zsv_opts ix_zopts = optsp->zsv_opts;
+  unsigned char temp_buff[8196];
   char *temp_filename;
   FILE *temp_f = NULL;
+  zsv_csv_writer temp_file_writer = NULL;
   FILE *fp = fopen(optsp->filename, "rb");
   if (!fp)
     return ret;
@@ -96,8 +62,6 @@ enum zsvsheet_index_status build_memory_index(struct zsvsheet_index_opts *optsp)
     goto out;
 
   if (optsp->row_filter) {
-    zsv_csv_writer temp_file_writer = NULL;
-    unsigned char temp_buff[8196];
 
     temp_filename = zsv_get_temp_filename("zsvsheet_filter_XXXXXXXX");
     if (!temp_filename)
@@ -116,12 +80,9 @@ enum zsvsheet_index_status build_memory_index(struct zsvsheet_index_opts *optsp)
     ixr.filter_stream = temp_f;
   }
 
-  const size_t initial_cap = 256;
-  ixr.ix = malloc(sizeof(*ixr.ix) + initial_cap * sizeof(size_t));
+  ixr.ix = zsv_index_new();
   if (!ixr.ix)
     goto out;
-  memset(ixr.ix, 0, sizeof(*ixr.ix));
-  ixr.ix->line_end_capacity = initial_cap;
 
   while ((zst = zsv_parse_more(ixr.parser)) == zsv_status_ok)
     ;
@@ -129,7 +90,7 @@ enum zsvsheet_index_status build_memory_index(struct zsvsheet_index_opts *optsp)
   zsv_finish(ixr.parser);
 
   if (zst == zsv_status_no_more_input) {
-    ret = zsvsheet_index_status_ok;
+    ret = zsv_index_status_ok;
     *optsp->index = ixr.ix;
   } else
     free(ixr.ix);
@@ -137,20 +98,10 @@ enum zsvsheet_index_status build_memory_index(struct zsvsheet_index_opts *optsp)
 out:
   zsv_delete(ixr.parser);
   fclose(fp);
+  if (temp_file_writer)
+    zsv_writer_delete(temp_file_writer);
   if (temp_f)
     fclose(temp_f);
 
   return ret;
-}
-
-void get_memory_index(struct zsvsheet_index *ix, uint64_t row, off_t *offset_out, size_t *remaining_rows_out) {
-  if (!row || row - 1 < LINE_END_N) {
-    *offset_out = (off_t)ix->header_line_end;
-    *remaining_rows_out = row;
-    return;
-  }
-
-  const size_t i = (row - LINE_END_N) >> LINE_END_SHIFT;
-  *offset_out = (off_t)ix->line_ends[i];
-  *remaining_rows_out = row & (LINE_END_N - 1);
 }

--- a/app/sheet/index.h
+++ b/app/sheet/index.h
@@ -8,29 +8,9 @@
 #include "zsv.h"
 #include "zsv/utils/writer.h"
 
-// Decides the number of rows we skip when storing the line end
-// 1 << 10 = 1024 means that we store every 1024th line end
-#define LINE_END_SHIFT 10
-#define LINE_END_N (1 << LINE_END_SHIFT)
-
-enum zsvsheet_index_status {
-  zsvsheet_index_status_ok = 0,
-  zsvsheet_index_status_memory,
-  zsvsheet_index_status_error,
-  zsvsheet_index_status_utf8,
-};
-
-struct zsvsheet_index {
-  uint64_t header_line_end;
-  uint64_t row_count;
-  size_t line_end_capacity;
-  size_t line_end_len;
-  uint64_t line_ends[];
-};
-
 struct zsvsheet_indexer {
   zsv_parser parser;
-  struct zsvsheet_index *ix;
+  struct zsv_index *ix;
   const char *filter;
   size_t filter_len;
   zsv_csv_writer writer;
@@ -43,7 +23,7 @@ struct zsvsheet_index_opts {
   char **temp_filename;
   const char *row_filter;
   struct zsv_opts zsv_opts;
-  struct zsvsheet_index **index;
+  struct zsv_index **index;
   unsigned char *index_ready;
   struct zsvsheet_ui_buffer *uib;
   int *errp;
@@ -51,7 +31,6 @@ struct zsvsheet_index_opts {
   const char *opts_used;
 };
 
-enum zsvsheet_index_status build_memory_index(struct zsvsheet_index_opts *optsp);
-void get_memory_index(struct zsvsheet_index *ix, uint64_t row, off_t *offset_out, size_t *remaining_rows_out);
+enum zsv_index_status build_memory_index(struct zsvsheet_index_opts *optsp);
 
 #endif

--- a/app/sheet/ui_buffer.c
+++ b/app/sheet/ui_buffer.c
@@ -1,7 +1,6 @@
 #include <unistd.h> // unlink()
 #include <pthread.h>
-
-#include "index.h"
+#include <zsv/utils/index.h>
 
 struct zsvsheet_ui_buffer {
   char *filename;
@@ -13,7 +12,7 @@ struct zsvsheet_ui_buffer {
   size_t cursor_row;
   size_t cursor_col;
   struct zsvsheet_input_dimensions dimensions;
-  struct zsvsheet_index *index;
+  struct zsv_index *index;
   pthread_mutex_t mutex;
 
   // input_offset: location within the input from which the buffer is read

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -604,7 +604,7 @@ test-sheet-3: ${BUILD_DIR}/bin/zsv_sheet${EXE}
 	@(tmux new-session -x 80 -y 5 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
 	sleep 0.5 && \
 	tmux send-keys -t $@ "f" "sarmaj" Enter && \
-	sleep 0.5 && \
+	sleep 2 && \
 	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	tmux send-keys -t $@ "q" && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || ${TEST_FAIL})

--- a/app/utils/index.c
+++ b/app/utils/index.c
@@ -1,0 +1,154 @@
+#include <assert.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <zsv.h>
+#include <zsv/utils/prop.h>
+
+#include "zsv/utils/index.h"
+
+struct zsv_index *zsv_index_new(void) {
+  struct zsv_index *ix = malloc(sizeof(*ix));
+
+  if (!ix)
+    return ix;
+
+  memset(ix, 0, sizeof(*ix));
+
+  const size_t init_cap = 256;
+  ix->array = malloc(sizeof(*ix->array) + init_cap * sizeof(ix->array->u64s[0]));
+  ix->array->capacity = init_cap;
+  ix->array->len = 0;
+
+  return ix;
+}
+
+enum zsv_index_status zsv_index_add_row(struct zsv_index *ix, zsv_parser parser) {
+  struct zsv_index_array *arr = ix->array;
+  size_t len = arr->len, cap = arr->capacity;
+  uint64_t line_end = zsv_cum_scanned_length(parser) + 1;
+
+  if (!ix->header_line_end) {
+    ix->header_line_end = line_end;
+    return zsv_index_status_ok;
+  }
+
+  ix->row_count++;
+
+  if ((ix->row_count & (ZSV_INDEX_ROW_N - 1)) != 0)
+    return zsv_index_status_ok;
+
+  if (len >= cap) {
+    cap *= 2;
+    arr = realloc(arr, sizeof(*arr) + cap * sizeof(arr->u64s[0]));
+    if (!arr)
+      return zsv_index_status_memory;
+
+    arr->capacity = cap;
+    ix->array = arr;
+  }
+
+  arr->u64s[len] = line_end;
+  arr->len++;
+
+  return zsv_index_status_ok;
+}
+
+enum zsv_index_status zsv_index_row_end_offset(const struct zsv_index *ix, uint64_t row, uint64_t *offset_out,
+                                               uint64_t *remaining_rows_out) {
+  if (row > ix->row_count)
+    return zsv_index_status_error;
+
+  if (row < ZSV_INDEX_ROW_N) {
+    *offset_out = ix->header_line_end;
+    *remaining_rows_out = row;
+  } else {
+    const size_t i = (row >> ZSV_INDEX_ROW_SHIFT) - 1;
+
+    assert(i < ix->array->len);
+    *offset_out = (long)ix->array->u64s[i];
+    *remaining_rows_out = row & (ZSV_INDEX_ROW_N - 1);
+  }
+
+  return zsv_index_status_ok;
+}
+
+struct seek_row_ctx {
+  uint64_t remaining_rows;
+  zsv_parser parser;
+};
+
+static void seek_row_handler(void *ctx) {
+  struct seek_row_ctx *c = ctx;
+
+  c->remaining_rows--;
+  if (c->remaining_rows > 0)
+    return;
+
+  zsv_abort(c->parser);
+}
+
+static enum zsv_index_status seek_and_check_newline(long offset, struct zsv_opts *opts) {
+  char maybe_space;
+  zsv_generic_read read = (zsv_generic_read)fread;
+  zsv_generic_seek seek = (zsv_generic_seek)fseek;
+  FILE *stream = opts->stream;
+
+  if (opts->seek)
+    seek = opts->seek;
+
+  if (opts->read)
+    read = opts->read;
+
+  if (seek(stream, offset, SEEK_SET))
+    return zsv_index_status_error;
+
+  if (read(&maybe_space, 1, 1, stream) != 1)
+    return zsv_index_status_error;
+
+  if (!isspace(maybe_space)) {
+    if (seek(stream, offset, SEEK_SET))
+      return zsv_index_status_error;
+  }
+
+  return zsv_index_status_ok;
+}
+
+enum zsv_index_status zsv_index_seek_row(const struct zsv_index *ix, struct zsv_opts *opts, uint64_t row) {
+  uint64_t offset;
+  uint64_t remaining_rows;
+  enum zsv_index_status zist = zsv_index_row_end_offset(ix, row, &offset, &remaining_rows);
+
+  if (zist != zsv_index_status_ok)
+    return zist;
+
+  if ((zist = seek_and_check_newline(offset, opts)) != zsv_index_status_ok)
+    return zist;
+
+  if (!remaining_rows)
+    return zsv_index_status_ok;
+
+  struct seek_row_ctx ctx = {
+    .remaining_rows = remaining_rows,
+  };
+  struct zsv_opts o;
+  memcpy(&o, opts, sizeof(o));
+  o.ctx = &ctx;
+  o.row_handler = seek_row_handler;
+  zsv_parser parser = zsv_new(&o);
+  ctx.parser = parser;
+
+  enum zsv_status zst;
+  while ((zst = zsv_parse_more(parser)) == zsv_status_ok)
+    ;
+
+  if (zst != zsv_status_cancelled)
+    return zsv_index_status_error;
+
+  offset += zsv_cum_scanned_length(parser) + 1;
+
+  zsv_delete(parser);
+
+  return seek_and_check_newline(offset, opts);
+}

--- a/include/zsv/common.h
+++ b/include/zsv/common.h
@@ -73,6 +73,7 @@ struct zsv_cell {
 
 typedef size_t (*zsv_generic_write)(const void *restrict, size_t, size_t, void *restrict);
 typedef size_t (*zsv_generic_read)(void *restrict, size_t n, size_t size, void *restrict);
+typedef int (*zsv_generic_seek)(void *, long, int);
 
 #ifdef ZSV_EXTRAS
 /**
@@ -154,6 +155,12 @@ struct zsv_opts {
    * If not specified, the default value is `fread()`
    */
   zsv_generic_read read;
+
+  /**
+   * Caller can specify its own seek function for setting the file position
+   * with zsv_index_seek. If not specified, the default value is `fseek()`
+   */
+  zsv_generic_seek seek;
 
   /**
    * Caller can specify its own stream that is passed to the read function

--- a/include/zsv/utils/index.h
+++ b/include/zsv/utils/index.h
@@ -1,0 +1,45 @@
+#ifndef ZSV_UTILS_INDEX_H
+#define ZSV_UTILS_INDEX_H
+
+#include <stdint.h>
+#include <stdio.h>
+#include <pthread.h>
+
+#include "zsv/common.h"
+
+// Decides the number of rows we skip when storing the line end
+// 1 << 10 = 1024 means that we store every 1024th line end
+#define ZSV_INDEX_ROW_SHIFT 10
+#define ZSV_INDEX_ROW_N (1 << ZSV_INDEX_ROW_SHIFT)
+
+enum zsv_index_status {
+  zsv_index_status_ok = 0,
+  zsv_index_status_memory,
+  zsv_index_status_error,
+  zsv_index_status_utf8,
+};
+
+// An array of uint64_t. Needs to be reallocated to extend the capacity.
+// Reallocation can be avoided by adding new arrays instead.
+struct zsv_index_array {
+  size_t capacity;
+  size_t len;
+  uint64_t u64s[];
+};
+
+struct zsv_index {
+  uint64_t header_line_end;
+  uint64_t row_count;
+
+  // array containing the offsets of every ZSV_INDEX_ROW_N line end
+  struct zsv_index_array *array;
+};
+
+struct zsv_index *zsv_index_new(void);
+void zsv_index_delete(struct zsv_index *ix);
+enum zsv_index_status zsv_index_add_row(struct zsv_index *ix, zsv_parser parser);
+enum zsv_index_status zsv_index_row_end_offset(const struct zsv_index *ix, uint64_t row, uint64_t *offset_out,
+                                               uint64_t *remaining_rows_out);
+enum zsv_index_status zsv_index_seek_row(const struct zsv_index *ix, struct zsv_opts *opts, uint64_t row);
+
+#endif


### PR DESCRIPTION
Move the basic in-memory index functionality into utils and rework the API to make it easier to use. There is now a seek function which moves the file offset to the exact line-end requested by the user.

The temp file generation has not been moved into utils because generalising it started to introduced a lot more callbacks and other complications.

This also changes the sheet display code so that (building index) is displayed in the status area while indexing is in progress.