### PR TITLE
Fix benchmarks commands

### DIFF
--- a/scripts/ci-run-benchmarks.sh
+++ b/scripts/ci-run-benchmarks.sh
@@ -141,7 +141,7 @@ for TOOL in zsv xsv tsv; do
   elif [ "$TOOL" = "xsv" ]; then
     CMD="$TOOLS_DIR/xsv select 2,1,3-7"
   elif [ "$TOOL" = "tsv" ]; then
-    CMD="$TOOLS_DIR/tsv-select -d, -f 1-7"
+    CMD="$TOOLS_DIR/tsv-select -d, -f 2,1,3-7"
   fi
 
   I=0

--- a/scripts/ci-run-benchmarks.sh
+++ b/scripts/ci-run-benchmarks.sh
@@ -114,9 +114,9 @@ for TOOL in zsv xsv tsv; do
   if [ "$TOOL" = "zsv" ]; then
     CMD="$TOOLS_DIR/zsv count"
   elif [ "$TOOL" = "xsv" ]; then
-    CMD="$TOOLS_DIR/xsv count"
+    CMD="$TOOLS_DIR/xsv count --no-headers"
   elif [ "$TOOL" = "tsv" ]; then
-    CMD="$TOOLS_DIR/number-lines -d,"
+    CMD="$TOOLS_DIR/tsv-summarize --count -d,"
   fi
 
   I=0


### PR DESCRIPTION
- Fix command for `tsv-select`
  - The output was different for `tsv-select`.
  - Fixing the command fixed the output.
  - Now, the output is same for `zsv`, `xsv`, and `tsv-select`.
- For count tests, the equivalent command from `tsv-utils` seems to be [`tsv-summarize --count`](https://github.com/eBay/tsv-utils/blob/master/docs/tool_reference/tsv-summarize.md) instead of [`number-lines`](https://github.com/eBay/tsv-utils/blob/master/docs/tool_reference/number-lines.md).
  - Now, the output is similar for all three tools except that counting of header row.

Here's the output of the equivalent count commands:

```shell
$ zsv count < worldcitiespop_mil.csv 
1000000

$ xsv count --no-headers < worldcitiespop_mil.csv 
1000001

$ tsv-summarize --count -d, < worldcitiespop_mil.csv 
1000001
```

Currently, `zsv count` doesn't support a `--no-headers` flag hence the difference of 1.

---

With above changes, ran benchmarks locally using builds from this workflow run:
https://github.com/liquidaty/zsv/actions/runs/11752021827

Here are the results:

### `gcc`

```shell
$ ZSV_LINUX_BUILD_COMPILER=gcc ./scripts/ci-run-benchmarks.sh
[INF] Running ./scripts/ci-run-benchmarks.sh
[INF] OS: linux
[INF] RUNS: 6
[INF] SKIP_FIRST_RUN: true
[INF] BENCHMARKS_DIR: .benchmarks
[INF] ZSV_TAG: 0.3.9-alpha
[INF] ZSV_LINUX_BUILD_COMPILER: gcc
[INF] Downloading CSV file... [worldcitiespop_mil.csv] [SKIPPED]
[INF] Downloading... [zsv-0.3.9-alpha-amd64-linux-gcc.tar.gz] [SKIPPED]
[INF] Extracting... [zsv-0.3.9-alpha-amd64-linux-gcc.tar.gz] [DONE]
[INF] Downloading... [tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz] [SKIPPED]
[INF] Extracting... [tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz] [DONE]
[INF] Downloading... [xsv-0.13.0-x86_64-unknown-linux-musl.tar.gz] [SKIPPED]
[INF] Extracting... [xsv-0.13.0-x86_64-unknown-linux-musl.tar.gz] [DONE]
[INF] Running count benchmarks...
1 | zsv : real 0.04 user 0.03 sys 0.00
2 | zsv : real 0.03 user 0.03 sys 0.00
3 | zsv : real 0.03 user 0.02 sys 0.00
4 | zsv : real 0.03 user 0.03 sys 0.00
5 | zsv : real 0.03 user 0.03 sys 0.00
1 | xsv : real 0.08 user 0.07 sys 0.00
2 | xsv : real 0.08 user 0.07 sys 0.00
3 | xsv : real 0.08 user 0.07 sys 0.01
4 | xsv : real 0.08 user 0.06 sys 0.01
5 | xsv : real 0.08 user 0.07 sys 0.00
1 | tsv : real 0.02 user 0.01 sys 0.00
2 | tsv : real 0.02 user 0.01 sys 0.00
3 | tsv : real 0.02 user 0.02 sys 0.00
4 | tsv : real 0.02 user 0.01 sys 0.00
5 | tsv : real 0.02 user 0.01 sys 0.00
[INF] Running select benchmarks...
1 | zsv : real 0.09 user 0.08 sys 0.00
2 | zsv : real 0.09 user 0.08 sys 0.00
3 | zsv : real 0.09 user 0.09 sys 0.00
4 | zsv : real 0.09 user 0.09 sys 0.00
5 | zsv : real 0.09 user 0.09 sys 0.00
1 | xsv : real 0.36 user 0.36 sys 0.00
2 | xsv : real 0.36 user 0.35 sys 0.00
3 | xsv : real 0.36 user 0.35 sys 0.00
4 | xsv : real 0.36 user 0.35 sys 0.00
5 | xsv : real 0.36 user 0.36 sys 0.00
1 | tsv : real 0.11 user 0.10 sys 0.00
2 | tsv : real 0.11 user 0.10 sys 0.00
3 | tsv : real 0.11 user 0.09 sys 0.01
4 | tsv : real 0.11 user 0.10 sys 0.01
5 | tsv : real 0.11 user 0.10 sys 0.00
[INF] Generating Markdown output... [benchmarks.md]
[INF] Generated Markdown output successfully!
[INF] --- [DONE] ---
```

### `clang`

```shell
$ ZSV_LINUX_BUILD_COMPILER=clang ./scripts/ci-run-benchmarks.sh
[INF] Running ./scripts/ci-run-benchmarks.sh
[INF] OS: linux
[INF] RUNS: 6
[INF] SKIP_FIRST_RUN: true
[INF] BENCHMARKS_DIR: .benchmarks
[INF] ZSV_TAG: 0.3.9-alpha
[INF] ZSV_LINUX_BUILD_COMPILER: clang
[INF] Downloading CSV file... [worldcitiespop_mil.csv] [SKIPPED]
[INF] Downloading... [zsv-0.3.9-alpha-amd64-linux-clang.tar.gz] [SKIPPED]
[INF] Extracting... [zsv-0.3.9-alpha-amd64-linux-clang.tar.gz] [DONE]
[INF] Downloading... [tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz] [SKIPPED]
[INF] Extracting... [tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz] [DONE]
[INF] Downloading... [xsv-0.13.0-x86_64-unknown-linux-musl.tar.gz] [SKIPPED]
[INF] Extracting... [xsv-0.13.0-x86_64-unknown-linux-musl.tar.gz] [DONE]
[INF] Running count benchmarks...
1 | zsv : real 0.05 user 0.04 sys 0.00
2 | zsv : real 0.04 user 0.03 sys 0.00
3 | zsv : real 0.04 user 0.03 sys 0.00
4 | zsv : real 0.04 user 0.03 sys 0.00
5 | zsv : real 0.04 user 0.04 sys 0.00
1 | xsv : real 0.08 user 0.07 sys 0.00
2 | xsv : real 0.08 user 0.07 sys 0.01
3 | xsv : real 0.08 user 0.07 sys 0.00
4 | xsv : real 0.08 user 0.08 sys 0.00
5 | xsv : real 0.08 user 0.07 sys 0.00
1 | tsv : real 0.02 user 0.02 sys 0.00
2 | tsv : real 0.02 user 0.01 sys 0.01
3 | tsv : real 0.02 user 0.02 sys 0.00
4 | tsv : real 0.02 user 0.02 sys 0.00
5 | tsv : real 0.02 user 0.01 sys 0.00
[INF] Running select benchmarks...
1 | zsv : real 0.09 user 0.08 sys 0.00
2 | zsv : real 0.10 user 0.09 sys 0.00
3 | zsv : real 0.09 user 0.09 sys 0.00
4 | zsv : real 0.10 user 0.09 sys 0.00
5 | zsv : real 0.09 user 0.08 sys 0.00
1 | xsv : real 0.36 user 0.35 sys 0.01
2 | xsv : real 0.37 user 0.36 sys 0.00
3 | xsv : real 0.36 user 0.34 sys 0.01
4 | xsv : real 0.36 user 0.35 sys 0.00
5 | xsv : real 0.36 user 0.35 sys 0.00
1 | tsv : real 0.11 user 0.10 sys 0.00
2 | tsv : real 0.11 user 0.11 sys 0.00
3 | tsv : real 0.10 user 0.10 sys 0.00
4 | tsv : real 0.11 user 0.10 sys 0.00
5 | tsv : real 0.11 user 0.11 sys 0.00
[INF] Generating Markdown output... [benchmarks.md]
[INF] Generated Markdown output successfully!
[INF] --- [DONE] ---
```

### `musl`

```shell
$ ZSV_LINUX_BUILD_COMPILER=musl ./scripts/ci-run-benchmarks.sh
[INF] Running ./scripts/ci-run-benchmarks.sh
[INF] OS: linux
[INF] RUNS: 6
[INF] SKIP_FIRST_RUN: true
[INF] BENCHMARKS_DIR: .benchmarks
[INF] ZSV_TAG: 0.3.9-alpha
[INF] ZSV_LINUX_BUILD_COMPILER: musl
[INF] Downloading CSV file... [worldcitiespop_mil.csv] [SKIPPED]
[INF] Downloading... [zsv-0.3.9-alpha-amd64-linux-musl.tar.gz] [SKIPPED]
[INF] Extracting... [zsv-0.3.9-alpha-amd64-linux-musl.tar.gz] [DONE]
[INF] Downloading... [tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz] [SKIPPED]
[INF] Extracting... [tsv-utils-v2.2.0_linux-x86_64_ldc2.tar.gz] [DONE]
[INF] Downloading... [xsv-0.13.0-x86_64-unknown-linux-musl.tar.gz] [SKIPPED]
[INF] Extracting... [xsv-0.13.0-x86_64-unknown-linux-musl.tar.gz] [DONE]
[INF] Running count benchmarks...
1 | zsv : real 0.03 user 0.03 sys 0.00
2 | zsv : real 0.03 user 0.03 sys 0.00
3 | zsv : real 0.03 user 0.03 sys 0.00
4 | zsv : real 0.03 user 0.03 sys 0.00
5 | zsv : real 0.03 user 0.02 sys 0.00
1 | xsv : real 0.08 user 0.07 sys 0.00
2 | xsv : real 0.08 user 0.08 sys 0.00
3 | xsv : real 0.08 user 0.07 sys 0.00
4 | xsv : real 0.08 user 0.07 sys 0.00
5 | xsv : real 0.08 user 0.08 sys 0.00
1 | tsv : real 0.02 user 0.01 sys 0.01
2 | tsv : real 0.02 user 0.01 sys 0.00
3 | tsv : real 0.02 user 0.01 sys 0.00
4 | tsv : real 0.02 user 0.02 sys 0.00
5 | tsv : real 0.02 user 0.02 sys 0.00
[INF] Running select benchmarks...
1 | zsv : real 0.25 user 0.24 sys 0.00
2 | zsv : real 0.26 user 0.25 sys 0.00
3 | zsv : real 0.26 user 0.26 sys 0.00
4 | zsv : real 0.25 user 0.24 sys 0.00
5 | zsv : real 0.25 user 0.25 sys 0.00
1 | xsv : real 0.36 user 0.35 sys 0.01
2 | xsv : real 0.36 user 0.35 sys 0.01
3 | xsv : real 0.36 user 0.36 sys 0.00
4 | xsv : real 0.36 user 0.36 sys 0.00
5 | xsv : real 0.36 user 0.34 sys 0.01
1 | tsv : real 0.11 user 0.10 sys 0.00
2 | tsv : real 0.11 user 0.10 sys 0.00
3 | tsv : real 0.11 user 0.11 sys 0.00
4 | tsv : real 0.10 user 0.10 sys 0.00
5 | tsv : real 0.11 user 0.10 sys 0.00
[INF] Generating Markdown output... [benchmarks.md]
[INF] Generated Markdown output successfully!
[INF] --- [DONE] ---
```

---

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>