### PR TITLE
Wasm updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ data/loans_2.csv
 data/.zsv/data/loans_2.csv/overwrite.sqlite3
 compile_commands.json
 .cache
+zsvsheet_filter_*
+overwrite.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ cppcheck*
 tmp
 include/zsv.h
 app/test/worldcitiespop_mil.csv
+app/test/worldcitiespop_mil.tsv
 data/quoted5.csv
 data/loans_2.csv
 data/.zsv/data/loans_2.csv/overwrite.sqlite3

--- a/app/2db.c
+++ b/app/2db.c
@@ -640,6 +640,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
                                struct zsv_prop_handler *custom_prop_handler, const char *opts_used) {
   (void)(zsv_opts);
   (void)(opts_used);
+  (void)(custom_prop_handler);
   FILE *f_in = NULL;
   int err = 0;
   struct zsv_2db_options opts = {0};
@@ -678,7 +679,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
 
   for (int i = 1; !err && i < argc; i++) {
     if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
-      for (int j = 0; usage[j]; j++)
+      for (size_t j = 0; usage[j]; j++)
         fprintf(stdout, "%s\n", usage[j]);
       goto exit_2db;
     } else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {

--- a/app/Makefile
+++ b/app/Makefile
@@ -97,12 +97,12 @@ ifeq ($(WIN),0)
 
   ifneq ($(findstring emcc,$(CC)),) # emcc
     NO_THREADING ?= 1
-    EXE=.em.js
+    EXE=.em.html
     EXPORTED_FUNCTIONS='_free','_malloc'
-    LDFLAGS += -s EXPORTED_FUNCTIONS="[${EXPORTED_FUNCTIONS}]" -s EXPORTED_RUNTIME_METHODS="['setValue','allocateUTF8','stringToUTF8Array','lengthBytesUTF8','writeArrayToMemory']" -s RESERVED_FUNCTION_POINTERS=4 -s ALLOW_MEMORY_GROWTH=1
-    CFLAGS_EXE += -s FORCE_FILESYSTEM=1 -lidbfs.js -s MAIN_MODULE
+    LDFLAGS += -sEXPORTED_FUNCTIONS="[${EXPORTED_FUNCTIONS}]" -sEXPORTED_RUNTIME_METHODS="['setValue','allocateUTF8','stringToUTF8Array','lengthBytesUTF8','writeArrayToMemory','FS','callMain']" -sRESERVED_FUNCTION_POINTERS=4 -sALLOW_MEMORY_GROWTH=1
+    CFLAGS_EXE += -sINVOKE_RUN=0 -sFORCE_FILESYSTEM=1 -lidbfs.js -sMAIN_MODULE
     ifeq ($(NO_THREADING),0)
-      CFLAGS_EXE += -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=2 -s PTHREAD_POOL_SIZE=8
+      CFLAGS_EXE += -sUSE_PTHREADS=1 -sPTHREAD_POOL_SIZE=2 -sPTHREAD_POOL_SIZE=8
     endif
   endif
 else
@@ -124,7 +124,7 @@ CFLAGS+=-Wunused
 CFLAGS_O ?=
 ifeq ($(CFLAGS_O),)
   ifeq ($(DEBUG),0)
-    CFLAGS_O=-O3
+    CFLAGS_O=-O0
   else
     CFLAGS_O=-O0
   endif
@@ -223,7 +223,7 @@ CLI_OBJ_PFX=${BUILD_DIR}/objs/cli_
 CLI_APP_OBJECT=${CLI_OBJ_PFX}cli.o
 CLI=${BUILD_DIR}/bin/cli${EXE}
 ifneq ($(findstring emcc,$(CC)),) # emcc
-    CLI_ADDITIONAL=${BUILD_DIR}/bin/cli.em.wasm
+  CLI_ADDITIONAL=${BUILD_DIR}/bin/cli.em.wasm
 endif
 CLI_OBJECTS=$(addprefix ${CLI_OBJ_PFX},$(addsuffix .o,${CLI_SOURCES}))
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -461,7 +461,7 @@ ${BUILD_DIR}-external/sqlite3/sqlite3_and_csv_vtab.o: ${BUILD_DIR}-external/%.o 
 
 ${YAJL_OBJ}: ${BUILD_DIR}-external/yajl/%.o : external/yajl/src/%.c
 	@mkdir -p `dirname "$@"`
-	${CC} ${CFLAGS} ${YAJL_INCLUDE} -c external/yajl/src/$*.c -o $@
+	${CC} ${CFLAGS} -w ${YAJL_INCLUDE} -c external/yajl/src/$*.c -o $@
 
 ${YAJL_HELPER_OBJ}: external/yajl_helper/yajl_helper.c
 	@mkdir -p `dirname "$@"`

--- a/app/Makefile
+++ b/app/Makefile
@@ -99,10 +99,10 @@ ifeq ($(WIN),0)
     NO_THREADING ?= 1
     EXE=.em.js
     EXPORTED_FUNCTIONS='_free','_malloc'
-    CFLAGS+= -s EXPORTED_FUNCTIONS="[${EXPORTED_FUNCTIONS}]" -s EXPORTED_RUNTIME_METHODS="['setValue','allocateUTF8','stringToUTF8Array','lengthBytesUTF8','writeArrayToMemory']" -s RESERVED_FUNCTION_POINTERS=4 -s ALLOW_MEMORY_GROWTH=1
-    CFLAGS_EXE+= -s FORCE_FILESYSTEM=1 -lidbfs.js -s MAIN_MODULE
+    LDFLAGS += -s EXPORTED_FUNCTIONS="[${EXPORTED_FUNCTIONS}]" -s EXPORTED_RUNTIME_METHODS="['setValue','allocateUTF8','stringToUTF8Array','lengthBytesUTF8','writeArrayToMemory']" -s RESERVED_FUNCTION_POINTERS=4 -s ALLOW_MEMORY_GROWTH=1
+    CFLAGS_EXE += -s FORCE_FILESYSTEM=1 -lidbfs.js -s MAIN_MODULE
     ifeq ($(NO_THREADING),0)
-      CFLAGS_EXE+= -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=2 -s PTHREAD_POOL_SIZE=8
+      CFLAGS_EXE += -s USE_PTHREADS=1 -s PTHREAD_POOL_SIZE=2 -s PTHREAD_POOL_SIZE=8
     endif
   endif
 else
@@ -418,7 +418,7 @@ ${JQ_BUNDLE_LIB}: ${JQ_SRC} # -D_REENTRANT needed for clang to not break
 	# copy the directory because its timestamp gets updated after libjq is built
 	@cp -a ${JQ_SRC} ${JQ_SRC}-conf
 	cd ${JQ_SRC}-conf \
-	&& CC="${CC}" CFLAGS="${CFLAGS} -D_REENTRANT" ./configure \
+	&& CC="${CC}" CFLAGS="${CFLAGS} -w -D_REENTRANT" ./configure \
 	    --prefix="${JQ_PREFIX}" \
 	    --disable-maintainer-mode \
 	    --without-oniguruma \
@@ -457,7 +457,7 @@ ${STANDALONE_PFX}%${EXE}: %.c ${OBJECTS} ${MORE_OBJECTS} ${LIBZSV_INSTALL} ${UTF
 
 ${BUILD_DIR}-external/sqlite3/sqlite3_and_csv_vtab.o: ${BUILD_DIR}-external/%.o : external/%.c
 	@mkdir -p `dirname "$@"`
-	${CC} ${CFLAGS} -I${INCLUDE_DIR} ${YAJL_INCLUDE} ${YAJL_HELPER_INCLUDE} -o $@ -c $<
+	${CC} ${CFLAGS} -w -I${INCLUDE_DIR} ${YAJL_INCLUDE} ${YAJL_HELPER_INCLUDE} -o $@ -c $<
 
 ${YAJL_OBJ}: ${BUILD_DIR}-external/yajl/%.o : external/yajl/src/%.c
 	@mkdir -p `dirname "$@"`

--- a/app/builtin/help.c
+++ b/app/builtin/help.c
@@ -29,9 +29,11 @@ static int main_help(int argc, const char *argv[]) {
 #endif
     "  zsv help [<command>]",
     "  zsv <command> <options> <arguments>  : run a command on data (see below for details)",
+#ifndef __EMSCRIPTEN__
     "  zsv <id>-<cmd> <options> <arguments> : invoke command 'cmd' of extension 'id'",
-    "  zsv thirdparty                       : view third-party licenses & acknowledgements",
     "  zsv license [<extension_id>]",
+#endif
+    "  zsv thirdparty                       : view third-party licenses & acknowledgements",
     "",
     "Options common to all commands except `prop`, `rm` and `jq`:",
 #ifdef ZSV_EXTRAS
@@ -83,6 +85,7 @@ static int main_help(int argc, const char *argv[]) {
   for (size_t i = 0; usage[i]; i++)
     fprintf(f, "%s\n", usage[i]);
 
+#ifndef __EMSCRIPTEN__
   char printed_init = 0;
   struct cli_config config;
   if (!config_init(&config, 1, 1, 0)) {
@@ -103,6 +106,6 @@ static int main_help(int argc, const char *argv[]) {
   }
   if (!printed_init)
     fprintf(f, "\n(No extended commands)\n");
-
+#endif
   return 0;
 }

--- a/app/builtin/thirdparty.c
+++ b/app/builtin/thirdparty.c
@@ -23,6 +23,7 @@ static int main_thirdparty(int argc, const char *argv[]) {
   printf("Third-party licenses and acknowledgements");
   print_str_array("ZSV/lib third-party dependencies", "", zsv_thirdparty);
 
+#ifndef __EMSCRIPTEN__
   struct cli_config config;
   const char *ss[2];
   ss[1] = NULL;
@@ -34,6 +35,7 @@ static int main_thirdparty(int argc, const char *argv[]) {
       }
     }
   }
+#endif
   printf("\n");
   return 0;
 }

--- a/app/cli.c
+++ b/app/cli.c
@@ -105,13 +105,14 @@ ZSV_MAINEXT_FUNC_DEFINE(sheet);
 #endif
 
 struct builtin_cmd builtin_cmds[] = {
+  CLI_BUILTIN_CMD(version),
+  CLI_BUILTIN_CMD(help),
   CLI_BUILTIN_CMD(license),
   CLI_BUILTIN_CMD(thirdparty),
-  CLI_BUILTIN_CMD(help),
-  CLI_BUILTIN_CMD(version),
+#ifndef __EMSCRIPTEN__
   CLI_BUILTIN_CMD(register),
   CLI_BUILTIN_CMD(unregister),
-
+#endif
   CLI_BUILTIN_COMMAND(select),
   CLI_BUILTIN_COMMAND(count),
   CLI_BUILTIN_COMMAND(paste),

--- a/app/cli.c
+++ b/app/cli.c
@@ -45,7 +45,7 @@ zsvsheet_status zsvsheet_ext_prompt(struct zsvsheet_proc_context *ctx, char *buf
 typedef int(cmd_main)(int argc, const char *argv[]);
 typedef int(zsv_cmd)(int argc, const char *argv[], struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler,
                      const char *opts_used);
-typedef int (*cmd_reserved)();
+typedef int (*cmd_reserved)(void);
 
 struct builtin_cmd {
   const char *name;
@@ -658,12 +658,12 @@ static char *dl_name_from_func(const void *func) {
   if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                         (LPCTSTR)func, &hModule))
     return get_module_name(hModule);
-#endif
-
-#ifdef __APPLE__
+#elif __APPLE__
   Dl_info info;
   if (dladdr(func, &info))
     return strdup(info.dli_fname);
+#else
+  (void)(func);
 #endif
   return NULL;
 }

--- a/app/count-pull.c
+++ b/app/count-pull.c
@@ -13,7 +13,7 @@
 #define ZSV_COMMAND count_pull
 #include "zsv_command.h"
 
-static int count_usage() {
+static int count_usage(void) {
   static const char *usage = "Usage: count [options]\n"
                              "\n"
                              "Options:\n"

--- a/app/count.c
+++ b/app/count.c
@@ -28,7 +28,7 @@ static void row(void *ctx) {
   ((struct data *)ctx)->rows++;
 }
 
-static int count_usage() {
+static int count_usage(void) {
   static const char *usage = "Usage: count [options]\n"
                              "\n"
                              "Options:\n"

--- a/app/desc.c
+++ b/app/desc.c
@@ -431,7 +431,7 @@ const char *zsv_desc_usage_msg[] = {
   NULL,
 };
 
-static int zsv_desc_usage() {
+static int zsv_desc_usage(void) {
   for (size_t i = 0; zsv_desc_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_desc_usage_msg[i]);
   return 0;

--- a/app/echo.c
+++ b/app/echo.c
@@ -116,10 +116,10 @@ const char *zsv_echo_usage_msg[] = {
   NULL,
 };
 
-static int zsv_echo_usage() {
+static int zsv_echo_usage(void) {
   for (size_t i = 0; zsv_echo_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_echo_usage_msg[i]);
-  return 1;
+  return 0;
 }
 
 static void zsv_echo_cleanup(struct zsv_echo_data *data) {

--- a/app/ext_example/configure
+++ b/app/ext_example/configure
@@ -578,7 +578,7 @@ if [ "$usejq" = "yes" ] || [ "$usejq" = "auto" ] ; then
             echo "Error: --enable-jq specified, but not found"
             exit 1
         fi
-    if ! [ "$LDFLAGS_JQ" = "" ] ; then
+    if [ "$LDFLAGS_JQ" != "" ] && [ "$CROSS_COMPILING" = "no" ]; then
         tryldflag LDFLAGS_JQ -lm
         tryldflag LDFLAGS_JQ -lshlwapi
         tryldflag LDFLAGS_JQ -pthread

--- a/app/external/sqlite3/sqlite3_csv_vtab-zsv.c
+++ b/app/external/sqlite3/sqlite3_csv_vtab-zsv.c
@@ -102,7 +102,7 @@ typedef struct zsvTable {
   sqlite_int64 rowCount;
 } zsvTable;
 
-struct zsvTable *zsvTable_new() {
+struct zsvTable *zsvTable_new(void) {
   struct zsvTable *z = sqlite3_malloc(sizeof(*z));
   if(z) {
     memset(z, 0, sizeof(*z));

--- a/app/flatten.c
+++ b/app/flatten.c
@@ -530,7 +530,7 @@ A,100,A,there,
 B,90,B,you,zzz
 */
 
-static void flatten_usage() {
+static void flatten_usage(void) {
   for (size_t i = 0; flatten_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", flatten_usage_msg[i]);
 }

--- a/app/mv.c
+++ b/app/mv.c
@@ -40,8 +40,8 @@ const char *zsv_mv_usage_msg[] = {
 };
 
 static int zsv_mv_usage(FILE *target) {
-  for (size_t j = 0; zsv_mv_usage_msg[j]; j++)
-    fprintf(target, "%s\n", zsv_mv_usage_msg[j]);
+  for (size_t i = 0; zsv_mv_usage_msg[i]; i++)
+    fprintf(target, "%s\n", zsv_mv_usage_msg[i]);
   return target == stdout ? 0 : 1;
 }
 

--- a/app/overwrite.c
+++ b/app/overwrite.c
@@ -62,15 +62,15 @@ const char *zsv_overwrite_usage_msg[] = {
   "  bulk-remove <datafile> : Bulk remove overwrite entries from a CSV or JSON file",
   "",
   "Options:",
-  "  -h,--help           : Show this help message",
-  "  --old-value <value> : For `add` or `remove`, only proceed if the old value",
-  "                        matches the given value",
-  "  --force             : For `add`, proceed even if an overwrite for the specified",
-  "                        cell already exists",
-  "                        For `remove`, exit without error even if no overwrite for",
-  "                        the specified cell already exists",
-  "  --no-timestamp      : For `add`, don't save timestamp when adding an overwrite",
-  "  --A1                : For `list`, Display addresses in A1-notation",
+  "  -h,--help              : Show this help message",
+  "  --old-value <value>    : For `add` or `remove`, only proceed if the old value",
+  "                           matches the given value",
+  "  --force                : For `add`, proceed even if an overwrite for the specified",
+  "                           cell already exists",
+  "                           For `remove`, exit without error even if no overwrite for",
+  "                           the specified cell already exists",
+  "  --no-timestamp         : For `add`, don't save timestamp when adding an overwrite",
+  "  --A1                   : For `list`, Display addresses in A1-notation",
   "",
   "Description:",
   "  The  `overwrite`  utility  allows  you to manage a list of \"overwrites\" associated",
@@ -78,14 +78,15 @@ const char *zsv_overwrite_usage_msg[] = {
   "  column,  original  value, and new value, along with optional timestamp and author",
   "  metadata.",
   "",
-  "  Overwrite data for a given input file `/path/to/my-data.csv` is stored in the \"over‐",
-  "  writes\"  table  of  `/path/to/.zsv/data/my-data.csv/overwrite.sqlite3`.",
+  "  Overwrite data for a given input file `/path/to/my-data.csv` is stored in the \"over-",
+  "  writes\" table  of `/path/to/.zsv/data/my-data.csv/overwrite.sqlite3`.",
   "",
   "  For bulk operations, the data file must be a CSV with \"row\", \"col\" and \"value\" columns",
   "  and may optionally include \"old value\", \"timestamp\" and/or \"author\"",
-  NULL};
+  NULL,
+};
 
-static int zsv_overwrite_usage() {
+static int zsv_overwrite_usage(void) {
   for (size_t i = 0; zsv_overwrite_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_overwrite_usage_msg[i]);
   return 1;

--- a/app/paste.c
+++ b/app/paste.c
@@ -14,8 +14,7 @@
 #define ZSV_COMMAND paste
 #include "zsv_command.h"
 
-static int zsv_paste_usage() {
-  /* clang-format off */
+static int zsv_paste_usage(void) {
   static const char *usage[] = {
     "Usage: paste <filename> [<filename> ...]",
     "",
@@ -27,10 +26,9 @@ static int zsv_paste_usage() {
     "",
     "Options:",
     "  -h,--help : show usage",
-    NULL
+    NULL,
   };
-  /* clang-format on */
-  for (int i = 0; usage[i]; i++)
+  for (size_t i = 0; usage[i]; i++)
     printf("%s\n", usage[i]);
   return 0;
 }

--- a/app/pretty.c
+++ b/app/pretty.c
@@ -49,7 +49,7 @@ enum zsv_pretty_status {
 
 #ifdef WIN32
 #include <windows.h>
-static size_t get_console_width() {
+static size_t get_console_width(void) {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   int ret;
   ret = GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
@@ -63,13 +63,13 @@ static size_t get_console_width() {
 #include <stdlib.h>
 
 #ifndef HAVE_TGETENT
-static size_t get_console_width() {
+static size_t get_console_width(void) {
   return 0;
 }
 
 #else
 #include <termcap.h>
-static size_t get_console_width() {
+static size_t get_console_width(void) {
   char termbuf[2048];
   char *termtype = getenv("TERM");
   if (tgetent(termbuf, termtype) < 0)
@@ -511,7 +511,7 @@ const char *zsv_pretty_usage_msg[] = {
   NULL,
 };
 
-static void zsv_pretty_usage() {
+static void zsv_pretty_usage(void) {
   for (size_t i = 0; zsv_pretty_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_pretty_usage_msg[i]);
 }

--- a/app/prop.c
+++ b/app/prop.c
@@ -71,8 +71,8 @@ const char *zsv_property_usage_msg[] = {
 };
 
 static int zsv_property_usage(FILE *target) {
-  for (size_t j = 0; zsv_property_usage_msg[j]; j++)
-    fprintf(target, "%s\n", zsv_property_usage_msg[j]);
+  for (size_t i = 0; zsv_property_usage_msg[i]; i++)
+    fprintf(target, "%s\n", zsv_property_usage_msg[i]);
   return target == stdout ? 0 : 1;
 }
 

--- a/app/rm.c
+++ b/app/rm.c
@@ -40,8 +40,8 @@ const char *zsv_rm_usage_msg[] = {
 };
 
 static int zsv_rm_usage(FILE *target) {
-  for (size_t j = 0; zsv_rm_usage_msg[j]; j++)
-    fprintf(target, "%s\n", zsv_rm_usage_msg[j]);
+  for (size_t i = 0; zsv_rm_usage_msg[i]; i++)
+    fprintf(target, "%s\n", zsv_rm_usage_msg[i]);
   return target == stdout ? 0 : 1;
 }
 

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -581,7 +581,7 @@ const char *zsv_select_usage_msg[] = {
   NULL,
 };
 
-static void zsv_select_usage() {
+static void zsv_select_usage(void) {
   for (size_t i = 0; zsv_select_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_select_usage_msg[i]);
 }

--- a/app/select.c
+++ b/app/select.c
@@ -397,7 +397,7 @@ static int zsv_select_check_exclusions_are_indexes(struct zsv_select_data *data)
 
 // demo_random_bw_1_and_100(): this is a poor random number generator. you probably
 // will want to use a better one
-static double demo_random_bw_1_and_100() {
+static double demo_random_bw_1_and_100(void) {
 #ifdef HAVE_ARC4RANDOM_UNIFORM
   return (long double)(arc4random_uniform(1000000)) / 10000;
 #else
@@ -600,7 +600,7 @@ const char *zsv_select_usage_msg[] = {
   NULL,
 };
 
-static void zsv_select_usage() {
+static void zsv_select_usage(void) {
   for (size_t i = 0; zsv_select_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_select_usage_msg[i]);
 }

--- a/app/serialize.c
+++ b/app/serialize.c
@@ -226,7 +226,7 @@ const char *serialize_usage_msg[] = {
   NULL,
 };
 
-static int serialize_usage() {
+static int serialize_usage(void) {
   for (size_t i = 0; serialize_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", serialize_usage_msg[i]);
   return 1;

--- a/app/sheet.c
+++ b/app/sheet.c
@@ -660,7 +660,7 @@ const char *display_cell(struct zsvsheet_screen_buffer *buff, size_t data_row, s
   char *str = (char *)zsvsheet_screen_buffer_cell_display(buff, data_row, data_col);
   size_t len = str ? strlen(str) : 0;
   if (len == 0 || has_multibyte_char(str, len < cell_display_width ? len : cell_display_width) == 0)
-    mvprintw(row, col * cell_display_width, "%-*.*s", cell_display_width, cell_display_width - 1, str);
+    mvprintw(row, col * cell_display_width, "%-*.*s", (int)cell_display_width, (int)cell_display_width - 1, str);
   else {
     size_t used_width;
     int err = 0;

--- a/app/sheet.c
+++ b/app/sheet.c
@@ -599,7 +599,7 @@ struct builtin_proc_desc {
   { zsvsheet_builtin_proc_move_bottom,    "bottom", "Jump to the last row",                                            zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_move_top,       "top",    "Jump to the first row",                                           zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_move_first_col, "first",  "Jump to the first column",                                        zsvsheet_builtin_proc_handler },
-  { zsvsheet_builtin_proc_pg_down,        "pagedown", "Move down one page",                                              zsvsheet_builtin_proc_handler },
+  { zsvsheet_builtin_proc_pg_down,        "pagedown", "Move down one page",                                            zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_pg_up,          "pageup", "Move up one page",                                                zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_move_last_col,  "last",   "Jump to the last column",                                         zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_move_up,        "up",     "Move up one row",                                                 zsvsheet_builtin_proc_handler },
@@ -609,17 +609,17 @@ struct builtin_proc_desc {
   { zsvsheet_builtin_proc_find,           "find",   "Set a search term and jump to the first result after the cursor", zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_find_next,      "next",   "Jump to the next search result",                                  zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_resize,         "resize", "Resize the layout to fit new terminal dimensions",                zsvsheet_builtin_proc_handler },
-  { zsvsheet_builtin_proc_open_file,      "open",   "Open a another CSV file",                                         zsvsheet_open_file_handler  },
-  { zsvsheet_builtin_proc_filter,         "filter", "Hide rows that do not contain the specified text",                zsvsheet_filter_handler     },
-  { zsvsheet_builtin_proc_help,           "help",   "Display a list of actions and key-bindings",                      zsvsheet_help_handler       },
-  { -1, NULL, NULL }
+  { zsvsheet_builtin_proc_open_file,      "open",   "Open a another CSV file",                                         zsvsheet_open_file_handler    },
+  { zsvsheet_builtin_proc_filter,         "filter", "Hide rows that do not contain the specified text",                zsvsheet_filter_handler       },
+  { zsvsheet_builtin_proc_help,           "help",   "Display a list of actions and key-bindings",                      zsvsheet_help_handler         },
+  { -1, NULL, NULL, NULL },
 };
 /* clang-format on */
 
 void zsvsheet_register_builtin_procedures(void) {
   for (struct builtin_proc_desc *desc = builtin_procedures; desc->proc_id != -1; ++desc) {
     if (zsvsheet_register_builtin_proc(desc->proc_id, desc->name, desc->description, desc->handler) < 0) {
-      fprintf(stderr, "failed to register builtin procedure\n");
+      fprintf(stderr, "Failed to register builtin procedure\n");
     }
   }
 }

--- a/app/sheet/read-data.c
+++ b/app/sheet/read-data.c
@@ -8,7 +8,9 @@
 #include "index.h"
 
 #if defined(WIN32) || defined(_WIN32)
+#ifndef NO_MEMMEM
 #define NO_MEMMEM
+#endif
 #include <zsv/utils/memmem.h>
 #endif
 #include <zsv/utils/writer.h>

--- a/app/sheet/usage.c
+++ b/app/sheet/usage.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 
 const char *zsvsheet_usage_msg[] = {
   APPNAME ": opens interactive spreadsheet-like viewer in the console", "", "Usage: " APPNAME " filename", "", NULL,

--- a/app/sql.c
+++ b/app/sql.c
@@ -59,10 +59,10 @@ const char *zsv_sql_usage_msg[] = {
   NULL,
 };
 
-static int zsv_sql_usage(FILE *f) {
+static int zsv_sql_usage(FILE *target) {
   for (size_t i = 0; zsv_sql_usage_msg[i]; i++)
-    fprintf(f, "%s\n", zsv_sql_usage_msg[i]);
-  return f == stderr ? 1 : 0;
+    fprintf(target, "%s\n", zsv_sql_usage_msg[i]);
+  return target == stdout ? 0 : 1;
 }
 
 struct zsv_sql_data {
@@ -170,7 +170,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       zsv_set_default_custom_prop_handler(*custom_prop_handler);
 
     struct zsv_csv_writer_options writer_opts = zsv_writer_get_default_opts();
-    int err = 0;
+    err = 0;
     for (int arg_i = 1; !err && arg_i < argc; arg_i++) {
       const char *arg = argv[arg_i];
       if (!strcmp(arg, "--join-indexes")) {

--- a/app/stack.c
+++ b/app/stack.c
@@ -30,7 +30,7 @@ const char *zsv_stack_usage_msg[] = {
   NULL,
 };
 
-static int zsv_stack_usage() {
+static int zsv_stack_usage(void) {
   for (size_t i = 0; zsv_stack_usage_msg[i]; i++)
     fprintf(stdout, "%s\n", zsv_stack_usage_msg[i]);
   return 0;

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -112,7 +112,7 @@ test-prop:
 	EXE=${BUILD_DIR}/bin/zsv_prop${EXE} ${MAKE} -C prop test
 
 test-overwrite: ${BUILD_DIR}/bin/zsv_overwrite${EXE} ${BUILD_DIR}/bin/zsv_echo${EXE}
-	EXE=${BUILD_DIR}/bin/zsv_overwrite${EXE} ECHO_EXE=${BUILD_DIR}/bin/zsv_echo${EXE} CMP=$(CMP) ${MAKE} -C overwrite test
+	@EXE=${BUILD_DIR}/bin/zsv_overwrite${EXE} ECHO_EXE=${BUILD_DIR}/bin/zsv_echo${EXE} CMP=$(CMP) ${MAKE} -C overwrite test
 
 test-echo: test-echo1 test-echo-overwrite-all test-echo-eol test-echo-chars test-echo-trim test-echo-skip-until test-echo-contiguous test-echo-trim-columns test-echo-trim-columns-2 test-echo-buffsize
 
@@ -192,7 +192,7 @@ worldcitiespop_mil.csv:
 	curl -LOk 'https://burntsushi.net/stuff/worldcitiespop_mil.csv'
 
 worldcitiespop_mil.tsv: worldcitiespop_mil.csv ${BUILD_DIR}/bin/zsv_2tsv
-	${BUILD_DIR}/bin/zsv_2tsv $< > $@
+	@${BUILD_DIR}/bin/zsv_2tsv $< > $@
 
 test-count test-count-pull: test-% : test-1-% test-2-%
 
@@ -706,7 +706,7 @@ test-sheet-11: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv
 	@(tmux new-session -x 80 -y 50 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
 	sleep 0.5 && \
 	tmux send-keys -t $@ -N 21 "C-d" && \
-	sleep 1 && \
+	sleep 2 && \
 	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	tmux send-keys -t $@ "q" && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || (echo 'Incorrect output:' && cat ${TMP_DIR}/$@.out && ${TEST_FAIL}))

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -63,9 +63,9 @@ COLOR_RED=\033[1;31m
 COLOR_BLUE=\033[1;34m
 COLOR_PINK=\033[1;35m
 
-TEST_PASS=echo -e "${COLOR_BLUE}$@: ${COLOR_GREEN}Passed${COLOR_NONE}"
-TEST_FAIL=(echo -e "${COLOR_BLUE}$@: ${COLOR_RED}Failed!${COLOR_NONE}" && exit 1)
-TEST_INIT=mkdir -p ${TMP_DIR} && echo -e "${COLOR_PINK}$@: ${COLOR_NONE}"
+TEST_PASS=printf "${COLOR_BLUE}$@: ${COLOR_GREEN}Passed${COLOR_NONE}\n"
+TEST_FAIL=(printf "${COLOR_BLUE}$@: ${COLOR_RED}Failed!${COLOR_NONE}\n" && exit 1)
+TEST_INIT=mkdir -p ${TMP_DIR} && printf "${COLOR_PINK}$@: ${COLOR_NONE}\n"
 
 ARGS-sql='select [Loan Number] from data'
 
@@ -114,7 +114,7 @@ test-prop:
 test-overwrite: ${BUILD_DIR}/bin/zsv_overwrite${EXE} ${BUILD_DIR}/bin/zsv_echo${EXE}
 	EXE=${BUILD_DIR}/bin/zsv_overwrite${EXE} ECHO_EXE=${BUILD_DIR}/bin/zsv_echo${EXE} CMP=$(CMP) ${MAKE} -C overwrite test
 
-test-echo : test-echo1 test-echo-overwrite-all test-echo-eol test-echo-chars test-echo-trim test-echo-skip-until test-echo-contiguous test-echo-trim-columns test-echo-trim-columns-2 test-echo-buffsize
+test-echo: test-echo1 test-echo-overwrite-all test-echo-eol test-echo-chars test-echo-trim test-echo-skip-until test-echo-contiguous test-echo-trim-columns test-echo-trim-columns-2 test-echo-buffsize
 
 test-echo-overwrite-all: test-echo-overwrite test-echo-overwrite-csv test-echo-overwrite-auto
 
@@ -223,7 +223,7 @@ test-merge-select test-merge-select-pull: test-merge-% : ${BUILD_DIR}/bin/zsv_%$
 
 test-quotebuff-select test-quotebuff-select-pull: test-quotebuff-% : ${BUILD_DIR}/bin/zsv_%${EXE}
 	@${TEST_INIT}
-	@${THIS_MAKEFILE_DIR}/select-quotebuff-gen.sh  | ${PREFIX} $< -B 4096 ${REDIRECT} /tmp/$@.out
+	@${THIS_MAKEFILE_DIR}/select-quotebuff-gen.sh | ${PREFIX} $< -B 4096 ${REDIRECT} /tmp/$@.out
 # use a dummy ${CMP} call so that it works with LEAKS=1
 	@${CMP} /dev/null /dev/null && sed 's/"/Q/g' < /tmp/$@.out | grep QQ >/dev/null && ${TEST_FAIL} || ${TEST_PASS}
 
@@ -245,13 +245,13 @@ test-n-select test-n-select-pull: test-n-% : ${BUILD_DIR}/bin/zsv_%${EXE}
 	@${PREFIX} $< ${TEST_DATA_DIR}/loans_1.csv -u "?" -R 4 -d 2 -N ${REDIRECT} ${TMP_DIR}/test-4-$*.out
 	@${CMP} ${TMP_DIR}/test-4-$*.out expected/test-4-select.out && ${TEST_PASS} || ${TEST_FAIL}
 
-	@${PREFIX} $<  ${TEST_DATA_DIR}/quoted.csv -e 'x' ${REDIRECT} ${TMP_DIR}/test-5-$*.out
+	@${PREFIX} $< ${TEST_DATA_DIR}/quoted.csv -e 'x' ${REDIRECT} ${TMP_DIR}/test-5-$*.out
 	@${CMP} ${TMP_DIR}/test-5-$*.out expected/test-5-select.out && ${TEST_PASS} || ${TEST_FAIL}
 
-	@${PREFIX} $<  ${TEST_DATA_DIR}/stack1.csv --no-header -H 10 ${REDIRECT} ${TMP_DIR}/test-no-header-$*.out
+	@${PREFIX} $< ${TEST_DATA_DIR}/stack1.csv --no-header -H 10 ${REDIRECT} ${TMP_DIR}/test-no-header-$*.out
 	@${CMP} ${TMP_DIR}/test-no-header-$*.out expected/test-no-header-select.out && ${TEST_PASS} || ${TEST_FAIL}
 
-	@${PREFIX} $<  ${TEST_DATA_DIR}/stack1.csv --prepend-header 'my,Header.' -H 10 ${REDIRECT} ${TMP_DIR}/test-prepend-header-$*.out
+	@${PREFIX} $< ${TEST_DATA_DIR}/stack1.csv --prepend-header 'my,Header.' -H 10 ${REDIRECT} ${TMP_DIR}/test-prepend-header-$*.out
 	@${CMP} ${TMP_DIR}/test-prepend-header-$*.out expected/test-prepend-header-select.out && ${TEST_PASS} || ${TEST_FAIL}
 
 test-6-select test-6-select-pull: test-6-% : ${BUILD_DIR}/bin/zsv_%${EXE}

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -717,9 +717,7 @@ test-sheet-12: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv
 	@(tmux new-session -x 80 -y 6 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
 	sleep 0.5 && \
 	tmux send-keys -t $@ "f" "el" "Enter" && \
-	sleep 1 && \
-	tmux send-keys -t $@ "f" "al" "Enter" && \
-	sleep 1 && \
+	sleep 0.5 && \
 	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	tmux send-keys -t $@ "q" && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || (echo 'Incorrect output:' && cat ${TMP_DIR}/$@.out && ${TEST_FAIL}))

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -717,8 +717,9 @@ test-sheet-12: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv
 	@(tmux new-session -x 80 -y 6 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
 	sleep 0.5 && \
 	tmux send-keys -t $@ "f" "el" "Enter" && \
-	sleep 0.5 && \
+	sleep 1 && \
 	tmux send-keys -t $@ "f" "al" "Enter" && \
+	sleep 1 && \
 	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	tmux send-keys -t $@ "q" && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || (echo 'Incorrect output:' && cat ${TMP_DIR}/$@.out && ${TEST_FAIL}))

--- a/app/test/expected/test-sheet-12.out
+++ b/app/test/expected/test-sheet-12.out
@@ -1,6 +1,6 @@
 Row #     Country   City      AccentCit Region    Populatio Latitude  Longitude
-117       pk        basti faz Basti Faz 04                  29.080758 70.984992
-415       mx        el salado El Salado 07                  29.644444 -101.7666
-590       af        abbaskhel Abbaskhel 29                  32.831993 69.12336
-807       af        `abdul `a `Abdul `A 10                  31.229677 64.206403
-(59456 filtered rows) 117
+4         id        selingon  Selingon  17                  -8.8374   116.4914
+23        ru        otdeleniy Otdeleniy 86                  51.726473 39.714345
+26        ad        el pui    El Pui    04                  42.55     1.5166667
+27        ad        els bons  Els Bons  03                  42.533333 1.5833333
+(59456 filtered rows) 4

--- a/app/test/overwrite/Makefile
+++ b/app/test/overwrite/Makefile
@@ -100,4 +100,4 @@ test-echo-overwrite-auto:
 clean:
 	@rm -rf ${TMP_DIR}
 
-.PHONY: test% clean
+.PHONY: help test% clean

--- a/app/test/overwrite/Makefile
+++ b/app/test/overwrite/Makefile
@@ -15,9 +15,9 @@ COLOR_PINK=\033[1;35m
 
 TMP_DIR=${THIS_MAKEFILE_DIR}/tmp
 
-TEST_PASS=echo "${COLOR_BLUE}$@: ${COLOR_GREEN}Passed${COLOR_NONE}"
-TEST_FAIL=(echo "${COLOR_BLUE}$@: ${COLOR_RED}Failed!${COLOR_NONE}" && exit 1)
-TEST_INIT=mkdir -p ${TMP_DIR} && rm -rf ${TMP_DIR}/test* && echo "${COLOR_PINK}test-overwrite-$@: ${COLOR_NONE}"
+TEST_PASS=printf "${COLOR_BLUE}$@: ${COLOR_GREEN}Passed${COLOR_NONE}\n"
+TEST_FAIL=(printf "${COLOR_BLUE}$@: ${COLOR_RED}Failed!${COLOR_NONE}\n" && exit 1)
+TEST_INIT=mkdir -p ${TMP_DIR} && rm -rf ${TMP_DIR}/test* && printf "${COLOR_PINK}test-overwrite-$@: ${COLOR_NONE}\n"
 
 LEAKS=
 ifneq ($(LEAKS),)

--- a/app/utils/arg.c
+++ b/app/utils/arg.c
@@ -60,12 +60,12 @@ static struct zsv_opts *zsv_with_default_opts(char mode) {
 }
 
 ZSV_EXPORT
-void zsv_clear_default_opts() {
+void zsv_clear_default_opts(void) {
   zsv_with_default_opts('c');
 }
 
 ZSV_EXPORT
-struct zsv_opts zsv_get_default_opts() {
+struct zsv_opts zsv_get_default_opts(void) {
   return *zsv_with_default_opts('g');
 }
 

--- a/app/utils/clock.c
+++ b/app/utils/clock.c
@@ -34,12 +34,12 @@ int zsv_fflush_clock(FILE *stream) {
   return i;
 }
 
-void zsv_clocks_begin() {
+void zsv_clocks_begin(void) {
   zsv_clock_in = zsv_clock_out = 0;
   zsv_clock_begin = clock();
 }
 
-void zsv_clocks_end() {
+void zsv_clocks_end(void) {
   clock_t clock_end = clock();
   clock_t clock_total = clock_end - zsv_clock_begin;
   clock_t clock_other = clock_total - zsv_clock_in - zsv_clock_out;

--- a/app/utils/dirs.c
+++ b/app/utils/dirs.c
@@ -55,6 +55,7 @@ size_t zsv_get_config_dir(char *buff, size_t buffsize, const char *prefix) {
     env_val = "C:\\temp";
   int written = snprintf(buff, buffsize, "%s", env_val);
 #elif defined(__EMSCRIPTEN__)
+  (void)(prefix);
   int written = snprintf(buff, buffsize, "/tmp");
 #else
   int written;

--- a/configure
+++ b/configure
@@ -736,10 +736,12 @@ fi
 
 tryldflag LDFLAGS_JQ -lm
 tryldflag LDFLAGS_JQ -lshlwapi
-if [ "$MINGW" = "1" ]; then
-    tryldflag LDFLAGS_TMP -pthread && STATIC_LIBS="$STATIC_LIBS -pthread"
-else
-    tryldflag LDFLAGS_JQ -pthread
+if [ "$CROSS_COMPILING" = "no" ]; then
+    if [ "$MINGW" = "1" ]; then
+        tryldflag LDFLAGS_TMP -pthread && STATIC_LIBS="$STATIC_LIBS -pthread"
+    else
+        tryldflag LDFLAGS_JQ -pthread
+    fi
 fi
 
 tryccfn CFLAGS_AUTO "arc4random_uniform" "stdlib.h" || tryccfn CFLAGS_AUTO "rand_s" "stdlib.h" "" "#define _CRT_RAND_S"

--- a/include/zsv/utils/clock.h
+++ b/include/zsv/utils/clock.h
@@ -12,8 +12,8 @@
 #include <time.h>
 #include <stdio.h>
 
-void zsv_clocks_begin();
-void zsv_clocks_end();
+void zsv_clocks_begin(void);
+void zsv_clocks_end(void);
 
 size_t zsv_fread_clock(void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream);
 size_t zsv_fwrite_clock(const void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream);


### PR DESCRIPTION
- Fix emscripten compilation/linking issues
- Fix compiler warnings
- Turn off warnings for `jq`, `sqlite3`, and `yajl`
  - Reduces noise from the compiler output.
- Replace `echo -e` with `printf` to avoid printing `-e` for tests
  - See https://stackoverflow.com/questions/11675070/makefile-echo-n-not-working for details.
  - FreeBSD test color codes are working now.
- Format usage text for alignment
- Misc other minor improvements in Makefile(s) etc.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>