### PR TITLE
[CI] Fix attestations' verification for musl build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,407 +116,407 @@ jobs:
     - name: Run shellcheck
       run: ./scripts/ci-run-shellcheck.sh
 
-  # ci:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
+  ci:
+    needs: [tag, clang-format, cppcheck, shellcheck]
 
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-22.04, macos-13, macos-14]
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-13, macos-14]
 
-  #   runs-on: ${{ matrix.os }}
-  #   timeout-minutes: 15
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
 
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-  #   - name: Set up Linux
-  #     if: runner.os == 'Linux'
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y rpm alien tmux
-  #       sudo apt remove -y jq
+    - name: Set up Linux
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+        sudo apt install -y rpm alien tmux
+        sudo apt remove -y jq
 
-  #   - name: Set up macOS (AMD64 and ARM64)
-  #     if: runner.os == 'macOS'
-  #     run: |
-  #       brew install --quiet coreutils tree autoconf automake libtool tmux sqlite3
-  #       brew uninstall jq
+    - name: Set up macOS (AMD64 and ARM64)
+      if: runner.os == 'macOS'
+      run: |
+        brew install --quiet coreutils tree autoconf automake libtool tmux sqlite3
+        brew uninstall jq
 
-  #   # --- Build ---
+    # --- Build ---
 
-  #   - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
-  #     if: runner.os == 'Linux'
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_GCC }}
-  #       CC: gcc
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: |
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-debian-package.sh
-  #       ./scripts/ci-create-rpm-package.sh
+    - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
+      if: runner.os == 'Linux'
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_GCC }}
+        CC: gcc
+        MAKE: make
+        RUN_TESTS: true
+      run: |
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-debian-package.sh
+        ./scripts/ci-create-rpm-package.sh
 
-  #   - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
-  #     if: runner.os == 'Linux'
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_CLANG }}
-  #       CC: clang
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: |
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-debian-package.sh
-  #       ./scripts/ci-create-rpm-package.sh
+    - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
+      if: runner.os == 'Linux'
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_CLANG }}
+        CC: clang
+        MAKE: make
+        RUN_TESTS: true
+      run: |
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-debian-package.sh
+        ./scripts/ci-create-rpm-package.sh
 
-  #   - name: Build on macOS (${{ env.AMD64_MACOSX_GCC }})
-  #     if: matrix.os == 'macos-13'
-  #     env:
-  #       PREFIX: ${{ env.AMD64_MACOSX_GCC }}
-  #       CC: gcc-13
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: ./scripts/ci-build.sh
+    - name: Build on macOS (${{ env.AMD64_MACOSX_GCC }})
+      if: matrix.os == 'macos-13'
+      env:
+        PREFIX: ${{ env.AMD64_MACOSX_GCC }}
+        CC: gcc-13
+        MAKE: make
+        RUN_TESTS: true
+      run: ./scripts/ci-build.sh
 
-  #   - name: Build on macOS (${{ env.ARM64_MACOSX_GCC }})
-  #     if: matrix.os == 'macos-14'
-  #     env:
-  #       PREFIX: ${{ env.ARM64_MACOSX_GCC }}
-  #       CC: gcc-13
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: ./scripts/ci-build.sh
+    - name: Build on macOS (${{ env.ARM64_MACOSX_GCC }})
+      if: matrix.os == 'macos-14'
+      env:
+        PREFIX: ${{ env.ARM64_MACOSX_GCC }}
+        CC: gcc-13
+        MAKE: make
+        RUN_TESTS: true
+      run: ./scripts/ci-build.sh
 
-  #   # --- Upload build artifacts ---
+    # --- Upload build artifacts ---
 
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v2
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
-  #     if: runner.os == 'Linux'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
-  #     if: runner.os == 'Linux'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
-  #     if: runner.os == 'Linux'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
-  #     if: runner.os == 'Linux'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
-  #     if: runner.os == 'Linux'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
-  #     if: runner.os == 'Linux'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip)
-  #     if: matrix.os == 'macos-13'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip)
+      if: matrix.os == 'macos-13'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.zip)
-  #     if: matrix.os == 'macos-14'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.zip)
+      if: matrix.os == 'macos-14'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
-  #     if: runner.os == 'Linux'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
-  #     if: runner.os == 'Linux'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz)
-  #     if: matrix.os == 'macos-13'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz)
+      if: matrix.os == 'macos-13'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.tar.gz)
-  #     if: matrix.os == 'macos-14'
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.tar.gz)
+      if: matrix.os == 'macos-14'
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
+    - name: Upload release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-upload-release-artifacts.sh
 
-  #   - name: Update homebrew tap (liquidaty/homebrew-zsv)
-  #     if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.os == 'macos-13' }}
-  #     env:
-  #       HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
-  #       TAG: ${{ env.TAG }}
-  #       TRIPLET: ${{ env.AMD64_MACOSX_GCC }}
-  #     run: ./scripts/ci-update-homebrew-tap.sh
+    - name: Update homebrew tap (liquidaty/homebrew-zsv)
+      if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.os == 'macos-13' }}
+      env:
+        HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+        TAG: ${{ env.TAG }}
+        TRIPLET: ${{ env.AMD64_MACOSX_GCC }}
+      run: ./scripts/ci-update-homebrew-tap.sh
 
-  # ci-bsd:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
+  ci-bsd:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
 
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-  #   - name: Build (${{ env.AMD64_FREEBSD_GCC }})
-  #     uses: cross-platform-actions/action@v0.26.0
-  #     env:
-  #       PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
-  #       CC: gcc
-  #       MAKE: gmake
-  #       RUN_TESTS: true
-  #     with:
-  #       operating_system: freebsd
-  #       version: '13.2'
-  #       environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
-  #       shell: sh
-  #       run: |
-  #         ./scripts/ci-freebsd-setup.sh
-  #         ./scripts/ci-build.sh
+    - name: Build (${{ env.AMD64_FREEBSD_GCC }})
+      uses: cross-platform-actions/action@v0.26.0
+      env:
+        PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
+        CC: gcc
+        MAKE: gmake
+        RUN_TESTS: true
+      with:
+        operating_system: freebsd
+        version: '13.2'
+        environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
+        shell: sh
+        run: |
+          ./scripts/ci-freebsd-setup.sh
+          ./scripts/ci-build.sh
 
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v2
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
+    - name: Upload release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-upload-release-artifacts.sh
 
-  # ci-mingw:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
+  ci-mingw:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
 
-  #   steps:
-  #   - name: Set up apt dependencies
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y mingw-w64 nuget
-  #       sudo apt remove -y jq
+    steps:
+    - name: Set up apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y mingw-w64 nuget
+        sudo apt remove -y jq
 
-  #   - name: Set VCPKG_MINGW_INSTALL_ROOT env var
-  #     run: echo "VCPKG_MINGW_INSTALL_ROOT=$VCPKG_INSTALLATION_ROOT/installed/x64-mingw-static" >>"$GITHUB_ENV"
+    - name: Set VCPKG_MINGW_INSTALL_ROOT env var
+      run: echo "VCPKG_MINGW_INSTALL_ROOT=$VCPKG_INSTALLATION_ROOT/installed/x64-mingw-static" >>"$GITHUB_ENV"
 
-  #   - name: Cache ncurses
-  #     uses: actions/cache@v4
-  #     id: cache-ncurses
-  #     with:
-  #       key: ncurses:x64-mingw-static
-  #       path: ${{ env.VCPKG_MINGW_INSTALL_ROOT }}
+    - name: Cache ncurses
+      uses: actions/cache@v4
+      id: cache-ncurses
+      with:
+        key: ncurses:x64-mingw-static
+        path: ${{ env.VCPKG_MINGW_INSTALL_ROOT }}
 
-  #   - name: Install ncurses with wide character support using vcpkg
-  #     if: ${{ steps.cache-ncurses.outputs.cache-hit != 'true' }}
-  #     run: |
-  #       NCURSES_PORTFILE="$VCPKG_INSTALLATION_ROOT/ports/ncurses/portfile.cmake"
-  #       cd "$VCPKG_INSTALLATION_ROOT"
-  #       if ! grep -- "--enable-widec" "$NCURSES_PORTFILE" >/dev/null; then
-  #         sed 's|--enable-pc-files|--enable-pc-files --enable-widec|' -i "$NCURSES_PORTFILE"
-  #       fi
-  #       ./vcpkg install ncurses:x64-mingw-static
-  #       tree ./installed/x64-mingw-static
+    - name: Install ncurses with wide character support using vcpkg
+      if: ${{ steps.cache-ncurses.outputs.cache-hit != 'true' }}
+      run: |
+        NCURSES_PORTFILE="$VCPKG_INSTALLATION_ROOT/ports/ncurses/portfile.cmake"
+        cd "$VCPKG_INSTALLATION_ROOT"
+        if ! grep -- "--enable-widec" "$NCURSES_PORTFILE" >/dev/null; then
+          sed 's|--enable-pc-files|--enable-pc-files --enable-widec|' -i "$NCURSES_PORTFILE"
+        fi
+        ./vcpkg install ncurses:x64-mingw-static
+        tree ./installed/x64-mingw-static
 
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
 
-  #   - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
-  #       CC: x86_64-w64-mingw32-gcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #       CXX: x86_64-w64-mingw32-g++
-  #       CPP: x86_64-w64-mingw32-cpp
-  #       RANLIB: x86_64-w64-mingw32-gcc-ranlib
-  #       AR: x86_64-w64-mingw32-gcc-ar
-  #       NM: x86_64-w64-mingw32-gcc-nm
-  #       WINDRES: x86_64-w64-mingw32-windres
-  #       CFLAGS: -I${{ env.VCPKG_MINGW_INSTALL_ROOT }}/include
-  #       LDFLAGS: -L${{ env.VCPKG_MINGW_INSTALL_ROOT }}/lib
-  #     run: |
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-nuget-package.sh
+    - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
+      env:
+        PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
+        CC: x86_64-w64-mingw32-gcc
+        MAKE: make
+        RUN_TESTS: false
+        CXX: x86_64-w64-mingw32-g++
+        CPP: x86_64-w64-mingw32-cpp
+        RANLIB: x86_64-w64-mingw32-gcc-ranlib
+        AR: x86_64-w64-mingw32-gcc-ar
+        NM: x86_64-w64-mingw32-gcc-nm
+        WINDRES: x86_64-w64-mingw32-windres
+        CFLAGS: -I${{ env.VCPKG_MINGW_INSTALL_ROOT }}/include
+        LDFLAGS: -L${{ env.VCPKG_MINGW_INSTALL_ROOT }}/lib
+      run: |
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-nuget-package.sh
 
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v2
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
+    - name: Upload release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-upload-release-artifacts.sh
 
   ci-musl:
     needs: [tag, clang-format, cppcheck, shellcheck]
@@ -551,13 +551,13 @@ jobs:
       run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
     - name: Attest build artifacts for release
-      # if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/attest-build-provenance@v2
       with:
         subject-path: ${{ env.ARTIFACT_DIR }}/*
 
     - name: Set up GitHub CLI
-      # if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         wget https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.tar.gz
         tar xvf gh_2.63.2_linux_amd64.tar.gz
@@ -565,7 +565,7 @@ jobs:
         rm -rf gh_2.63.2_linux_amd64
 
     - name: Verify attestations of release artifacts
-      # if: startsWith(github.ref, 'refs/tags/v')
+      if: startsWith(github.ref, 'refs/tags/v')
       run: ./scripts/ci-verify-attestations.sh
 
     - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
@@ -592,138 +592,138 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       run: ./scripts/ci-upload-release-artifacts.sh
 
-  # ghcr:
-  #   needs: ci-musl
-  #   runs-on: ubuntu-22.04
+  ghcr:
+    needs: ci-musl
+    runs-on: ubuntu-22.04
 
-  #   permissions:
-  #     packages: write
+    permissions:
+      packages: write
 
-  #   env:
-  #     TAG: ${{ needs.ci-musl.outputs.TAG }}
+    env:
+      TAG: ${{ needs.ci-musl.outputs.TAG }}
 
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-  #     with:
-  #       sparse-checkout: |
-  #         Dockerfile.ci
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          Dockerfile.ci
 
-  #   - name: Download (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-  #       path: ${{ env.AMD64_LINUX_MUSL }}
+    - name: Download (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
+      uses: actions/download-artifact@v4
+      with:
+        name: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+        path: ${{ env.AMD64_LINUX_MUSL }}
 
-  #   - name: Unzip
-  #     env:
-  #       ZIP: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-  #       DIR: ${{ env.AMD64_LINUX_MUSL }}
-  #     run: |
-  #       cd "$DIR"
-  #       unzip -o "$ZIP"
-  #       cd ..
-  #       mkdir -p ./ci
-  #       mv ./"$DIR"/bin/zsv ./ci/
-  #       rm -rf ./"$DIR"
+    - name: Unzip
+      env:
+        ZIP: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+        DIR: ${{ env.AMD64_LINUX_MUSL }}
+      run: |
+        cd "$DIR"
+        unzip -o "$ZIP"
+        cd ..
+        mkdir -p ./ci
+        mv ./"$DIR"/bin/zsv ./ci/
+        rm -rf ./"$DIR"
 
-  #   - name: Set up QEMU
-  #     uses: docker/setup-qemu-action@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
-  #   - name: Set up Docker Buildx
-  #     uses: docker/setup-buildx-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
-  #   - name: Login to GitHub Container Registry
-  #     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  #     uses: docker/login-action@v3
-  #     with:
-  #       registry: ghcr.io
-  #       username: ${{ github.repository_owner }}
-  #       password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to GitHub Container Registry
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-  #   - name: Build and push (on release)
-  #     uses: docker/build-push-action@v6
-  #     env:
-  #       DOCKER_BUILD_RECORD_UPLOAD: false
-  #     with:
-  #       no-cache: true
-  #       context: .
-  #       file: Dockerfile.ci
-  #       platforms: linux/amd64
-  #       push: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  #       tags: |
-  #         ghcr.io/liquidaty/zsv:${{ env.TAG }}
-  #         ghcr.io/liquidaty/zsv:latest
+    - name: Build and push (on release)
+      uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_RECORD_UPLOAD: false
+      with:
+        no-cache: true
+        context: .
+        file: Dockerfile.ci
+        platforms: linux/amd64
+        push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        tags: |
+          ghcr.io/liquidaty/zsv:${{ env.TAG }}
+          ghcr.io/liquidaty/zsv:latest
 
-  # ci-wasm:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
+  ci-wasm:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
 
-  #   steps:
-  #   - name: Set up emsdk
-  #     uses: mymindstorm/setup-emsdk@v14
+    steps:
+    - name: Set up emsdk
+      uses: mymindstorm/setup-emsdk@v14
 
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
 
-  #   - name: Update version in index.html
-  #     run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
+    - name: Update version in index.html
+      run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
 
-  #   - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
-  #       CC: emcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #       CONFIGFILE: "config.emcc"
-  #       CFLAGS: "-msse2 -msimd128"
-  #       CROSS_COMPILING: "yes"
-  #       NO_THREADING: "1"
-  #       STATIC_BUILD: "1"
-  #     run: |
-  #       emconfigure ./configure --enable-pic --disable-pie
-  #       emmake make install NO_STDIN=1 NO_PLAYGROUND=0
-  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground
+    - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_WASM }}
+        CC: emcc
+        MAKE: make
+        RUN_TESTS: false
+        CONFIGFILE: "config.emcc"
+        CFLAGS: "-msse2 -msimd128"
+        CROSS_COMPILING: "yes"
+        NO_THREADING: "1"
+        STATIC_BUILD: "1"
+      run: |
+        emconfigure ./configure --enable-pic --disable-pie
+        emmake make install NO_STDIN=1 NO_PLAYGROUND=0
+        cp "$PREFIX"/bin/cli.em.{js,wasm} playground
 
-  #   - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
-  #       CC: emcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #       CONFIGFILE: "config.emcc"
-  #       CROSS_COMPILING: "yes"
-  #       NO_THREADING: "1"
-  #       STATIC_BUILD: "1"
-  #     run: |
-  #       emconfigure ./configure --enable-pic --disable-pie
-  #       emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
-  #       mkdir -p playground/non-simd
-  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
+    - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_WASM }}
+        CC: emcc
+        MAKE: make
+        RUN_TESTS: false
+        CONFIGFILE: "config.emcc"
+        CROSS_COMPILING: "yes"
+        NO_THREADING: "1"
+        STATIC_BUILD: "1"
+      run: |
+        emconfigure ./configure --enable-pic --disable-pie
+        emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
+        mkdir -p playground/non-simd
+        cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
 
-  #   - name: Upload GitHub Pages artifacts
-  #     uses: actions/upload-pages-artifact@v3
-  #     with:
-  #       path: playground
+    - name: Upload GitHub Pages artifacts
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: playground
 
-  # deploy-playground:
-  #   if: ${{ github.ref_name == 'main' }}
-  #   needs: ci-wasm
-  #   runs-on: ubuntu-22.04
+  deploy-playground:
+    if: ${{ github.ref_name == 'main' }}
+    needs: ci-wasm
+    runs-on: ubuntu-22.04
 
-  #   permissions:
-  #     pages: write
-  #     id-token: write
+    permissions:
+      pages: write
+      id-token: write
 
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
-  #   steps:
-  #   - name: Deploy to GitHub Pages
-  #     id: deployment
-  #     uses: actions/deploy-pages@v4
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,407 +116,407 @@ jobs:
     - name: Run shellcheck
       run: ./scripts/ci-run-shellcheck.sh
 
-  ci:
-    needs: [tag, clang-format, cppcheck, shellcheck]
+  # ci:
+  #   needs: [tag, clang-format, cppcheck, shellcheck]
 
-    strategy:
-      matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-22.04, macos-13, macos-14]
 
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+  #   runs-on: ${{ matrix.os }}
+  #   timeout-minutes: 15
 
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Set up Linux
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt update
-        sudo apt install -y rpm alien tmux
-        sudo apt remove -y jq
+  #   - name: Set up Linux
+  #     if: runner.os == 'Linux'
+  #     run: |
+  #       sudo apt update
+  #       sudo apt install -y rpm alien tmux
+  #       sudo apt remove -y jq
 
-    - name: Set up macOS (AMD64 and ARM64)
-      if: runner.os == 'macOS'
-      run: |
-        brew install --quiet coreutils tree autoconf automake libtool tmux sqlite3
-        brew uninstall jq
+  #   - name: Set up macOS (AMD64 and ARM64)
+  #     if: runner.os == 'macOS'
+  #     run: |
+  #       brew install --quiet coreutils tree autoconf automake libtool tmux sqlite3
+  #       brew uninstall jq
 
-    # --- Build ---
+  #   # --- Build ---
 
-    - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
-      if: runner.os == 'Linux'
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_GCC }}
-        CC: gcc
-        MAKE: make
-        RUN_TESTS: true
-      run: |
-        ./scripts/ci-build.sh
-        ./scripts/ci-create-debian-package.sh
-        ./scripts/ci-create-rpm-package.sh
+  #   - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
+  #     if: runner.os == 'Linux'
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_GCC }}
+  #       CC: gcc
+  #       MAKE: make
+  #       RUN_TESTS: true
+  #     run: |
+  #       ./scripts/ci-build.sh
+  #       ./scripts/ci-create-debian-package.sh
+  #       ./scripts/ci-create-rpm-package.sh
 
-    - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
-      if: runner.os == 'Linux'
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_CLANG }}
-        CC: clang
-        MAKE: make
-        RUN_TESTS: true
-      run: |
-        ./scripts/ci-build.sh
-        ./scripts/ci-create-debian-package.sh
-        ./scripts/ci-create-rpm-package.sh
+  #   - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
+  #     if: runner.os == 'Linux'
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_CLANG }}
+  #       CC: clang
+  #       MAKE: make
+  #       RUN_TESTS: true
+  #     run: |
+  #       ./scripts/ci-build.sh
+  #       ./scripts/ci-create-debian-package.sh
+  #       ./scripts/ci-create-rpm-package.sh
 
-    - name: Build on macOS (${{ env.AMD64_MACOSX_GCC }})
-      if: matrix.os == 'macos-13'
-      env:
-        PREFIX: ${{ env.AMD64_MACOSX_GCC }}
-        CC: gcc-13
-        MAKE: make
-        RUN_TESTS: true
-      run: ./scripts/ci-build.sh
+  #   - name: Build on macOS (${{ env.AMD64_MACOSX_GCC }})
+  #     if: matrix.os == 'macos-13'
+  #     env:
+  #       PREFIX: ${{ env.AMD64_MACOSX_GCC }}
+  #       CC: gcc-13
+  #       MAKE: make
+  #       RUN_TESTS: true
+  #     run: ./scripts/ci-build.sh
 
-    - name: Build on macOS (${{ env.ARM64_MACOSX_GCC }})
-      if: matrix.os == 'macos-14'
-      env:
-        PREFIX: ${{ env.ARM64_MACOSX_GCC }}
-        CC: gcc-13
-        MAKE: make
-        RUN_TESTS: true
-      run: ./scripts/ci-build.sh
+  #   - name: Build on macOS (${{ env.ARM64_MACOSX_GCC }})
+  #     if: matrix.os == 'macos-14'
+  #     env:
+  #       PREFIX: ${{ env.ARM64_MACOSX_GCC }}
+  #       CC: gcc-13
+  #       MAKE: make
+  #       RUN_TESTS: true
+  #     run: ./scripts/ci-build.sh
 
-    # --- Upload build artifacts ---
+  #   # --- Upload build artifacts ---
 
-    - name: Prepare build artifacts for upload
-      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+  #   - name: Prepare build artifacts for upload
+  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-    - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/attest-build-provenance@v2
-      with:
-        subject-path: ${{ env.ARTIFACT_DIR }}/*
+  #   - name: Attest build artifacts for release
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     uses: actions/attest-build-provenance@v2
+  #     with:
+  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-    - name: Verify attestations of release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-verify-attestations.sh
+  #   - name: Verify attestations of release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-verify-attestations.sh
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
+  #     if: runner.os == 'Linux'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
+  #     if: runner.os == 'Linux'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
+  #     if: runner.os == 'Linux'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
+  #     if: runner.os == 'Linux'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
+  #     if: runner.os == 'Linux'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
+  #     if: runner.os == 'Linux'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip)
-      if: matrix.os == 'macos-13'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip)
+  #     if: matrix.os == 'macos-13'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.zip)
-      if: matrix.os == 'macos-14'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.zip)
+  #     if: matrix.os == 'macos-14'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
+  #     if: runner.os == 'Linux'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
-      if: runner.os == 'Linux'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
+  #     if: runner.os == 'Linux'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz)
-      if: matrix.os == 'macos-13'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz)
+  #     if: matrix.os == 'macos-13'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_MACOSX_GCC }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.tar.gz)
-      if: matrix.os == 'macos-14'
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.tar.gz)
+  #     if: matrix.os == 'macos-14'
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.ARM64_MACOSX_GCC }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-upload-release-artifacts.sh
+  #   - name: Upload release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-upload-release-artifacts.sh
 
-    - name: Update homebrew tap (liquidaty/homebrew-zsv)
-      if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.os == 'macos-13' }}
-      env:
-        HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
-        TAG: ${{ env.TAG }}
-        TRIPLET: ${{ env.AMD64_MACOSX_GCC }}
-      run: ./scripts/ci-update-homebrew-tap.sh
+  #   - name: Update homebrew tap (liquidaty/homebrew-zsv)
+  #     if: ${{ startsWith(github.ref, 'refs/tags/v') && matrix.os == 'macos-13' }}
+  #     env:
+  #       HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+  #       TAG: ${{ env.TAG }}
+  #       TRIPLET: ${{ env.AMD64_MACOSX_GCC }}
+  #     run: ./scripts/ci-update-homebrew-tap.sh
 
-  ci-bsd:
-    needs: [tag, clang-format, cppcheck, shellcheck]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+  # ci-bsd:
+  #   needs: [tag, clang-format, cppcheck, shellcheck]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
 
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Build (${{ env.AMD64_FREEBSD_GCC }})
-      uses: cross-platform-actions/action@v0.26.0
-      env:
-        PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
-        CC: gcc
-        MAKE: gmake
-        RUN_TESTS: true
-      with:
-        operating_system: freebsd
-        version: '13.2'
-        environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
-        shell: sh
-        run: |
-          ./scripts/ci-freebsd-setup.sh
-          ./scripts/ci-build.sh
+  #   - name: Build (${{ env.AMD64_FREEBSD_GCC }})
+  #     uses: cross-platform-actions/action@v0.26.0
+  #     env:
+  #       PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
+  #       CC: gcc
+  #       MAKE: gmake
+  #       RUN_TESTS: true
+  #     with:
+  #       operating_system: freebsd
+  #       version: '13.2'
+  #       environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
+  #       shell: sh
+  #       run: |
+  #         ./scripts/ci-freebsd-setup.sh
+  #         ./scripts/ci-build.sh
 
-    - name: Prepare build artifacts for upload
-      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+  #   - name: Prepare build artifacts for upload
+  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-    - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/attest-build-provenance@v2
-      with:
-        subject-path: ${{ env.ARTIFACT_DIR }}/*
+  #   - name: Attest build artifacts for release
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     uses: actions/attest-build-provenance@v2
+  #     with:
+  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-    - name: Verify attestations of release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-verify-attestations.sh
+  #   - name: Verify attestations of release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-verify-attestations.sh
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-upload-release-artifacts.sh
+  #   - name: Upload release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-upload-release-artifacts.sh
 
-  ci-mingw:
-    needs: [tag, clang-format, cppcheck, shellcheck]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+  # ci-mingw:
+  #   needs: [tag, clang-format, cppcheck, shellcheck]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
 
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
 
-    steps:
-    - name: Set up apt dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y mingw-w64 nuget
-        sudo apt remove -y jq
+  #   steps:
+  #   - name: Set up apt dependencies
+  #     run: |
+  #       sudo apt update
+  #       sudo apt install -y mingw-w64 nuget
+  #       sudo apt remove -y jq
 
-    - name: Set VCPKG_MINGW_INSTALL_ROOT env var
-      run: echo "VCPKG_MINGW_INSTALL_ROOT=$VCPKG_INSTALLATION_ROOT/installed/x64-mingw-static" >>"$GITHUB_ENV"
+  #   - name: Set VCPKG_MINGW_INSTALL_ROOT env var
+  #     run: echo "VCPKG_MINGW_INSTALL_ROOT=$VCPKG_INSTALLATION_ROOT/installed/x64-mingw-static" >>"$GITHUB_ENV"
 
-    - name: Cache ncurses
-      uses: actions/cache@v4
-      id: cache-ncurses
-      with:
-        key: ncurses:x64-mingw-static
-        path: ${{ env.VCPKG_MINGW_INSTALL_ROOT }}
+  #   - name: Cache ncurses
+  #     uses: actions/cache@v4
+  #     id: cache-ncurses
+  #     with:
+  #       key: ncurses:x64-mingw-static
+  #       path: ${{ env.VCPKG_MINGW_INSTALL_ROOT }}
 
-    - name: Install ncurses with wide character support using vcpkg
-      if: ${{ steps.cache-ncurses.outputs.cache-hit != 'true' }}
-      run: |
-        NCURSES_PORTFILE="$VCPKG_INSTALLATION_ROOT/ports/ncurses/portfile.cmake"
-        cd "$VCPKG_INSTALLATION_ROOT"
-        if ! grep -- "--enable-widec" "$NCURSES_PORTFILE" >/dev/null; then
-          sed 's|--enable-pc-files|--enable-pc-files --enable-widec|' -i "$NCURSES_PORTFILE"
-        fi
-        ./vcpkg install ncurses:x64-mingw-static
-        tree ./installed/x64-mingw-static
+  #   - name: Install ncurses with wide character support using vcpkg
+  #     if: ${{ steps.cache-ncurses.outputs.cache-hit != 'true' }}
+  #     run: |
+  #       NCURSES_PORTFILE="$VCPKG_INSTALLATION_ROOT/ports/ncurses/portfile.cmake"
+  #       cd "$VCPKG_INSTALLATION_ROOT"
+  #       if ! grep -- "--enable-widec" "$NCURSES_PORTFILE" >/dev/null; then
+  #         sed 's|--enable-pc-files|--enable-pc-files --enable-widec|' -i "$NCURSES_PORTFILE"
+  #       fi
+  #       ./vcpkg install ncurses:x64-mingw-static
+  #       tree ./installed/x64-mingw-static
 
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
-      env:
-        PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
-        CC: x86_64-w64-mingw32-gcc
-        MAKE: make
-        RUN_TESTS: false
-        CXX: x86_64-w64-mingw32-g++
-        CPP: x86_64-w64-mingw32-cpp
-        RANLIB: x86_64-w64-mingw32-gcc-ranlib
-        AR: x86_64-w64-mingw32-gcc-ar
-        NM: x86_64-w64-mingw32-gcc-nm
-        WINDRES: x86_64-w64-mingw32-windres
-        CFLAGS: -I${{ env.VCPKG_MINGW_INSTALL_ROOT }}/include
-        LDFLAGS: -L${{ env.VCPKG_MINGW_INSTALL_ROOT }}/lib
-      run: |
-        ./scripts/ci-build.sh
-        ./scripts/ci-create-nuget-package.sh
+  #   - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
+  #       CC: x86_64-w64-mingw32-gcc
+  #       MAKE: make
+  #       RUN_TESTS: false
+  #       CXX: x86_64-w64-mingw32-g++
+  #       CPP: x86_64-w64-mingw32-cpp
+  #       RANLIB: x86_64-w64-mingw32-gcc-ranlib
+  #       AR: x86_64-w64-mingw32-gcc-ar
+  #       NM: x86_64-w64-mingw32-gcc-nm
+  #       WINDRES: x86_64-w64-mingw32-windres
+  #       CFLAGS: -I${{ env.VCPKG_MINGW_INSTALL_ROOT }}/include
+  #       LDFLAGS: -L${{ env.VCPKG_MINGW_INSTALL_ROOT }}/lib
+  #     run: |
+  #       ./scripts/ci-build.sh
+  #       ./scripts/ci-create-nuget-package.sh
 
-    - name: Prepare build artifacts for upload
-      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+  #   - name: Prepare build artifacts for upload
+  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-    - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/attest-build-provenance@v2
-      with:
-        subject-path: ${{ env.ARTIFACT_DIR }}/*
+  #   - name: Attest build artifacts for release
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     uses: actions/attest-build-provenance@v2
+  #     with:
+  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-    - name: Verify attestations of release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-verify-attestations.sh
+  #   - name: Verify attestations of release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-verify-attestations.sh
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-upload-release-artifacts.sh
+  #   - name: Upload release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-upload-release-artifacts.sh
 
   ci-musl:
     needs: [tag, clang-format, cppcheck, shellcheck]
@@ -533,7 +533,7 @@ jobs:
     steps:
     - name: Set up dependencies
       shell: sh
-      run: apk add bash gcc make musl-dev perl ncurses-dev ncurses-static tmux file sqlite curl zip
+      run: apk add bash gcc make musl-dev perl ncurses-dev ncurses-static tmux file sqlite curl zip wget tar
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -551,13 +551,21 @@ jobs:
       run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
     - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
+      # if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/attest-build-provenance@v2
       with:
         subject-path: ${{ env.ARTIFACT_DIR }}/*
 
+    - name: Set up GitHub CLI
+      # if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        wget https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.tar.gz
+        tar xvf gh_2.63.2_linux_amd64.tar.gz
+        cp gh_2.63.2_linux_amd64/bin/gh /usr/bin
+        rm -rf gh_2.63.2_linux_amd64
+
     - name: Verify attestations of release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
+      # if: startsWith(github.ref, 'refs/tags/v')
       run: ./scripts/ci-verify-attestations.sh
 
     - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
@@ -584,138 +592,138 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       run: ./scripts/ci-upload-release-artifacts.sh
 
-  ghcr:
-    needs: ci-musl
-    runs-on: ubuntu-22.04
+  # ghcr:
+  #   needs: ci-musl
+  #   runs-on: ubuntu-22.04
 
-    permissions:
-      packages: write
+  #   permissions:
+  #     packages: write
 
-    env:
-      TAG: ${{ needs.ci-musl.outputs.TAG }}
+  #   env:
+  #     TAG: ${{ needs.ci-musl.outputs.TAG }}
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        sparse-checkout: |
-          Dockerfile.ci
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     with:
+  #       sparse-checkout: |
+  #         Dockerfile.ci
 
-    - name: Download (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
-      uses: actions/download-artifact@v4
-      with:
-        name: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-        path: ${{ env.AMD64_LINUX_MUSL }}
+  #   - name: Download (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+  #       path: ${{ env.AMD64_LINUX_MUSL }}
 
-    - name: Unzip
-      env:
-        ZIP: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-        DIR: ${{ env.AMD64_LINUX_MUSL }}
-      run: |
-        cd "$DIR"
-        unzip -o "$ZIP"
-        cd ..
-        mkdir -p ./ci
-        mv ./"$DIR"/bin/zsv ./ci/
-        rm -rf ./"$DIR"
+  #   - name: Unzip
+  #     env:
+  #       ZIP: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+  #       DIR: ${{ env.AMD64_LINUX_MUSL }}
+  #     run: |
+  #       cd "$DIR"
+  #       unzip -o "$ZIP"
+  #       cd ..
+  #       mkdir -p ./ci
+  #       mv ./"$DIR"/bin/zsv ./ci/
+  #       rm -rf ./"$DIR"
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+  #   - name: Set up QEMU
+  #     uses: docker/setup-qemu-action@v3
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+  #   - name: Set up Docker Buildx
+  #     uses: docker/setup-buildx-action@v3
 
-    - name: Login to GitHub Container Registry
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+  #   - name: Login to GitHub Container Registry
+  #     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  #     uses: docker/login-action@v3
+  #     with:
+  #       registry: ghcr.io
+  #       username: ${{ github.repository_owner }}
+  #       password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push (on release)
-      uses: docker/build-push-action@v6
-      env:
-        DOCKER_BUILD_RECORD_UPLOAD: false
-      with:
-        no-cache: true
-        context: .
-        file: Dockerfile.ci
-        platforms: linux/amd64
-        push: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        tags: |
-          ghcr.io/liquidaty/zsv:${{ env.TAG }}
-          ghcr.io/liquidaty/zsv:latest
+  #   - name: Build and push (on release)
+  #     uses: docker/build-push-action@v6
+  #     env:
+  #       DOCKER_BUILD_RECORD_UPLOAD: false
+  #     with:
+  #       no-cache: true
+  #       context: .
+  #       file: Dockerfile.ci
+  #       platforms: linux/amd64
+  #       push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  #       tags: |
+  #         ghcr.io/liquidaty/zsv:${{ env.TAG }}
+  #         ghcr.io/liquidaty/zsv:latest
 
-  ci-wasm:
-    needs: [tag, clang-format, cppcheck, shellcheck]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+  # ci-wasm:
+  #   needs: [tag, clang-format, cppcheck, shellcheck]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
 
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
 
-    steps:
-    - name: Set up emsdk
-      uses: mymindstorm/setup-emsdk@v14
+  #   steps:
+  #   - name: Set up emsdk
+  #     uses: mymindstorm/setup-emsdk@v14
 
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Update version in index.html
-      run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
+  #   - name: Update version in index.html
+  #     run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
 
-    - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_WASM }}
-        CC: emcc
-        MAKE: make
-        RUN_TESTS: false
-        CONFIGFILE: "config.emcc"
-        CFLAGS: "-msse2 -msimd128"
-        CROSS_COMPILING: "yes"
-        NO_THREADING: "1"
-        STATIC_BUILD: "1"
-      run: |
-        emconfigure ./configure --enable-pic --disable-pie
-        emmake make install NO_STDIN=1 NO_PLAYGROUND=0
-        cp "$PREFIX"/bin/cli.em.{js,wasm} playground
+  #   - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
+  #       CC: emcc
+  #       MAKE: make
+  #       RUN_TESTS: false
+  #       CONFIGFILE: "config.emcc"
+  #       CFLAGS: "-msse2 -msimd128"
+  #       CROSS_COMPILING: "yes"
+  #       NO_THREADING: "1"
+  #       STATIC_BUILD: "1"
+  #     run: |
+  #       emconfigure ./configure --enable-pic --disable-pie
+  #       emmake make install NO_STDIN=1 NO_PLAYGROUND=0
+  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground
 
-    - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_WASM }}
-        CC: emcc
-        MAKE: make
-        RUN_TESTS: false
-        CONFIGFILE: "config.emcc"
-        CROSS_COMPILING: "yes"
-        NO_THREADING: "1"
-        STATIC_BUILD: "1"
-      run: |
-        emconfigure ./configure --enable-pic --disable-pie
-        emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
-        mkdir -p playground/non-simd
-        cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
+  #   - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
+  #       CC: emcc
+  #       MAKE: make
+  #       RUN_TESTS: false
+  #       CONFIGFILE: "config.emcc"
+  #       CROSS_COMPILING: "yes"
+  #       NO_THREADING: "1"
+  #       STATIC_BUILD: "1"
+  #     run: |
+  #       emconfigure ./configure --enable-pic --disable-pie
+  #       emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
+  #       mkdir -p playground/non-simd
+  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
 
-    - name: Upload GitHub Pages artifacts
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: playground
+  #   - name: Upload GitHub Pages artifacts
+  #     uses: actions/upload-pages-artifact@v3
+  #     with:
+  #       path: playground
 
-  deploy-playground:
-    if: ${{ github.ref_name == 'main' }}
-    needs: ci-wasm
-    runs-on: ubuntu-22.04
+  # deploy-playground:
+  #   if: ${{ github.ref_name == 'main' }}
+  #   needs: ci-wasm
+  #   runs-on: ubuntu-22.04
 
-    permissions:
-      pages: write
-      id-token: write
+  #   permissions:
+  #     pages: write
+  #     id-token: write
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
 
-    steps:
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+  #   steps:
+  #   - name: Deploy to GitHub Pages
+  #     id: deployment
+  #     uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Refer to the failed job on release: https://github.com/liquidaty/zsv/actions/runs/12230465958/job/34111840491
- Update CI to install GitHub CLI before running verification command
- Tested locally with `apk add github-cli` but the installed version was an older one i.e. 2.47.*
  - It wasn't able to verify correctly.
  - Installing the latest version (https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.tar.gz) worked fine.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>