### PR TITLE
Fix local wasm build issues on Ubuntu 22.04 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,13 @@
 *.log
 *.mk
 *.mk.log
+*.emcc
+*.emcc.log
+*.wasm
+*.worker.js
+package.json
+package-lock.json
+node_modules
 *.c.in
 *.h.in
 *.zip

--- a/app/Makefile
+++ b/app/Makefile
@@ -384,7 +384,7 @@ ${INIH_OBJECT}: ${INIH_SRC}/ini.c
 ${CLI_APP_OBJECT} : cli_ini.c builtin/*.c ${JQ_LIB}
 ${CLI_APP_OBJECT} ${CLI_OBJECTS}: ${CLI_OBJ_PFX}%.o: %.c ${UTF8PROC_SRC}/utf8proc.c # ${MORE_OBJECTS}
 	@mkdir -p `dirname "$@"`
-	${CC} ${CFLAGS} -DVERSION=\"${VERSION}\" -DZSV_CLI ${CLI_INCLUDE} -I${THIS_MAKEFILE_DIR}/external/sglib -I${INCLUDE_DIR} -c $< -o $@ ${MORE_SOURCE}
+	${CC} ${CFLAGS} -DVERSION=\"${VERSION}\" -DZSV_CLI ${CLI_INCLUDE} -I${THIS_MAKEFILE_DIR}/external/sglib -I${INCLUDE_DIR} -I${UTF8PROC_INCLUDE}-c $< -o $@ ${MORE_SOURCE}
 
 ${CLI}: cli_internal.c.in cli_internal.h cli_internal.h.in ${CLI_APP_OBJECT} ${CLI_OBJECTS} ${OBJECTS} ${UTF8PROC_OBJECT} cli_ini.c ${INIH_OBJECT} ${LIBZSV_INSTALL} ${MORE_OBJECTS}
 	@mkdir -p `dirname "$@"`

--- a/app/Makefile
+++ b/app/Makefile
@@ -457,7 +457,7 @@ ${STANDALONE_PFX}%${EXE}: %.c ${OBJECTS} ${MORE_OBJECTS} ${LIBZSV_INSTALL} ${UTF
 
 ${BUILD_DIR}-external/sqlite3/sqlite3_and_csv_vtab.o: ${BUILD_DIR}-external/%.o : external/%.c
 	@mkdir -p `dirname "$@"`
-	${CC} ${CFLAGS} -I${INCLUDE_DIR} -o $@ -c $<
+	${CC} ${CFLAGS} -I${INCLUDE_DIR} ${YAJL_INCLUDE} ${YAJL_HELPER_INCLUDE} -o $@ -c $<
 
 ${YAJL_OBJ}: ${BUILD_DIR}-external/yajl/%.o : external/yajl/src/%.c
 	@mkdir -p `dirname "$@"`

--- a/app/Makefile
+++ b/app/Makefile
@@ -384,7 +384,7 @@ ${INIH_OBJECT}: ${INIH_SRC}/ini.c
 ${CLI_APP_OBJECT} : cli_ini.c builtin/*.c ${JQ_LIB}
 ${CLI_APP_OBJECT} ${CLI_OBJECTS}: ${CLI_OBJ_PFX}%.o: %.c ${UTF8PROC_SRC}/utf8proc.c # ${MORE_OBJECTS}
 	@mkdir -p `dirname "$@"`
-	${CC} ${CFLAGS} -DVERSION=\"${VERSION}\" -DZSV_CLI ${CLI_INCLUDE} -I${THIS_MAKEFILE_DIR}/external/sglib -I${INCLUDE_DIR} -I${UTF8PROC_INCLUDE}-c $< -o $@ ${MORE_SOURCE}
+	${CC} ${CFLAGS} -DVERSION=\"${VERSION}\" -DZSV_CLI ${CLI_INCLUDE} -I${THIS_MAKEFILE_DIR}/external/sglib -I${INCLUDE_DIR} -I${UTF8PROC_INCLUDE} -c $< -o $@ ${MORE_SOURCE}
 
 ${CLI}: cli_internal.c.in cli_internal.h cli_internal.h.in ${CLI_APP_OBJECT} ${CLI_OBJECTS} ${OBJECTS} ${UTF8PROC_OBJECT} cli_ini.c ${INIH_OBJECT} ${LIBZSV_INSTALL} ${MORE_OBJECTS}
 	@mkdir -p `dirname "$@"`

--- a/app/Makefile
+++ b/app/Makefile
@@ -501,5 +501,5 @@ clean-internal:
 	$(RM) cli_internal.c.in cli_internal.h.in
 
 ${UTF8PROC_SRC}/utf8proc.c ${UTF8PROC_SRC}/utf8proc.h: ${THIS_MAKEFILE_DIR}/external/utf8proc-2.6.1.tar.gz
-	@cd external && tar xf $< && chown -R `whoami` utf8proc-2.6.1
+	@cd external && tar xf utf8proc-2.6.1.tar.gz && chown -R `whoami` utf8proc-2.6.1
 	@touch $@

--- a/app/select.c
+++ b/app/select.c
@@ -24,6 +24,7 @@
 #include <zsv/utils/utf8.h>
 #include <zsv/utils/string.h>
 #include <zsv/utils/mem.h>
+#include <zsv/utils/memmem.h>
 #include <zsv/utils/arg.h>
 
 struct zsv_select_search_str {

--- a/app/utils/signal.c
+++ b/app/utils/signal.c
@@ -26,7 +26,7 @@ static int consoleHandler(DWORD signal) {
   return 0;
 }
 
-void zsv_handle_ctrl_c_signal() {
+void zsv_handle_ctrl_c_signal(void) {
   if (!SetConsoleCtrlHandler(consoleHandler, 1))
     fprintf(stderr, "Warning: unable to set signal handler\n");
 }
@@ -44,7 +44,7 @@ static void INThandler(int sig) {
   }
 }
 
-void zsv_handle_ctrl_c_signal() {
+void zsv_handle_ctrl_c_signal(void) {
   // sigaction only ADDs the handler instead of REPLACING it
   // so we will use signal() instead
   signal(SIGINT, INThandler);

--- a/examples/js/Makefile
+++ b/examples/js/Makefile
@@ -25,7 +25,8 @@ ZSVSRC=$(addprefix ${ZSVSRCDIR}/,${ZSVSRC1})
 
 INCLUDE_DIR=${THIS_MAKEFILE_DIR}/../../include
 
-CFLAGS+= -I../../app/external/utf8proc-2.6.1 # for app/utils/string.c
+CFLAGS += -I../../app/external/utf8proc-2.6.1 # for app/utils/string.c
+CFLAGS += -I../../app/external/sqlite3
 
 ifeq ($(DEBUG),1)
   DBG_SUBDIR+=dbg
@@ -83,9 +84,12 @@ run: ${BROWSER_JS} ${STATIC}
 clean:
 	rm -rf build node
 
-prep: ../../app/external/utf8proc-2.6.1/utf8proc.h
+prep: utf8proc.h zsv.h
 
-../../app/external/utf8proc-2.6.1/utf8proc.h:
+zsv.h:
+	make -C ../../src ../include/zsv.h
+
+utf8proc.h:
 	make -C ../../app ./external/utf8proc-2.6.1/utf8proc.h THIS_MAKEFILE_DIR=.
 
 test: node_ok npm/test/select_all.js node

--- a/examples/js/README.md
+++ b/examples/js/README.md
@@ -1,4 +1,4 @@
-# ZSV in web assembly example
+# ZSV in WebAssembly example
 
 ## Overview
 
@@ -41,11 +41,11 @@ already installed
    save the config output to `config.emcc`:
 
    ```shell
-   emconfigure ./configure CONFIGFILE=config.emcc
+   CROSS_COMPILING=yes emconfigure ./configure CONFIGFILE=config.emcc
    ```
 
-2. Change back to this directory (examples/wasm), then run `emmake make run`.
-   You should see output messages ending with:
+2. Change back to this directory `examples/js`, then run `emmake make run`. You
+   should see output messages ending with:
 
    ```shell
    Listening on https://127.0.0.1:8888

--- a/examples/js/browser/zsv-browser-example.js
+++ b/examples/js/browser/zsv-browser-example.js
@@ -30,9 +30,9 @@ function rowHandler() {
 function finish() {
   zHandle.finish();
   zHandle.delete();
-  alert('Parsed ' + bytes_read + ' bytes; ' + rowcount + ' rows in '
-    + (performance.now() - start) + 'ms. '
-    + 'You can view the parsed data in your browser dev tools console (right-click and select Inspect)');
+  alert(
+    'Parsed ' + bytes_read + ' bytes (' + rowcount + ' rows) in ' + parseFloat(performance.now() - start).toFixed(2) + ' ms.\n' +
+    'View the parsed data in the browser\'s Developer Tools Console (right-click and select Inspect).');
   console.log('zsv parsed data', data);
   data = null;
 }

--- a/include/zsv/utils/signal.h
+++ b/include/zsv/utils/signal.h
@@ -13,6 +13,6 @@
 
 extern volatile sig_atomic_t zsv_signal_interrupted;
 
-void zsv_handle_ctrl_c_signal();
+void zsv_handle_ctrl_c_signal(void);
 
 #endif


### PR DESCRIPTION
- Fix some build issues encountered locally
- Fix README typo
- Update `alert` message format for better UX e.g. two decimal places for elapsed time in milliseconds, etc.
- Ignore generated files

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>