### PR TITLE
Transformation sheet API

### DIFF
--- a/app/cli.c
+++ b/app/cli.c
@@ -24,6 +24,7 @@
 #ifdef ZSVSHEET_BUILD
 #include "sheet/sheet_internal.h"
 #include "sheet/handlers_internal.h"
+#include "sheet/transformation.h"
 #endif
 #include "sheet/procedure.h"
 #include "sheet/key-bindings.h"
@@ -404,6 +405,11 @@ static struct zsv_ext_callbacks *zsv_ext_callbacks_init(struct zsv_ext_callbacks
     e->ext_sheet_open_file = zsvsheet_open_file;
     e->ext_sheet_register_proc = zsvsheet_register_proc;
     e->ext_sheet_register_proc_key_binding = zsvsheet_register_proc_key_binding;
+    e->ext_sheet_push_transformation = zsvsheet_push_transformation;
+    e->ext_sheet_transformation_writer = zsvsheet_transformation_writer;
+    e->ext_sheet_transformation_parser = zsvsheet_transformation_parser;
+    e->ext_sheet_transformation_filename = zsvsheet_transformation_filename;
+    e->ext_sheet_transformation_user_context = zsvsheet_transformation_user_context;
 #endif
   }
   return e;

--- a/app/sheet.c
+++ b/app/sheet.c
@@ -696,7 +696,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     handler_state.display_info.update_buffer = false;
 
     pthread_mutex_lock(&current_ui_buffer->mutex);
-    status_msg = current_ui_buffer->status;
+    if (current_ui_buffer->status)
+      status_msg = strdup(current_ui_buffer->status);
+
     if (current_ui_buffer->index_ready &&
         current_ui_buffer->dimensions.row_count != current_ui_buffer->index->row_count + 1) {
       current_ui_buffer->dimensions.row_count = current_ui_buffer->index->row_count + 1;
@@ -723,8 +725,10 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       }
     }
 
-    if (status_msg)
+    if (status_msg) {
       zsvsheet_priv_set_status(&display_dims, 1, status_msg);
+      free(status_msg);
+    }
 
     display_buffer_subtable(current_ui_buffer, header_span, &display_dims);
   }

--- a/app/sheet.c
+++ b/app/sheet.c
@@ -41,6 +41,7 @@ struct zsvsheet_opts {
 
 #include "sheet/utf8-width.c"
 #include "sheet/ui_buffer.c"
+#include "sheet/transformation.c"
 #include "sheet/index.c"
 #include "sheet/read-data.c"
 #include "sheet/key-bindings.c"

--- a/app/sheet/handlers.c
+++ b/app/sheet/handlers.c
@@ -185,7 +185,8 @@ enum zsvsheet_status zsvsheet_push_transformation(zsvsheet_proc_context_t ctx, v
   if (zst != zsv_status_ok)
     goto out;
 
-  stat = zsvsheet_open_file(ctx, zsvsheet_transformation_filename(trn), &zopts);
+  // TODO: need to free filename
+  stat = zsvsheet_open_file(ctx, strdup(zsvsheet_transformation_filename(trn)), &zopts);
 
 out:
   zsvsheet_transformation_delete(trn);

--- a/app/sheet/handlers_internal.h
+++ b/app/sheet/handlers_internal.h
@@ -105,4 +105,9 @@ zsvsheet_status zsvsheet_register_command(int ch, const char *long_name,
                                           zsvsheet_status (*subcommand_handler)(zsvsheet_subcommand_context_t),
                                           zsvsheet_status (*handler)(zsvsheet_context_t));
 
+/**
+ * Transform the current buffer's underlying file into a new one and open the new file in a buffer
+ */
+enum zsvsheet_status zsvsheet_push_transformation(zsvsheet_proc_context_t ctx, void *user_context,
+                                                  void (*row_handler)(void *exec_ctx));
 #endif

--- a/app/sheet/index.c
+++ b/app/sheet/index.c
@@ -100,7 +100,7 @@ static enum zsv_status filter_file(struct zsvsheet_index_opts *optsp) {
   if (zst != zsv_status_ok)
     goto out;
 
-  if (asprintf(optsp->data_filenamep, "%s", zsvsheet_transformation_filename(trn)) == -1)
+  if (!(optsp->uib->data_filename = strdup(zsvsheet_transformation_filename(trn))))
     zst = zsv_status_memory;
 
 out:
@@ -127,7 +127,7 @@ enum zsv_index_status build_memory_index(struct zsvsheet_index_opts *optsp) {
     if (zst != zsv_status_ok)
       goto out;
 
-    ix_zopts.stream = fopen(*optsp->data_filenamep, "rb");
+    ix_zopts.stream = fopen(optsp->uib->data_filename, "rb");
   } else {
     ix_zopts.stream = fopen(optsp->filename, "rb");
   }
@@ -154,7 +154,6 @@ enum zsv_index_status build_memory_index(struct zsvsheet_index_opts *optsp) {
 
   if (zst == zsv_status_no_more_input) {
     ret = zsv_index_status_ok;
-    // *optsp->index = ixr.ix;
     optsp->uib->index = ixr.ix;
   } else
     zsv_index_delete(ixr.ix);

--- a/app/sheet/index.c
+++ b/app/sheet/index.c
@@ -8,40 +8,104 @@
 #include <zsv/utils/writer.h>
 
 #include "index.h"
+#include "transformation.h"
 
-static void save_filtered_file_row_handler(void *ctx) {
-  struct zsvsheet_indexer *ixr = ctx;
-  zsv_parser parser = ixr->parser;
+struct filtered_file_ctx {
+  const char *filter;
+  size_t filter_len;
+  size_t row_num; // 1-based row number (1 = header row, 2 = first data row)
+  unsigned char seen_header : 1;
+  unsigned char has_row_num : 1;
+  unsigned char _ : 7;
+};
+
+static void save_filtered_file_row_handler(void *trn) {
+  struct filtered_file_ctx *ctx = zsvsheet_transformation_user_context(trn);
+  zsv_parser parser = zsvsheet_transformation_parser(trn);
+  zsv_csv_writer writer = zsvsheet_transformation_writer(trn);
   size_t col_count = zsv_cell_count(parser);
-  ixr->row_num++;
+  ctx->row_num++;
   if (col_count == 0)
     return;
 
   struct zsv_cell first_cell = zsv_get_cell(parser, 0);
-  if (ixr->seen_header) {
+  if (ctx->seen_header) {
     struct zsv_cell last_cell = zsv_get_cell(parser, col_count - 1);
-    if (!memmem(first_cell.str, last_cell.str - first_cell.str + last_cell.len, ixr->filter, ixr->filter_len))
+    if (!memmem(first_cell.str, last_cell.str - first_cell.str + last_cell.len, ctx->filter, ctx->filter_len))
       return;
     // future enhancement: optionally, handle if row may have unusual quotes e.g. cell1,"ce"ll2,cell3
   } else {
-    ixr->seen_header = 1;
+    ctx->seen_header = 1;
     if (first_cell.len == ZSVSHEET_ROWNUM_HEADER_LEN && !memcmp(first_cell.str, ZSVSHEET_ROWNUM_HEADER, first_cell.len))
-      ixr->has_row_num = 1;
+      ctx->has_row_num = 1;
   }
 
   char row_started = 0;
-  if (!ixr->has_row_num) {
+  if (!ctx->has_row_num) {
     // create our own rownum column
     row_started = 1;
-    if (ixr->row_num == 1)
-      zsv_writer_cell_s(ixr->writer, 1, (const unsigned char *)"Row #", 0); // to do: consolidate "Row #"
+    if (ctx->row_num == 1)
+      zsv_writer_cell_s(writer, 1, (const unsigned char *)"Row #", 0); // to do: consolidate "Row #"
     else
-      zsv_writer_cell_zu(ixr->writer, 1, ixr->row_num - 1);
+      zsv_writer_cell_zu(writer, 1, ctx->row_num - 1);
   }
   for (size_t i = 0; i < col_count; i++) {
     struct zsv_cell cell = zsv_get_cell(parser, i);
-    zsv_writer_cell(ixr->writer, i == 0 && row_started == 0, cell.str, cell.len, cell.quoted);
+    zsv_writer_cell(writer, i == 0 && row_started == 0, cell.str, cell.len, cell.quoted);
   }
+}
+
+static enum zsv_status filter_file(struct zsvsheet_index_opts *optsp) {
+  struct filtered_file_ctx ctx = {
+    .seen_header = 0,
+    .row_num = 0,
+    .has_row_num = 0,
+    .filter = optsp->row_filter,
+    .filter_len = strlen(optsp->row_filter),
+  };
+  struct zsvsheet_transformation_opts opts = {
+    .custom_prop_handler = optsp->custom_prop_handler,
+    .input_filename = optsp->filename,
+  };
+  zsvsheet_transformation trn;
+  struct zsv_opts zopts = optsp->zsv_opts;
+
+  zopts.ctx = &ctx;
+  zopts.row_handler = save_filtered_file_row_handler;
+  zopts.stream = fopen(optsp->filename, "rb");
+
+  if (!zopts.stream)
+    goto out;
+
+  opts.zsv_opts = zopts;
+
+  enum zsv_status zst = zsvsheet_transformation_new(opts, &trn);
+  if (zst != zsv_status_ok)
+    return zst;
+
+  zsv_parser parser = zsvsheet_transformation_parser(trn);
+
+  while ((zst = zsv_parse_more(parser)) == zsv_status_ok)
+    ;
+
+  switch (zst) {
+  case zsv_status_no_more_input:
+  case zsv_status_cancelled:
+    break;
+  default:
+    goto out;
+  }
+
+  zst = zsv_finish(parser);
+  if (zst != zsv_status_ok)
+    goto out;
+
+  if (asprintf(optsp->data_filenamep, "%s", zsvsheet_transformation_filename(trn)) == -1)
+    zst = zsv_status_memory;
+
+out:
+  zsvsheet_transformation_delete(trn);
+  return zst;
 }
 
 static void build_memory_index_row_handler(void *ctx) {
@@ -55,62 +119,23 @@ static void build_memory_index_row_handler(void *ctx) {
 
 enum zsv_index_status build_memory_index(struct zsvsheet_index_opts *optsp) {
   struct zsvsheet_indexer ixr = {0};
-  ixr.filter = optsp->row_filter;
-  ixr.filter_len = optsp->row_filter ? strlen(optsp->row_filter) : 0;
-
   enum zsv_index_status ret = zsv_index_status_error;
   struct zsv_opts ix_zopts = optsp->zsv_opts;
-  unsigned char temp_buff[8196];
-  char *temp_filename;
-  FILE *temp_f = NULL;
-  zsv_csv_writer temp_file_writer = NULL;
-  FILE *fp = fopen(optsp->filename, "rb");
-  if (!fp)
-    return ret;
-
-  ix_zopts.ctx = &ixr;
-  ix_zopts.stream = fp;
 
   if (optsp->row_filter) {
-    temp_filename = zsv_get_temp_filename("zsvsheet_filter_XXXXXXXX");
-    if (!temp_filename)
-      return ret;
-
-    // *optsp->data_filenamep = temp_filename;
-    optsp->uib->data_filename = temp_filename;
-
-    struct zsv_csv_writer_options writer_opts = {0};
-    if (!(writer_opts.stream = temp_f = fopen(temp_filename, "w+")))
-      return ret;
-    if (!(temp_file_writer = zsv_writer_new(&writer_opts)))
-      goto out;
-
-    zsv_writer_set_temp_buff(temp_file_writer, temp_buff, sizeof(temp_buff));
-    ixr.writer = temp_file_writer;
-    ixr.filter_stream = temp_f;
-    ix_zopts.row_handler = save_filtered_file_row_handler;
-
-    enum zsv_status zst =
-      zsv_new_with_properties(&ix_zopts, optsp->custom_prop_handler, optsp->filename, NULL, &ixr.parser);
+    enum zsv_status zst = filter_file(optsp);
     if (zst != zsv_status_ok)
       goto out;
 
-    while ((zst = zsv_parse_more(ixr.parser)) == zsv_status_ok)
-      ;
-
-    if (zst != zsv_status_no_more_input)
-      goto out;
-
-    zsv_finish(ixr.parser);
-    zsv_delete(ixr.parser);
-    zsv_writer_delete(temp_file_writer);
-    temp_file_writer = NULL;
-    if (fseek(temp_f, 0, SEEK_SET))
-      goto out;
-
-    ix_zopts.stream = temp_f;
+    ix_zopts.stream = fopen(*optsp->data_filenamep, "rb");
+  } else {
+    ix_zopts.stream = fopen(optsp->filename, "rb");
   }
 
+  if (!ix_zopts.stream)
+    goto out;
+
+  ix_zopts.ctx = &ixr;
   ix_zopts.row_handler = build_memory_index_row_handler;
 
   enum zsv_status zst =
@@ -135,12 +160,10 @@ enum zsv_index_status build_memory_index(struct zsvsheet_index_opts *optsp) {
     zsv_index_delete(ixr.ix);
 
 out:
-  zsv_delete(ixr.parser);
-  fclose(fp);
-  if (temp_file_writer)
-    zsv_writer_delete(temp_file_writer);
-  if (temp_f)
-    fclose(temp_f);
+  if (ixr.parser)
+    zsv_delete(ixr.parser);
+  if (ix_zopts.stream)
+    fclose(ix_zopts.stream);
 
   return ret;
 }

--- a/app/sheet/index.h
+++ b/app/sheet/index.h
@@ -13,11 +13,8 @@ struct zsvsheet_indexer {
 struct zsvsheet_index_opts {
   pthread_mutex_t *mutexp;
   const char *filename;
-  char **data_filenamep;
   const char *row_filter;
   struct zsv_opts zsv_opts;
-  struct zsv_index **index;
-  unsigned char *index_ready;
   struct zsvsheet_ui_buffer *uib;
   int *errp;
   struct zsv_prop_handler *custom_prop_handler;

--- a/app/sheet/index.h
+++ b/app/sheet/index.h
@@ -1,24 +1,13 @@
 #ifndef SHEET_INDEX_H
 #define SHEET_INDEX_H
 
-#include <stdint.h>
-#include <stdio.h>
 #include <pthread.h>
 
 #include "zsv.h"
-#include "zsv/utils/writer.h"
 
 struct zsvsheet_indexer {
   zsv_parser parser;
   struct zsv_index *ix;
-  const char *filter;
-  size_t filter_len;
-  zsv_csv_writer writer;
-  FILE *filter_stream;
-  size_t row_num; // 1-based row number (1 = header row, 2 = first data row)
-  unsigned char seen_header : 1;
-  unsigned char has_row_num : 1;
-  unsigned char _ : 6;
 };
 
 struct zsvsheet_index_opts {

--- a/app/sheet/read-data.c
+++ b/app/sheet/read-data.c
@@ -33,11 +33,8 @@ static void get_data_index_async(struct zsvsheet_ui_buffer *uibuffp, const char 
   struct zsvsheet_index_opts *ixopts = calloc(1, sizeof(*ixopts));
   ixopts->mutexp = mutexp;
   ixopts->filename = filename;
-  //  ixopts->data_filenamep = &uibuffp->data_filename;
   ixopts->zsv_opts = *optsp;
   ixopts->row_filter = row_filter;
-  // ixopts->index = &uibuffp->index;
-  //  ixopts->index_ready = &uibuffp->index_ready;
   ixopts->custom_prop_handler = custom_prop_handler;
   //  ixopts->opts_used = opts_used;
   ixopts->uib = uibuffp;
@@ -269,6 +266,7 @@ static void *get_data_index(void *gdi) {
       }
     }
   }
+  d->uib->ixopts = NULL;
   free(d);
   pthread_mutex_unlock(mutexp);
 

--- a/app/sheet/transformation.c
+++ b/app/sheet/transformation.c
@@ -9,12 +9,13 @@ struct zsvsheet_transformation {
   zsv_csv_writer writer;
   char *output_filename;
   FILE *output_stream;
+  unsigned char *output_buffer;
   struct zsvsheet_transformation_opts opts;
   void *user_context;
 };
 
 enum zsv_status zsvsheet_transformation_new(struct zsvsheet_transformation_opts opts, zsvsheet_transformation *out) {
-  unsigned char temp_buff[8196];
+  unsigned char *temp_buff = NULL;
   char *temp_filename = NULL;
   FILE *temp_f = NULL;
   zsv_csv_writer temp_file_writer = NULL;
@@ -37,9 +38,14 @@ enum zsv_status zsvsheet_transformation_new(struct zsvsheet_transformation_opts 
   if (!(temp_file_writer = zsv_writer_new(&writer_opts)))
     goto free;
 
-  zsv_writer_set_temp_buff(temp_file_writer, temp_buff, sizeof(temp_buff));
+  const size_t temp_buff_size = 8196;
+  temp_buff = malloc(temp_buff_size);
+  if (!temp_buff)
+    goto free;
+  zsv_writer_set_temp_buff(temp_file_writer, temp_buff, temp_buff_size);
   trn->writer = temp_file_writer;
   trn->output_stream = temp_f;
+  trn->output_buffer = temp_buff;
   trn->user_context = opts.zsv_opts.ctx;
   opts.zsv_opts.ctx = trn;
 
@@ -59,6 +65,8 @@ free:
     fclose(temp_f);
   if (temp_file_writer)
     zsv_writer_delete(temp_file_writer);
+  if (temp_buff)
+    free(temp_buff);
 
   return zst;
 }
@@ -68,6 +76,7 @@ void zsvsheet_transformation_delete(zsvsheet_transformation trn) {
   zsv_delete(trn->parser);
   free(trn->output_filename);
   fclose(trn->output_stream);
+  free(trn->output_buffer);
   free(trn);
 }
 

--- a/app/sheet/transformation.c
+++ b/app/sheet/transformation.c
@@ -10,6 +10,7 @@ struct zsvsheet_transformation {
   char *output_filename;
   FILE *output_stream;
   struct zsvsheet_transformation_opts opts;
+  void *user_context;
 };
 
 enum zsv_status zsvsheet_transformation_new(struct zsvsheet_transformation_opts opts, zsvsheet_transformation *out) {
@@ -39,6 +40,8 @@ enum zsv_status zsvsheet_transformation_new(struct zsvsheet_transformation_opts 
   zsv_writer_set_temp_buff(temp_file_writer, temp_buff, sizeof(temp_buff));
   trn->writer = temp_file_writer;
   trn->output_stream = temp_f;
+  trn->user_context = opts.zsv_opts.ctx;
+  opts.zsv_opts.ctx = trn;
 
   zst = zsv_new_with_properties(&opts.zsv_opts, opts.custom_prop_handler, opts.input_filename, NULL, &trn->parser);
   if (zst != zsv_status_ok)
@@ -76,6 +79,10 @@ zsv_csv_writer zsvsheet_transformation_writer(zsvsheet_transformation trn) {
   return trn->writer;
 }
 
-char *zsvsheet_transformation_filename(zsvsheet_transformation trn) {
+const char *zsvsheet_transformation_filename(zsvsheet_transformation trn) {
   return trn->output_filename;
+}
+
+void *zsvsheet_transformation_user_context(zsvsheet_transformation trn) {
+  return trn->user_context;
 }

--- a/app/sheet/transformation.c
+++ b/app/sheet/transformation.c
@@ -1,0 +1,81 @@
+#include <stdlib.h>
+
+#include "transformation.h"
+#include "zsv/utils/file.h"
+#include "zsv/utils/prop.h"
+
+struct zsvsheet_transformation {
+  zsv_parser parser;
+  zsv_csv_writer writer;
+  char *output_filename;
+  FILE *output_stream;
+  struct zsvsheet_transformation_opts opts;
+};
+
+enum zsv_status zsvsheet_transformation_new(struct zsvsheet_transformation_opts opts, zsvsheet_transformation *out) {
+  unsigned char temp_buff[8196];
+  char *temp_filename = NULL;
+  FILE *temp_f = NULL;
+  zsv_csv_writer temp_file_writer = NULL;
+  enum zsv_status zst = zsv_status_memory;
+
+  struct zsvsheet_transformation *trn = calloc(1, sizeof(*trn));
+  if (trn == NULL)
+    return zst;
+
+  zst = zsv_status_error;
+
+  temp_filename = zsv_get_temp_filename("zsvsheet_filter_XXXXXXXX");
+  if (!temp_filename)
+    return zst;
+  trn->output_filename = temp_filename;
+
+  struct zsv_csv_writer_options writer_opts = {0};
+  if (!(writer_opts.stream = temp_f = fopen(temp_filename, "w+")))
+    goto free;
+  if (!(temp_file_writer = zsv_writer_new(&writer_opts)))
+    goto free;
+
+  zsv_writer_set_temp_buff(temp_file_writer, temp_buff, sizeof(temp_buff));
+  trn->writer = temp_file_writer;
+  trn->output_stream = temp_f;
+
+  zst = zsv_new_with_properties(&opts.zsv_opts, opts.custom_prop_handler, opts.input_filename, NULL, &trn->parser);
+  if (zst != zsv_status_ok)
+    goto free;
+
+  *out = trn;
+  return zst;
+
+free:
+  if (trn)
+    free(trn);
+  if (temp_filename)
+    free(temp_filename);
+  if (temp_f)
+    fclose(temp_f);
+  if (temp_file_writer)
+    zsv_writer_delete(temp_file_writer);
+
+  return zst;
+}
+
+void zsvsheet_transformation_delete(zsvsheet_transformation trn) {
+  zsv_writer_delete(trn->writer);
+  zsv_delete(trn->parser);
+  free(trn->output_filename);
+  fclose(trn->output_stream);
+  free(trn);
+}
+
+zsv_parser zsvsheet_transformation_parser(zsvsheet_transformation trn) {
+  return trn->parser;
+}
+
+zsv_csv_writer zsvsheet_transformation_writer(zsvsheet_transformation trn) {
+  return trn->writer;
+}
+
+char *zsvsheet_transformation_filename(zsvsheet_transformation trn) {
+  return trn->output_filename;
+}

--- a/app/sheet/transformation.h
+++ b/app/sheet/transformation.h
@@ -3,8 +3,7 @@
 
 #include "zsv.h"
 #include "zsv/utils/writer.h"
-
-typedef struct zsvsheet_transformation *zsvsheet_transformation;
+#include "zsv/ext/sheet.h"
 
 struct zsvsheet_transformation_opts {
   /**
@@ -21,6 +20,7 @@ void zsvsheet_transformation_delete(zsvsheet_transformation);
 
 zsv_parser zsvsheet_transformation_parser(zsvsheet_transformation);
 zsv_csv_writer zsvsheet_transformation_writer(zsvsheet_transformation);
-char *zsvsheet_transformation_filename(zsvsheet_transformation);
+const char *zsvsheet_transformation_filename(zsvsheet_transformation);
+void *zsvsheet_transformation_user_context(zsvsheet_transformation trn);
 
 #endif

--- a/app/sheet/transformation.h
+++ b/app/sheet/transformation.h
@@ -1,0 +1,26 @@
+#ifndef ZSVSHEET_TRANSFORMATION_H
+#define ZSVSHEET_TRANSFORMATION_H
+
+#include "zsv.h"
+#include "zsv/utils/writer.h"
+
+typedef struct zsvsheet_transformation *zsvsheet_transformation;
+
+struct zsvsheet_transformation_opts {
+  /**
+   * As usual the zsv_opts used during parsing, but note that the
+   * ctx passed to the row_handler is wrapped in zsvsheet_transformation.
+   */
+  struct zsv_opts zsv_opts;
+  struct zsv_prop_handler *custom_prop_handler;
+  const char *input_filename;
+};
+
+enum zsv_status zsvsheet_transformation_new(struct zsvsheet_transformation_opts, zsvsheet_transformation *);
+void zsvsheet_transformation_delete(zsvsheet_transformation);
+
+zsv_parser zsvsheet_transformation_parser(zsvsheet_transformation);
+zsv_csv_writer zsvsheet_transformation_writer(zsvsheet_transformation);
+char *zsvsheet_transformation_filename(zsvsheet_transformation);
+
+#endif

--- a/app/sheet/ui_buffer.c
+++ b/app/sheet/ui_buffer.c
@@ -45,6 +45,8 @@ struct zsvsheet_ui_buffer {
   unsigned char _ : 3;
 };
 
+// TODO: need to wait for any threads with references to this UI buffer, e.g. transformation or
+//       indexer
 void zsvsheet_ui_buffer_delete(struct zsvsheet_ui_buffer *ub) {
   if (ub) {
     if (ub->ext_on_close)

--- a/include/zsv/ext.h
+++ b/include/zsv/ext.h
@@ -17,6 +17,7 @@
 #include "ext/sheet.h"
 #include "utils/sql.h"
 #include "utils/prop.h"
+#include "utils/writer.h"
 
 /**
  * @file ext.h
@@ -255,6 +256,36 @@ struct zsv_ext_callbacks {
                              struct zsv_prop_handler *custom_prop_handler, const char *opts_used);
   void (*ext_sqlite3_db_delete)(zsv_sqlite3_db_t);
   zsv_sqlite3_db_t (*ext_sqlite3_db_new)(struct zsv_sqlite3_dbopts *dbopts);
+
+  /**
+   * Create a new buffer from the current one using a transformation
+   * and make the new buffer the current one
+   */
+  zsvsheet_status (*ext_sheet_push_transformation)(zsvsheet_proc_context_t ctx, void *user_context,
+                                                   void (*row_handler)(void *ctx));
+
+  /**
+   * Get the writer associated with a transformation.
+   *
+   * The transformation itself is passed as the context variable to the row handler
+   */
+  zsv_csv_writer (*ext_sheet_transformation_writer)(zsvsheet_transformation trn);
+
+  /**
+   * Get the user provided context from the context provided to a transformation row handler
+   */
+  void *(*ext_sheet_transformation_user_context)(zsvsheet_transformation trn);
+
+  /**
+   * Get the parser from the context provided to a transformation row handler
+   */
+  zsv_parser (*ext_sheet_transformation_parser)(zsvsheet_transformation trn);
+
+  /**
+   * Get the filename that the transformation writer outputs to from the context provided to a transformation row
+   * handler.
+   */
+  const char *(*ext_sheet_transformation_filename)(zsvsheet_transformation trn);
 };
 
 /** @} */

--- a/include/zsv/ext/sheet.h
+++ b/include/zsv/ext/sheet.h
@@ -21,4 +21,6 @@ typedef struct zsvsheet_subcommand_context *zsvsheet_subcommand_context_t;
 typedef void *zsvsheet_buffer_t;
 // int zsvsheet_ext_keypress(zsvsheet_proc_context_t);
 
+typedef struct zsvsheet_transformation *zsvsheet_transformation;
+
 #endif


### PR DESCRIPTION
The first two commits refactor the current index filter code. This actually
introduces more lines of code than it saves, but decouples the filtering from
the indexing a little.

The last commit adds a higher level API for extensions to use on top of the first. An example of what this API looks like is below, this adds an extra column to the active buffer counting the rows.
```c
// Similar to a regular ZSV row handler used in ext_parse_all
void my_transformer_row_handler(void *ctx) {
  zsvsheet_transformation trn = ctx;
  struct transformation_context *priv = zsv_cb.ext_sheet_transformation_user_context(trn);
  zsv_parser parser = zsv_cb.ext_sheet_transformation_parser(trn);
  zsv_csv_writer writer = zsv_cb.ext_sheet_transformation_writer(trn);

  size_t j = zsv_cb.cell_count(parser);
  for (size_t i = 0; i < j; i++) {
    struct zsv_cell c = zsv_cb.get_cell(parser, i);
    zsv_writer_cell(writer, i == 0, c.str, c.len, c.quoted);
  }

  priv->col_count += j;

  if (!priv->row_count)
    zsv_writer_cell_s(writer, 0, (const unsigned char *)"Column count", 0);
  else
    zsv_writer_cell_zu(writer, 0, priv->col_count);

  priv->row_count++;
}

zsvsheet_status my_transformer_command_handler(zsvsheet_proc_context_t ctx) {
  struct transformation_context my_ctx = {
    .col_count = 0,
    .row_count = 0,
  };

  // TODO: This probably should happen in another worker thread and while that is happening the status should display
  //       that some work is in progress. The extension author will maybe want to have control over the status message.
  return zsv_cb.ext_sheet_push_transformation(ctx, &my_ctx, my_transformer_row_handler);
}
```

TODO (either in this PR or another):
- [ ] run the transformation in a background thread and keep the user updated by changing the status
- [x] figure out where custom_prop_handler and opts_used should come from?
- [ ] tests