### PR TITLE
add --apply-overwrites option description to help message

### DIFF
--- a/app/builtin/help.c
+++ b/app/builtin/help.c
@@ -54,6 +54,9 @@ static int main_help(int argc, const char *argv[]) {
     "  -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows",
     "  -0,--header-row <header> : insert the provided CSV as the first row (in position 0)",
     "                             e.g. --header-row 'col1,col2,\"my col 3\"'",
+#ifdef ZSV_EXTRAS
+    "  -1,--apply-overwrites    : automatically apply cached overwrites",
+#endif
     "  -v,--verbose             : verbose output",
     "",
     "Commands that parse CSV or other tabular data:",

--- a/app/ext_example/test/expected/zsvext-test-3.out
+++ b/app/ext_example/test/expected/zsvext-test-3.out
@@ -32,6 +32,7 @@ Options common to all commands except `prop`, `rm` and `jq`:
   -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows
   -0,--header-row <header> : insert the provided CSV as the first row (in position 0)
                              e.g. --header-row 'col1,col2,"my col 3"'
+  -1,--apply-overwrites    : automatically apply cached overwrites
   -v,--verbose             : verbose output
 
 Commands that parse CSV or other tabular data:
@@ -91,6 +92,7 @@ Options common to all commands except `prop`, `rm` and `jq`:
   -S,--keep-blank-headers  : disable default behavior of ignoring leading blank rows
   -0,--header-row <header> : insert the provided CSV as the first row (in position 0)
                              e.g. --header-row 'col1,col2,"my col 3"'
+  -1,--apply-overwrites    : automatically apply cached overwrites
   -v,--verbose             : verbose output
 
 Commands that parse CSV or other tabular data:

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -587,6 +587,7 @@ test-sheet: test-%: ${BUILD_DIR}/bin/zsv_%${EXE} worldcitiespop_mil.csv test-she
 
 test-sheet-cleanup:
 	@rm -f tmux-*.log
+	@tmux kill-server || printf ''
 
 test-sheet-all: test-sheet-1 test-sheet-2 test-sheet-3 test-sheet-4 test-sheet-5 test-sheet-6 test-sheet-7 test-sheet-8 test-sheet-9 test-sheet-10 test-sheet-11 test-sheet-12 test-sheet-13 test-sheet-14 test-sheet-prop-cmd-opt
 	@(for SESSION in $^; do ! tmux kill-session -t "$$SESSION" 2>/dev/null; done && ${TEST_PASS} || ${TEST_FAIL})

--- a/app/test/overwrite/Makefile
+++ b/app/test/overwrite/Makefile
@@ -42,7 +42,7 @@ test: test-1 test-2 test-excel-cells test-add test-remove test-old-value test-fo
 
 test-1:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy.csv clear 
+	@${PREFIX} ${EXE} dummy.csv clear
 	@${CHECK} [ "`${EXE} dummy.csv list`" = "row,column,value,timestamp,author" ] && ${TEST_PASS} || ${TEST_FAIL}
 
 TIMESTAMP=$(shell date +"%s")
@@ -50,20 +50,20 @@ HEADER=row,column,value,timestamp,author
 
 test-2:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy.csv clear 
+	@${PREFIX} ${EXE} dummy.csv clear
 	@${PREFIX} ${EXE} dummy.csv add 2-1 ABC --no-timestamp
 	@${CHECK} [ "`${EXE} dummy.csv list`" = "`printf \"$(HEADER)\n2,1,ABC,,\n\"`" ] && ${TEST_PASS} || ${TEST_FAIL}
 
 test-excel-cells:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy.csv clear 
+	@${PREFIX} ${EXE} dummy.csv clear
 	@${PREFIX} ${EXE} dummy.csv add C2 EXCEL --no-timestamp
 	@${CHECK} [ "`${EXE} dummy.csv list`" = "`printf \"$(HEADER)\n1,2,EXCEL,,\n\"`" ] && ${TEST_PASS} || ${TEST_FAIL}
 	@${CHECK} [ "`${EXE} dummy.csv list --A1`" = "`printf \"$(HEADER)\nC2,EXCEL,,\n\"`" ] && ${TEST_PASS} || ${TEST_FAIL}
 
 test-add:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy2.csv clear 
+	@${PREFIX} ${EXE} dummy2.csv clear
 	@${PREFIX} ${EXE} dummy2.csv add 1-2 VAL1 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 2-2 VAL2 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 2-3 VAL3 --no-timestamp
@@ -75,7 +75,7 @@ test-add:
 
 test-remove:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy2.csv clear 
+	@${PREFIX} ${EXE} dummy2.csv clear
 	@${PREFIX} ${EXE} dummy2.csv add 1-1 V1 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 2-1 V2 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 3-1 V3 --no-timestamp
@@ -86,32 +86,32 @@ test-remove:
 	@${PREFIX} ${EXE} dummy2.csv remove 4-1
 	@${CHECK} [ "`${EXE} dummy2.csv list`" = "`printf \"$(HEADER)\n1,1,V1,,\n3,1,V3,,\n\"`" ] \
 		&& ${TEST_PASS} || ${TEST_FAIL}
-	@${PREFIX} ${EXE} dummy2.csv remove --all 
+	@${PREFIX} ${EXE} dummy2.csv remove --all
 	@${CHECK} [ ! -f ".zsv/overwrite/dummy2.csv/overwrite.sqlite3" ] \
 			&& ${TEST_PASS} || ${TEST_FAIL}
 
 test-old-value:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy2.csv clear 
+	@${PREFIX} ${EXE} dummy2.csv clear
 	@${PREFIX} ${EXE} dummy2.csv add 1-1 V1 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 2-1 V2 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 3-1 V3 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 4-1 V4 --no-timestamp
 	@${CHECK} [ "`printf \"$$(${PREFIX} ${EXE} dummy2.csv add 3-1 NEW_V4 --no-timestamp 2>&1)\"`" = "`cat expected/$@-fail.out`" ] \
 		&& ${TEST_PASS} || ${TEST_FAIL}
-	@${PREFIX} ${EXE} dummy2.csv remove 2-1 --old-value V3 
+	@${PREFIX} ${EXE} dummy2.csv remove 2-1 --old-value V3
 	@${CHECK} [ "`${EXE} dummy2.csv list`" = "`printf \"$(HEADER)\n1,1,V1,,\n2,1,V2,,\n3,1,V3,,\n4,1,V4,,\n\"`" ] \
 		&& ${TEST_PASS} || ${TEST_FAIL}
 	@${PREFIX} ${EXE} dummy2.csv add 2-1 NEW_V2 --old-value V2 --no-timestamp
 	@${CHECK} [ "`${EXE} dummy2.csv list`" = "`printf \"$(HEADER)\n1,1,V1,,\n2,1,NEW_V2,,\n3,1,V3,,\n4,1,V4,,\n\"`" ] \
 		&& ${TEST_PASS} || ${TEST_FAIL}
-	@${PREFIX} ${EXE} dummy2.csv remove 3-1 --old-value V3 
+	@${PREFIX} ${EXE} dummy2.csv remove 3-1 --old-value V3
 	@${CHECK} [ "`${EXE} dummy2.csv list`" = "`printf \"$(HEADER)\n1,1,V1,,\n2,1,NEW_V2,,\n4,1,V4,,\n\"`" ] \
 		&& ${TEST_PASS} || ${TEST_FAIL}
 
 test-force:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy2.csv clear 
+	@${PREFIX} ${EXE} dummy2.csv clear
 	@${PREFIX} ${EXE} dummy2.csv add 1-2 VAL1 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 2-2 VAL2 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv add 2-3 VAL3 --no-timestamp
@@ -126,7 +126,7 @@ test-force:
 
 test-bulk-add:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy2.csv clear 
+	@${PREFIX} ${EXE} dummy2.csv clear
 	@${PREFIX} ${EXE} dummy2.csv add 1-1 OLD_V1 --no-timestamp # for old value test
 	@${PREFIX} ${EXE} dummy2.csv add 2-1 OLD_VAL2 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv bulk-add overwrite.csv
@@ -135,7 +135,7 @@ test-bulk-add:
 
 test-bulk-remove:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy2.csv clear 
+	@${PREFIX} ${EXE} dummy2.csv clear
 	@${PREFIX} ${EXE} dummy2.csv add 1-1 OLD_V1 --no-timestamp # for old value test
 	@${PREFIX} ${EXE} dummy2.csv add 2-1 OLD_VAL2 --no-timestamp
 	@${PREFIX} ${EXE} dummy2.csv bulk-add overwrite.csv
@@ -146,24 +146,24 @@ test-bulk-remove:
 STAT_MOD_TS=$(shell if stat -c %Y Makefile >/dev/null 2>/dev/null; then echo 'stat -c %Y' ; else echo 'stat -f %m' ; fi)
 test-timestamp:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy2.csv clear 
+	@${PREFIX} ${EXE} dummy2.csv clear
 	@(${PREFIX} ${EXE} dummy2.csv add 1-2 ABC && ${STAT_MOD_TS} .zsv/data/dummy2.csv/overwrite.sqlite3 > ${TMP_DIR}/timestamp1.txt)
 	@(${PREFIX} ${EXE} dummy2.csv add 1-3 ABC && ${STAT_MOD_TS} .zsv/data/dummy2.csv/overwrite.sqlite3 > ${TMP_DIR}/timestamp2.txt)
 	@{ \
 		EXPECTED_TS1=`cat ${TMP_DIR}/timestamp1.txt`; \
 		EXPECTED_TS2=`cat ${TMP_DIR}/timestamp2.txt`; \
-		LOWER_TS1=$$((EXPECTED_TS1 - 1)); \
-		LOWER_TS2=$$((EXPECTED_TS2 - 1)); \
+		LOWER_TS1=$$((EXPECTED_TS1 - 3)); \
+		LOWER_TS2=$$((EXPECTED_TS2 - 3)); \
 		OUTPUT="`${EXE} dummy2.csv list | tr -d '\n'`"; \
 		echo "$$OUTPUT" | grep -q "${HEADER}1,2,ABC,\($$LOWER_TS1\|$$EXPECTED_TS1\),1,3,ABC,\($$LOWER_TS2\|$$EXPECTED_TS2\)," && ${TEST_PASS} || ${TEST_FAIL}; \
 	}
 
 test-echo-overwrite-auto:
 	@${TEST_INIT}
-	@${PREFIX} ${EXE} dummy.csv clear 
+	@${PREFIX} ${EXE} dummy.csv clear
 	@${PREFIX} ${EXE} dummy.csv add 1-0 ABC
-	@${PREFIX} ${EXE} dummy.csv add 2-2 123 
-	@${ECHO_EXE} --apply-overwrites dummy.csv > ${TMP_DIR}/$@.out 
+	@${PREFIX} ${EXE} dummy.csv add 2-2 123
+	@${ECHO_EXE} --apply-overwrites dummy.csv > ${TMP_DIR}/$@.out
 	@${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || ${TEST_FAIL}
 
 clean:


### PR DESCRIPTION
test/overwrite/Makefile: make test-timestamp more flexible for fewer false fails, remove trailing white