### PR TITLE
Fix 2db command usage

### DIFF
--- a/app/2db.c
+++ b/app/2db.c
@@ -649,7 +649,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
   const char *usage[] = {
     APPNAME ": convert JSON to SQLite3 DB",
     "",
-    "Usage: " APPNAME " -o <filename> [-t <table>] [input.json]\n",
+    "Usage: " APPNAME " -o <filename> [-t <table>] [input.json]",
     "",
     "Options:",
     "  -h,--help              : show usage",

--- a/app/2db.c
+++ b/app/2db.c
@@ -649,12 +649,13 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
   const char *usage[] = {
     APPNAME ": convert JSON to SQLite3 DB",
     "",
-    "Usage: " APPNAME " -o <output path> [-t <table name>] [input.json]\n",
+    "Usage: " APPNAME " -o <filename> [-t <table>] [input.json]\n",
     "",
     "Options:",
-    "  -h,--help            : show usage",
-    "  --table <table_name> : save as specified table name",
-    "  --overwrite          : overwrite existing database",
+    "  -h,--help              : show usage",
+    "  -t,--table <table>     : save as specified table name",
+    "  --overwrite            : overwrite existing database",
+    "  -o,--output <filename> : filename to save database",
     // TO DO:
     // --sql to output sql statements
     // --append: append to existing db
@@ -691,7 +692,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
         opts.db_fn = (char *)argv[i]; // we won't free this
     } else if (!strcmp(argv[i], "--overwrite")) {
       opts.overwrite = 1;
-    } else if (!strcmp(argv[i], "--table")) {
+    } else if (!strcmp(argv[i], "-t") || !strcmp(argv[i], "--table")) {
       if (++i >= argc)
         fprintf(stderr, "%s option requires a filename value\n", argv[i - 1]), err = 1;
       else if (opts.table_name)

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -707,7 +707,7 @@ test-sheet-11: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv
 	@(tmux new-session -x 80 -y 50 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
 	sleep 0.5 && \
 	tmux send-keys -t $@ -N 21 "C-d" && \
-	sleep 1 && \
+	sleep 1.5 && \
 	tmux capture-pane -t $@ -p ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	tmux send-keys -t $@ "q" && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || (echo 'Incorrect output:' && cat ${TMP_DIR}/$@.out && ${TEST_FAIL}))


### PR DESCRIPTION
- Add missing handling of `-t` short flag
- Add missing output flags in usage text

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>