### PR TITLE
sheet: Override header span and skip rows when using properties file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
         PREFIX: ${{ env.ARM64_MACOSX_GCC }}
         CC: gcc-13
         MAKE: make
-        RUN_TESTS: false
+        RUN_TESTS: true
       run: ./scripts/ci-build.sh
 
     # --- Upload build artifacts ---

--- a/app/sheet/index.h
+++ b/app/sheet/index.h
@@ -15,6 +15,7 @@ struct zsvsheet_indexer {
   size_t filter_len;
   zsv_csv_writer writer;
   FILE *filter_stream;
+  char seen_header;
 };
 
 struct zsvsheet_index_opts {

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -579,7 +579,7 @@ test-compare: test-%: ${BUILD_DIR}/bin/zsv_%${EXE}
 
 test-sheet: test-%: ${BUILD_DIR}/bin/zsv_%${EXE} worldcitiespop_mil.csv test-sheet-all
 
-test-sheet-all: test-sheet-1 test-sheet-2 test-sheet-3 test-sheet-4 test-sheet-5 test-sheet-6 test-sheet-7
+test-sheet-all: test-sheet-1 test-sheet-2 test-sheet-3 test-sheet-4 test-sheet-5 test-sheet-6 test-sheet-7 test-sheet-8
 	@(for SESSION in $^; do ! tmux kill-session -t "$$SESSION" 2>/dev/null; done && ${TEST_PASS} || ${TEST_FAIL})
 
 test-sheet-1: ${BUILD_DIR}/bin/zsv_sheet${EXE}
@@ -649,3 +649,28 @@ test-sheet-7: ${BUILD_DIR}/bin/zsv_sheet${EXE}
 	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	tmux send-keys -t $@ "q" && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || ${TEST_FAIL})
+
+test-sheet-7: ${BUILD_DIR}/bin/zsv_sheet${EXE}
+	@${TEST_INIT}
+	@echo 'set-option default-terminal "tmux-256color"' > ~/.tmux.conf
+	@(tmux new-session -x 80 -y 5 -d -s $@ "${PREFIX} $< -d 3 ${TEST_DATA_DIR}/test/mixed-line-endings.csv" && \
+	sleep 0.5 && \
+	tmux send-keys -t $@ "G" "g" "g" "C-u" "/" "1234" "Enter" && \
+	sleep 0.5 && \
+	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
+	tmux send-keys -t $@ "q" && \
+	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || ${TEST_FAIL})
+
+test-sheet-8: ${BUILD_DIR}/bin/zsv_sheet${EXE}
+	@${TEST_INIT}
+	@echo 'set-option default-terminal "tmux-256color"' > ~/.tmux.conf
+	@(tmux new-session -x 160 -y 5 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
+	sleep 0.5 && \
+	tmux send-keys -t $@ "f" "e" "Enter" && \
+	sleep 0.5 && \
+	tmux send-keys -t $@ "G" "C-u" "k" && \
+	sleep 0.5 && \
+	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
+	tmux send-keys -t $@ "q" && \
+	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || ${TEST_FAIL})
+

--- a/app/test/expected/test-sheet-8.out
+++ b/app/test/expected/test-sheet-8.out
@@ -1,0 +1,5 @@
+Row #               Country             City                AccentCity          Region              Population          Latitude            Longitude
+493034              gb                  ruthven             Ruthven             V3                                      57.066667           -4.033333
+493035              gb                  rutlandshire        Rutlandshire        L4                                      52.666667           -.666667
+493036              gb                  rutupiae            Rutupiæ             G5                                      51.283333           1.333333
+(493039 filtered rows) 493035


### PR DESCRIPTION
The properties file was overriding opts.rows_to_ignore and
opts.header_span values that need to be set to zero when using an
index. This recreates the parser with zsv_new after the opts have
been rewritten when an index is active.
