### PR TITLE
Add help buffer

### DIFF
--- a/app/sheet.c
+++ b/app/sheet.c
@@ -681,6 +681,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   noecho();
   keypad(stdscr, TRUE);
   cbreak();
+  set_escdelay(30);
   struct zsvsheet_display_dimensions display_dims = get_display_dimensions(1, 1);
   display_buffer_subtable(current_ui_buffer, header_span, &display_dims);
 

--- a/app/sheet/key-bindings.h
+++ b/app/sheet/key-bindings.h
@@ -20,7 +20,8 @@ enum zsvsheet_key {
   zsvsheet_key_find,
   zsvsheet_key_find_next,
   zsvsheet_key_open_file,
-  zsvsheet_key_resize
+  zsvsheet_key_resize,
+  zsvsheet_key_question,
 };
 
 struct zsvsheet_key_binding_context;
@@ -32,6 +33,8 @@ typedef zsvsheet_status (*zsvsheet_key_binding_fn)(struct zsvsheet_key_binding_c
  * be implemented if need be by defining a custom handler */
 struct zsvsheet_key_binding {
   int ch;
+  const char *ch_name;
+  char hidden;
   zsvsheet_key_binding_fn handler;
   zsvsheet_proc_id_t proc_id;
 };
@@ -51,6 +54,7 @@ int zsvsheet_register_key_binding(struct zsvsheet_key_binding *binding);
 
 zsvsheet_status zsvsheet_key_press(int ch, void *subcommand_context);
 
+struct zsvsheet_key_binding *zsvsheet_get_key_binding(size_t i);
 struct zsvsheet_key_binding *zsvsheet_find_key_binding(int ch);
 
 /*
@@ -60,5 +64,7 @@ struct zsvsheet_key_binding *zsvsheet_find_key_binding(int ch);
 void zsvsheet_register_vim_key_bindings(void);
 
 void zsvsheet_register_emacs_key_bindings(void);
+
+const char *zsvsheet_key_binding_ch_name(struct zsvsheet_key_binding *binding);
 
 #endif

--- a/app/sheet/procedure.c
+++ b/app/sheet/procedure.c
@@ -15,6 +15,7 @@
 struct zsvsheet_procedure {
   zsvsheet_proc_id_t id;
   const char *name;
+  const char *description;
   zsvsheet_proc_fn handler;
 };
 
@@ -75,12 +76,14 @@ static zsvsheet_proc_id_t zsvsheet_do_register_proc(struct zsvsheet_procedure *p
   return proc->id;
 }
 
-zsvsheet_proc_id_t zsvsheet_register_builtin_proc(zsvsheet_proc_id_t id, const char *name, zsvsheet_proc_fn handler) {
-  struct zsvsheet_procedure procedure = {.id = id, .name = name, .handler = handler};
+zsvsheet_proc_id_t zsvsheet_register_builtin_proc(zsvsheet_proc_id_t id, const char *name, const char *description,
+                                                  zsvsheet_proc_fn handler) {
+  struct zsvsheet_procedure procedure = {.id = id, .name = name, .description = description, .handler = handler};
   return zsvsheet_do_register_proc(&procedure);
 }
 
-zsvsheet_proc_id_t zsvsheet_register_proc(const char *name, zsvsheet_proc_fn handler) {
-  struct zsvsheet_procedure procedure = {.id = zsvsheet_generate_proc_id(), .name = name, .handler = handler};
+zsvsheet_proc_id_t zsvsheet_register_proc(const char *name, const char *description, zsvsheet_proc_fn handler) {
+  struct zsvsheet_procedure procedure = {
+    .id = zsvsheet_generate_proc_id(), .name = name, .description = description, .handler = handler};
   return zsvsheet_do_register_proc(&procedure);
 }

--- a/app/sheet/procedure.h
+++ b/app/sheet/procedure.h
@@ -30,6 +30,8 @@ enum {
   zsvsheet_builtin_proc_open_file,
   zsvsheet_builtin_proc_resize,
   zsvsheet_builtin_proc_prompt,
+  zsvsheet_builtin_proc_help,
+  zsvsheet_builtin_proc_vim_g_key_binding_dmux,
 };
 
 #define ZSVSHEET_PROC_INVALID 0
@@ -73,9 +75,10 @@ zsvsheet_status zsvsheet_proc_invoke_from_keypress(zsvsheet_proc_id_t proc_id, i
 zsvsheet_status zsvsheet_proc_invoke(zsvsheet_proc_id_t proc_id, struct zsvsheet_proc_context *ctx);
 
 /* Register builtin procedure with fixed id */
-zsvsheet_proc_id_t zsvsheet_register_builtin_proc(zsvsheet_proc_id_t id, const char *name, zsvsheet_proc_fn handler);
+zsvsheet_proc_id_t zsvsheet_register_builtin_proc(zsvsheet_proc_id_t id, const char *name, const char *description,
+                                                  zsvsheet_proc_fn handler);
 
 /* Dynamically register a procedure, returns a positive id or negative error */
-zsvsheet_proc_id_t zsvsheet_register_proc(const char *name, zsvsheet_proc_fn handler);
+zsvsheet_proc_id_t zsvsheet_register_proc(const char *name, const char *description, zsvsheet_proc_fn handler);
 
 #endif /* ZSVSHEET_PROCEDURE_H */

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -63,9 +63,9 @@ COLOR_RED=\033[1;31m
 COLOR_BLUE=\033[1;34m
 COLOR_PINK=\033[1;35m
 
-TEST_PASS=echo "${COLOR_BLUE}$@: ${COLOR_GREEN}Passed${COLOR_NONE}"
-TEST_FAIL=(echo "${COLOR_BLUE}$@: ${COLOR_RED}Failed!${COLOR_NONE}" && exit 1)
-TEST_INIT=mkdir -p ${TMP_DIR} && echo "${COLOR_PINK}$@: ${COLOR_NONE}"
+TEST_PASS=echo -e "${COLOR_BLUE}$@: ${COLOR_GREEN}Passed${COLOR_NONE}"
+TEST_FAIL=(echo -e "${COLOR_BLUE}$@: ${COLOR_RED}Failed!${COLOR_NONE}" && exit 1)
+TEST_INIT=mkdir -p ${TMP_DIR} && echo -e "${COLOR_PINK}$@: ${COLOR_NONE}"
 
 ARGS-sql='select [Loan Number] from data'
 

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -587,7 +587,7 @@ test-sheet: test-%: ${BUILD_DIR}/bin/zsv_%${EXE} worldcitiespop_mil.csv test-she
 test-sheet-cleanup:
 	@rm -f tmux-*.log
 
-test-sheet-all: test-sheet-1 test-sheet-2 test-sheet-3 test-sheet-4 test-sheet-5 test-sheet-6 test-sheet-7 test-sheet-8 test-sheet-9 test-sheet-10 test-sheet-11 test-sheet-12
+test-sheet-all: test-sheet-1 test-sheet-2 test-sheet-3 test-sheet-4 test-sheet-5 test-sheet-6 test-sheet-7 test-sheet-8 test-sheet-9 test-sheet-10 test-sheet-11 test-sheet-12 test-sheet-13 test-sheet-14
 	@(for SESSION in $^; do ! tmux kill-session -t "$$SESSION" 2>/dev/null; done && ${TEST_PASS} || ${TEST_FAIL})
 
 TMUX_TERM=xterm-256color
@@ -719,6 +719,30 @@ test-sheet-12: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv
 	tmux send-keys -t $@ "f" "el" "Enter" && \
 	sleep 0.5 && \
 	tmux send-keys -t $@ "f" "al" "Enter" && \
+	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
+	tmux send-keys -t $@ "q" && \
+	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || (echo 'Incorrect output:' && cat ${TMP_DIR}/$@.out && ${TEST_FAIL}))
+
+test-sheet-13: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv
+	@${TEST_INIT}
+	@echo 'set-option default-terminal "${TMUX_TERM}"' > ~/.tmux.conf
+	@(tmux new-session -x 80 -y 25 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
+	sleep 0.5 && \
+	tmux send-keys -t $@ "?" "/" "f" && \
+	sleep 0.5 && \
+	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
+	tmux send-keys -t $@ "q" && \
+	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || (echo 'Incorrect output:' && cat ${TMP_DIR}/$@.out && ${TEST_FAIL}))
+
+test-sheet-14: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv
+	@${TEST_INIT}
+	@echo 'set-option default-terminal "${TMUX_TERM}"' > ~/.tmux.conf
+	@(tmux new-session -x 80 -y 25 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
+	sleep 0.5 && \
+	tmux send-keys -t $@ "?" && \
+	sleep 0.5 && \
+	tmux send-keys -t $@ "Escape" && \
+	sleep 1 && \
 	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	tmux send-keys -t $@ "q" && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || (echo 'Incorrect output:' && cat ${TMP_DIR}/$@.out && ${TEST_FAIL}))

--- a/app/test/expected/test-sheet-13.out
+++ b/app/test/expected/test-sheet-13.out
@@ -1,0 +1,25 @@
+Key(s)                    Action                    Description
+q                         quit                      Exit the application
+<esc>                     escape                    Leave the current view or
+^                         first                     Jump to the first column
+$                         last                      Jump to the last column
+<shift><left>             first                     Jump to the first column
+<shift><right>            last                      Jump to the last column
+k                         up                        Move up one row
+j                         down                      Move down one row
+h                         left                      Move left one column
+l                         right                     Move right one column
+<up>                      up                        Move up one row
+<down>                    down                      Move down one row
+<left>                    left                      Move left one column
+<right>                   right                     Move right one column
+<ctrl>d                   pagedown                  Move down one page
+<ctrl>u                   pageup                    Move up one page
+<page up>                 pagedown                  Move down one page
+<page down>               pageup                    Move up one page
+g g                       top                       Jump to the first row
+G                         bottom                    Jump to the last row
+/                         find                      Set a search term and jum
+n                         next                      Jump to the next search r
+e                         open                      Open a another CSV file
+<esc> to exit help Key(s)

--- a/app/test/expected/test-sheet-14.out
+++ b/app/test/expected/test-sheet-14.out
@@ -1,0 +1,25 @@
+Row #     Country   City      AccentCit Region    Populatio Latitude  Longitude
+1         ir        sarmaj-e  Sarmaj-e  13                  34.3578   47.5207
+2         ad        aixirival Aixirival 06                  42.466666 1.5
+3         mm        mokho-atw Mokho-atw 09                  18.033333 96.75
+4         id        selingon  Selingon  17                  -8.8374   116.4914
+5         ir        berimvand Berimvand 13                  34.2953   47.1096
+6         pl        chomiaza  Chomiaza  73                  52.7508   17.841793
+7         mg        itona     Itona     02                  -23.86666 47.216666
+8         ad        andorra-v Andorra-V 07                  42.5      1.5166667
+9         mx        la tortug La Tortug 25                  25.75     -108.3333
+10        us        asaph     Asaph     PA                  41.770833 -77.40527
+11        ad        andorre-v Andorre-V 07                  42.5      1.5166667
+12        ru        dolmatova Dolmatova 71                  57.436791 63.279522
+13        ro        escu      Escu      13                  47.133333 23.533333
+14        us        la presa  La Presa  CA        35119     32.708055 -116.9963
+15        pk        makam khu Makam Khu 04                  33.650863 72.551536
+16        ad        aubinya   Aubinyà   06                  42.45     1.5
+17        mm        kiosong   Kiosöng   11                  22.583333 97.05
+18        tr        donencay  Dönençay  28                  40.266667 38.583333
+19        it        roncaglia Roncaglia 05                  45.05     9.8
+20        ml        kourmouss Kourmouss 04                  14.75     -5.033333
+21        id        lamogo    Lamogo    38                  -4.3945   119.9028
+22        ad        casas vil Casas Vil 03                  42.533333 1.5666667
+23        ru        otdeleniy Otdeleniy 86                  51.726473 39.714345
+? for help 1


### PR DESCRIPTION
This adds a help buffer activated by pressing '?'

The initial version is slightly different from planned because it uses 3 columns instead of 1 to help with layout.

TODO:
- [ ] ~~Add a type to the UI buffer that the event handlers can read and make sure invalid handlers do not run on help~~
- [x] Describe all of the keys (perhaps add the help text to an event handlers table or the key bindings table)
- [x] Add tests
- [x] Update the status when in help to "Press <esc> to close help"
