### PR TITLE
Add documentation file for `overwrite` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ that implements the expected
     `jq`, `prop`, `rm`
   - easily [convert between CSV/JSON/sqlite3](docs/csv_json_sqlite.md)
   - [compare multiple files](docs/compare.md)
+  - [overwrite cells in files](docs/overwrite.md)
 - CLI is easy to extend/customize with a few lines of code via modular plug-in
   framework. Just write a few custom functions and compile into a distributable
   DLL that any existing zsv installation can use.

--- a/data/bulkdata.csv
+++ b/data/bulkdata.csv
@@ -1,0 +1,9 @@
+row,col,value,timestamp
+1,2,Saudi Arabia,1733283235
+1,7,Kuwait,1733283102
+2,3,Israel,1733282194
+2,7,Jordan,1733258125
+2,2,Palestine,1733285225
+2,5,Iraq,1733284211
+3,3,Georgia,1733284010
+3,4,Azerbaijan,1733285510

--- a/data/mydata.csv
+++ b/data/mydata.csv
@@ -1,0 +1,8 @@
+Arabian,Fertile Crescent,South Caucasus
+Kuwait,Iraq,Armenia
+Oman,Jordan,Azerbaijan
+Qatar,Lebanon,Georgia
+Yemen,Palestine
+Bahrain,Syria
+Saudi Arabia,Israel
+United Arab Emirates

--- a/docs/overwrite.md
+++ b/docs/overwrite.md
@@ -111,7 +111,11 @@ Example layout of a bulk file [bulkdata.csv](../data/bulkdata.csv):
 
 bulk-add would add overwrites to the overwrite file, where bulk-remove would remove matching overwrites from the overwrite file.
 
-Table after adding the bulk overwrites above:
+```sh
+overwrite mydata.csv bulk-add bulkdata.csv
+select mydata.csv --apply-overwrites
+```
+Output:
 | Arabian 	       | Fertile Crescent | South Caucasus |
 | ---------------- | ---------------- | -------------- |
 | Saudi Arabia     | Palestine	      | Armenia        |
@@ -122,7 +126,11 @@ Table after adding the bulk overwrites above:
 | Saudi Arabia     | Jordan		      |   	           |
 | Kuwait 	       |       		      | 	           |
 
-If we now use the list command to display all of the overwrites after running bulk-add, the output would look like this (corresponds to the bulk overwrites file):
+Now we can list the overwrites
+```sh
+overwrite mydata.csv list
+```
+Output:
 ```
 row,column,value,timestamp,author
 1,2,Saudi Arabia,1733283235,
@@ -135,8 +143,15 @@ row,column,value,timestamp,author
 3,4,Azerbaijan,1733285510,
 ```
 
-If bulk remove was applied on the new overwrites, it would remove each of the new overwrites, leaving an empty overwrite table.
-
+Applying bulk-remove
+```sh
+overwrite mydata.csv bulk-remove bulkdata.csv
+overwrite mydata.csv list
+```
+Output:
+```
+row,column,value,timestamp,author
+```
 
 ### Basic Overwrite operations
 
@@ -145,8 +160,9 @@ To add an overwrite entry that changes the value in cell B2:
 To add a value:
 ```sh
 overwrite mydata.csv add B2 "Syria"
+select mydata.csv --apply-overwrites
 ```
-The table above after adding this overwrite:
+Output:
 | Arabian 	           | Fertile Crescent | South Caucasus |
 | -------------------- | ------------     | -------------- |
 | Kuwait               | Syria   	      | Armenia        |
@@ -160,14 +176,26 @@ The table above after adding this overwrite:
 To remove the added value:
 ```sh
 overwrite mydata.csv remove B2
+select mydata.csv --apply-overwrites
 ```
-The table would then be the same as the original table.
+Output:
+| Arabian 	           | Fertile Crescent | South Caucasus |
+| -------------------- | ------------     | -------------- |
+| Kuwait               | Iraq   	      | Armenia        |
+| Oman   	           | Jordan   	      | Azerbaijan     |
+| Qatar     	       | Lebanon   	      | Georgia        |
+| Yemen   	           | Palestine        |	               |
+| Bahrain   	       | Syria   	      |  	           |
+| Saudi Arabia         | Israel   	      |   	           |
+| United Arab Emirates |       		      | 	           |
 
-To force add a value, even if there is already a value in that cell:
+To force add a value, even if there is already a value in that cell.
+This overwrites the original value in B2 with the new selected value.
 ```sh
 overwrite mydata.csv add B2 "Lebanon" --force
+select mydata.csv --apply-overwrites
 ```
-After applying this overwrite:
+Output:
 | Arabian 	           | Fertile Crescent | South Caucasus |
 | -------------------- | ------------     | -------------- |
 | Kuwait               | Lebanon   	      | Armenia        |
@@ -177,14 +205,14 @@ After applying this overwrite:
 | Bahrain   	       | Syria   	      |  	           |
 | Saudi Arabia         | Israel   	      |   	           |
 | United Arab Emirates |       		      | 	           |
-This overwrites the original value in B2 with the new selected value.
 
 To remove/add a value, depending on the old value at the cell position.
 This will only trigger if the existing value is "Azerbaijan":
 ```sh
 overwrite mydata.csv add C3 "India" --old-value "Azerbaijan"
+select mydata.csv --apply-overwrites
 ```
-After applying this overwrite:
+Output:
 | Arabian 	           | Fertile Crescent | South Caucasus |
 | -------------------- | ------------     | -------------- |
 | Kuwait               | Iraq   	      | Armenia        |
@@ -198,15 +226,27 @@ After applying this overwrite:
 Alternatively, if the old value was not the same as the value in the table.
 ```sh
 overwrite mydata.csv add C3 "Pakistan" --old-value "Armenia"
+select mydata.csv --apply-overwrites
 ```
-The table would then not change.
+The output would remain the same, as no values would be changed.
 
 To remove all overwrites and delete the SQLite file:
 ```sh
 overwrite mydata.csv remove --all
+select mydata.csv --apply-overwrites
 ```
-The table will then revert to the original state, and the SQLite file would be removed. The CSV file would look like
-the original one above.
+Output:
+| Arabian 	           | Fertile Crescent | South Caucasus |
+| -------------------- | ------------     | -------------- |
+| Kuwait               | Iraq   	      | Armenia        |
+| Oman   	           | Jordan   	      | Azerbaijan     |
+| Qatar     	       | Lebanon   	      | Georgia        |
+| Yemen   	           | Palestine        |	               |
+| Bahrain   	       | Syria   	      |  	           |
+| Saudi Arabia         | Israel   	      |   	           |
+| United Arab Emirates |       		      | 	           |
+The table now looks like the original table.
+
 
 ## File Storage
 

--- a/docs/overwrite.md
+++ b/docs/overwrite.md
@@ -1,0 +1,210 @@
+# Overwrite - Manage Overwrites Associated with a CSV File
+
+The `overwrite` utility allows you to manage a list of "overwrites" associated with a given CSV input file. Each overwrite entry is a tuple consisting of row, column, original value, and new value, along with optional timestamp and author metadata.
+
+## Usage
+
+```shell
+overwrite <file> <command> [arguments] [options]
+```
+
+### Commands
+
+**List**  
+Display all saved overwrite entries.
+
+**Add**  
+`add <cell> <value>`  
+Add an overwrite entry.  
+Option for either row-col style cells, or Excel A1 style.
+Examples:  
+1. Overwrite the first column of the first non-header row:  
+   ```sh
+   overwrite mydata.csv add B2 "new value"
+   ```  
+   or  
+   ```sh
+   overwrite mydata.csv add 1-1 "new value"
+   ```
+
+2. Change the header in the second column to "ID #":  
+   ```sh
+   overwrite mydata.csv add B1 "ID #"
+   ```  
+   or  
+   ```sh
+   overwrite mydata.csv add 0-1 "ID #"
+   ```
+
+**Remove**  
+`remove <cell>`  
+Remove an overwrite entry.
+Similar to add for examples, without value.
+
+**Clear**  
+`clear`
+Remove any or all overwrites.
+
+**Bulk Add**  
+`bulk-add <datafile>`  
+Bulk add overwrite entries from a CSV or JSON file.
+
+**Bulk Remove**  
+`bulk-remove <datafile>`  
+Bulk remove overwrite entries from a CSV or JSON file.
+
+### Note:
+JSON not currently supported.
+
+### Options
+
+- **-h, --help**  
+  Show this help message.
+
+- **--old-value <value>**  
+  For `add` or `remove`, only proceed if the current overwrite value matches the given value at the given cell.
+
+- **--force**  
+  - For `add`, proceed even if an overwrite for the specified cell already exists.  
+  - For `remove`, exit without error even if no overwrite for the specified cell already exists.
+
+- **--no-timestamp**  
+  For `add`, do not save a timestamp when adding an overwrite.
+
+- **--all**  
+  For `remove`, remove all overwrites and delete the SQLite file.
+
+- **--A1**  
+  For `list`, display addresses in A1-notation.
+
+## Description
+
+Overwrite data for a given input file `/path/to/my-data.csv` is stored in the "overwrites" table of `/path/to/.zsv/data/my-data.csv/overwrite.sqlite3`.
+
+For bulk operations, the data file must be a CSV with "row", "col," and "value" columns and may optionally include "old value," "timestamp," and/or "author."
+
+## Examples
+
+Example CSV file (mydata.csv):
+| Arabian 	       | Fertile Crescent | South Caucasus |
+| -------------------- | ---------------- | -------------- |
+| Kuwait               | Iraq   	  | Armenia        |
+| Oman   	       | Jordan   	  | Azerbaijan     |
+| Qatar     	       | Lebanon   	  | Georgia        |
+| Yemen   	       | Palestine   	  |	           |
+| Bahrain   	       | Syria   	  |  	           |
+| Saudi Arabia         | Israel   	  |   	           |
+| United Arab Emirates |       		  | 	           |
+
+### Bulk Overwrite operations
+Example layout of a bulk file:
+
+| row | col | value        | timestamp  |
+| --- | --- | ------------ | ---------- |
+| 1   | 2   | Saudi Arabia | 1733283235 |
+| 1   | 7   | Kuwait 	   | 1733283102 |
+| 2   | 3   | Israel 	   | 1733282194 |
+| 2   | 7   | Jordan 	   | 1733258125 |
+| 2   | 2   | Palestine    | 1733285225 |
+| 2   | 5   | Iraq 	   | 1733284211 |
+| 3   | 3   | Georgia 	   | 1733284010 |
+| 3   | 4   | Azerbaijan   | 1733285510 | 
+
+bulk-add would add overwrites to the overwrite file, where bulk-remove would remove matching overwrites from the overwrite file.
+
+### Basic Overwrite operations
+
+To add an overwrite entry that changes the value in cell B2:
+
+To add a value:
+```sh
+overwrite mydata.csv add B2 "Syria"
+```
+
+To remove the added value:
+```sh
+overwrite mydata.csv remove B2
+```
+
+To force add a value, even if there is already a value in that cell:
+```sh
+overwrite mydata.csv add B2 "Lebanon" --force
+```
+
+To remove/add a value, depending on the old value at the cell position.
+This will only trigger if the existing value is "Lebanon":
+```sh
+overwrite mydata.csv add B2 "Jordan" --old-value "Lebanon"
+```
+
+Table after all overwrites above are applied:
+| Arabian 	       | Fertile Crescent | South Caucasus |
+| -------------------- | ---------------- | -------------- |
+| Saudi Arabia         | Lebanon	  | Armenia        |
+| Oman   	       | Israel 	  | Georgia	   |
+| Qatar     	       | Lebanon   	  | Azerbaijan	   |
+| Yemen   	       | Iraq   	  |	           |
+| Bahrain   	       | Syria   	  |  	           |
+| Saudi Arabia         | Jordan		  |   	           |
+| Kuwait 	       |       		  | 	           |
+
+To remove all overwrites and delete the SQLite file:
+```sh
+overwrite mydata.csv remove --all
+```
+The table will then revert to the original state
+
+## File Storage
+
+Overwrite data is stored in a dedicated SQLite database for each input file. The SQL operations are optimized for performance, by limiting the number of operations.
+The SQLite file gets automatically created when a new overwrite is initialized, and is organized based on the input filename.
+
+## Usage Details
+```
+zsv overwrite -h
+
+Usage:
+  overwrite <file> <command> [arguments] [options]
+
+Commands (where <cell> can be <row>-<col> or an Excel-style address):
+  list                   : Display all saved overwrite entries
+  add <cell> <value>     : Add an overwrite entry
+                           Example 1: overwrite the first column of the first
+                           non-header row
+                             overwrite mydata.csv add B2 "new value"
+                               - or -
+                             overwrite mydata.csv add 1-1 "new value"
+                           Example 2: change the header in the second column
+                           to "ID #"
+                             overwrite mydata.csv add B1 "new value"
+                               - or -
+                             overwrite mydata.csv add 0-1 "ID #"
+  remove <cell>          : Remove an overwrite entry
+  clear                  : Remove any / all overwrites
+  bulk-add <datafile>    : Bulk add overwrite entries from a CSV or JSON file
+  bulk-remove <datafile> : Bulk remove overwrite entries from a CSV or JSON file
+
+Options:
+  -h,--help              : Show this help message
+  --old-value <value>    : For `add` or `remove`, only proceed if the old value
+                           matches the given value
+  --force.               : For `add`, proceed even if an overwrite for the specified
+                           cell already exists
+                           For `remove`, exit without error even if no overwrite for
+                           the specified cell already exists
+  --no-timestamp.        : For `add`, don't save timestamp when adding an overwrite
+  --all                  : For `remove`, remove all overwrites and delete sqlite file
+  --A1                   : For `list`, Display addresses in A1-notation
+
+Description:
+  The  `overwrite`  utility  allows  you to manage a list of "overwrites" associated
+  with a given CSV input file. Each overwrite entry is a tuple consisting  of  row,
+  column,  original  value, and new value, along with optional timestamp and author
+  metadata.
+
+  Overwrite data for a given input file `/path/to/my-data.csv` is stored in the "over‐
+  writes"  table  of  `/path/to/.zsv/data/my-data.csv/overwrite.sqlite3`.
+
+  For bulk operations, the data file must be a CSV with "row", "col" and "value" columns
+  and may optionally include "old value", "timestamp" and/or "author"
+```

--- a/docs/overwrite.md
+++ b/docs/overwrite.md
@@ -11,7 +11,8 @@ overwrite <file> <command> [arguments] [options]
 ### Commands
 
 **List**  
-Display all saved overwrite entries.
+`list`  
+List all overwrites in the overwrites file.
 
 **Add**  
 `add <cell> <value>`  
@@ -45,17 +46,11 @@ Similar to add for examples, without value.
 `clear`
 Remove any or all overwrites.
 
-**Bulk Add**  
+**Bulk Operations**
 `bulk-add <datafile>`  
-Bulk add overwrite entries from a CSV or JSON file.
-
-**Bulk Remove**  
+or
 `bulk-remove <datafile>`  
-Bulk remove overwrite entries from a CSV or JSON file.
-
-**List**  
-`list`  
-List all overwrites in the overwrites file.
+Bulk operations add or remove overwrite entries from a CSV or JSON file.
 
 **Note:**
 JSON not currently supported.
@@ -89,19 +84,19 @@ For bulk operations, the data file must be a CSV with "row", "col," and "value" 
 
 ## Examples
 
-Example CSV file (mydata.csv):
-| Arabian 	       | Fertile Crescent | South Caucasus |
-| -------------------- | ---------------- | -------------- |
-| Kuwait               | Iraq   	  | Armenia        |
-| Oman   	       | Jordan   	  | Azerbaijan     |
-| Qatar     	       | Lebanon   	  | Georgia        |
-| Yemen   	       | Palestine   	  |	           |
-| Bahrain   	       | Syria   	  |  	           |
-| Saudi Arabia         | Israel   	  |   	           |
-| United Arab Emirates |       		  | 	           |
+Example CSV file ([mydata.csv](../data/mydata.csv)):
+| Arabian 	           | Fertile Crescent | South Caucasus |
+| -------------------- | ------------     | -------------- |
+| Kuwait               | Iraq   	      | Armenia        |
+| Oman   	           | Jordan   	      | Azerbaijan     |
+| Qatar     	       | Lebanon   	      | Georgia        |
+| Yemen   	           | Palestine        |	               |
+| Bahrain   	       | Syria   	      |  	           |
+| Saudi Arabia         | Israel   	      |   	           |
+| United Arab Emirates |       		      | 	           |
 
 ### Bulk Overwrite operations
-Example layout of a bulk file:
+Example layout of a bulk file [bulkdata.csv](../data/bulkdata.csv):
 
 | row | col | value        | timestamp  |
 | --- | --- | ------------ | ---------- |
@@ -110,11 +105,38 @@ Example layout of a bulk file:
 | 2   | 3   | Israel 	   | 1733282194 |
 | 2   | 7   | Jordan 	   | 1733258125 |
 | 2   | 2   | Palestine    | 1733285225 |
-| 2   | 5   | Iraq 	   | 1733284211 |
+| 2   | 5   | Iraq 	       | 1733284211 |
 | 3   | 3   | Georgia 	   | 1733284010 |
 | 3   | 4   | Azerbaijan   | 1733285510 | 
 
 bulk-add would add overwrites to the overwrite file, where bulk-remove would remove matching overwrites from the overwrite file.
+
+Table after adding the bulk overwrites above:
+| Arabian 	       | Fertile Crescent | South Caucasus |
+| ---------------- | ---------------- | -------------- |
+| Saudi Arabia     | Palestine	      | Armenia        |
+| Oman   	       | Israel 	      | Georgia	       |
+| Qatar     	   | Lebanon   	      | Azerbaijan	   |
+| Yemen   	       | Iraq   	      |	               |
+| Bahrain   	   | Syria   	      |  	           |
+| Saudi Arabia     | Jordan		      |   	           |
+| Kuwait 	       |       		      | 	           |
+
+If we now use the list command to display all of the overwrites after running bulk-add, the output would like like this:
+```
+row,column,value,timestamp,author
+1,2,Saudi Arabia,1733283235,
+1,7,Kuwait,1733283102,
+2,2,Palestine,1733285225,
+2,3,Israel,1733282194,
+2,5,Iraq,1733284211,
+2,7,Jordan,1733258125,
+3,3,Georgia,1733284010,
+3,4,Azerbaijan,1733285510,
+```
+
+If bulk remove was applied on the new overwrites, it would remove each of the new overwrites, leaving an empty overwrite table.
+
 
 ### Basic Overwrite operations
 
@@ -124,11 +146,22 @@ To add a value:
 ```sh
 overwrite mydata.csv add B2 "Syria"
 ```
+The table above after adding this overwrite:
+| Arabian 	           | Fertile Crescent | South Caucasus |
+| -------------------- | ------------     | -------------- |
+| Kuwait               | Syria   	      | Armenia        |
+| Oman   	           | Jordan   	      | Azerbaijan     |
+| Qatar     	       | Lebanon   	      | Georgia        |
+| Yemen   	           | Palestine        |	               |
+| Bahrain   	       | Syria   	      |  	           |
+| Saudi Arabia         | Israel   	      |   	           |
+| United Arab Emirates |       		      | 	           |
 
 To remove the added value:
 ```sh
 overwrite mydata.csv remove B2
 ```
+The table would then be the same as the original table.
 
 To force add a value, even if there is already a value in that cell:
 ```sh
@@ -138,25 +171,31 @@ overwrite mydata.csv add B2 "Lebanon" --force
 To remove/add a value, depending on the old value at the cell position.
 This will only trigger if the existing value is "Lebanon":
 ```sh
-overwrite mydata.csv add B2 "Jordan" --old-value "Lebanon"
+overwrite mydata.csv add C3 "India" --old-value "Azerbaijan"
 ```
+After applying this overwrite:
+| Arabian 	           | Fertile Crescent | South Caucasus |
+| -------------------- | ------------     | -------------- |
+| Kuwait               | Iraq   	      | Armenia        |
+| Oman   	           | Jordan   	      | India          |
+| Qatar     	       | Lebanon   	      | Georgia        |
+| Yemen   	           | Palestine        |	               |
+| Bahrain   	       | Syria   	      |  	           |
+| Saudi Arabia         | Israel   	      |   	           |
+| United Arab Emirates |       		      | 	           |
 
-Table after all overwrites above are applied:
-| Arabian 	       | Fertile Crescent | South Caucasus |
-| -------------------- | ---------------- | -------------- |
-| Saudi Arabia         | Lebanon	  | Armenia        |
-| Oman   	       | Israel 	  | Georgia	   |
-| Qatar     	       | Lebanon   	  | Azerbaijan	   |
-| Yemen   	       | Iraq   	  |	           |
-| Bahrain   	       | Syria   	  |  	           |
-| Saudi Arabia         | Jordan		  |   	           |
-| Kuwait 	       |       		  | 	           |
+Alternatively, if the old value was not the same as the value in the table.
+```sh
+overwrite mydata.csv add C3 "Pakistan" --old-value "Armenia"
+```
+The table would then not change.
 
 To remove all overwrites and delete the SQLite file:
 ```sh
 overwrite mydata.csv remove --all
 ```
-The table will then revert to the original state
+The table will then revert to the original state, and the SQLite file would be removed. The CSV file would look like
+the original one above.
 
 ## File Storage
 

--- a/docs/overwrite.md
+++ b/docs/overwrite.md
@@ -122,7 +122,7 @@ Table after adding the bulk overwrites above:
 | Saudi Arabia     | Jordan		      |   	           |
 | Kuwait 	       |       		      | 	           |
 
-If we now use the list command to display all of the overwrites after running bulk-add, the output would like like this:
+If we now use the list command to display all of the overwrites after running bulk-add, the output would look like this (corresponds to the bulk overwrites file):
 ```
 row,column,value,timestamp,author
 1,2,Saudi Arabia,1733283235,
@@ -167,9 +167,20 @@ To force add a value, even if there is already a value in that cell:
 ```sh
 overwrite mydata.csv add B2 "Lebanon" --force
 ```
+After applying this overwrite:
+| Arabian 	           | Fertile Crescent | South Caucasus |
+| -------------------- | ------------     | -------------- |
+| Kuwait               | Lebanon   	      | Armenia        |
+| Oman   	           | Jordan   	      | India          |
+| Qatar     	       | Lebanon   	      | Georgia        |
+| Yemen   	           | Palestine        |	               |
+| Bahrain   	       | Syria   	      |  	           |
+| Saudi Arabia         | Israel   	      |   	           |
+| United Arab Emirates |       		      | 	           |
+This overwrites the original value in B2 with the new selected value.
 
 To remove/add a value, depending on the old value at the cell position.
-This will only trigger if the existing value is "Lebanon":
+This will only trigger if the existing value is "Azerbaijan":
 ```sh
 overwrite mydata.csv add C3 "India" --old-value "Azerbaijan"
 ```

--- a/docs/overwrite.md
+++ b/docs/overwrite.md
@@ -1,6 +1,6 @@
 # Overwrite - Manage Overwrites Associated with a CSV File
 
-The `overwrite` utility allows you to manage a list of "overwrites" associated with a given CSV input file. Each overwrite entry is a tuple consisting of row, column, original value, and new value, along with optional timestamp and author metadata.
+The `overwrite` utility allows you to manage a list of "overwrites" associated with a given CSV input file. Each overwrite entry is a tuple consisting of row, column, and new value, along with optional timestamp and author metadata.
 
 ## Usage
 
@@ -53,7 +53,11 @@ Bulk add overwrite entries from a CSV or JSON file.
 `bulk-remove <datafile>`  
 Bulk remove overwrite entries from a CSV or JSON file.
 
-### Note:
+**List**  
+`list`  
+List all overwrites in the overwrites file.
+
+**Note:**
 JSON not currently supported.
 
 ### Options


### PR DESCRIPTION
The pull request is simple, it just adds a file which documents the usage of the `overwrite` command. Similar to the `docs/compare.md` documentation file.

There is a basic overview of the functionality, basic usage and layout of commands and options, a description of the command, examples of how the command works (with input and output data), an explanation of the SQLite database, and the help message for the command.