### PR TITLE
fix recent bug in writer that closed stream, which should be left to caller to manage

### DIFF
--- a/app/utils/writer.c
+++ b/app/utils/writer.c
@@ -196,10 +196,12 @@ enum zsv_writer_status zsv_writer_delete(zsv_csv_writer w) {
   if (w->started)
     w->out.write("\n", 1, 1, w->out.stream);
 
+  /* closing the stream should be handled by whatever code first opened the stream
   if (w->out.stream && w->out.stream != stdout) {
     fclose(w->out.stream);
     w->out.stream = NULL;
   }
+  */
 
   if (w->out.buff)
     free(w->out.buff);


### PR DESCRIPTION
in addition, there is no assurance that w->out.stream is a FILE * or that we can otherwise assume that `fclose` is the correct way to close it

@iamazeem obviously this change was made for a reason-- please examine and make the appropriate changes to resolve while handling all stream closure outside of zsv_writer_delete().

In otherwords, zsv_writer_delete() should not close anything that was not opened by zsv_writer_new() (or any other zsv_writer function)