### PR TITLE
[CI][MAC] Generate artifacts with and without codesigning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,7 @@ jobs:
         {
           echo "PREFIX=$PREFIX"
           echo "ZIP=zsv-$TAG-$PREFIX.zip"
+          echo "TAR=zsv-$TAG-$PREFIX.tar.gz"
         } | tee -a "$GITHUB_ENV"
 
     - name: Build on macOS (${{ env.AMD64_MACOSX_GCC }})
@@ -290,7 +291,6 @@ jobs:
         CC: gcc-13
         MAKE: make
         RUN_TESTS: true
-        SKIP_TAR_ARCHIVE: true
       run: ./scripts/ci-build.sh
 
     - name: Prepare build artifacts for upload
@@ -318,6 +318,16 @@ jobs:
       uses: actions/upload-artifact@v4
       env:
         ARTIFACT_NAME: ${{ env.ZIP }}
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (${{ env.TAR }})
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: ${{ env.TAR }}
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
     - name: Prepare build artifacts for upload
       run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-    - name: Codesign and notarize (${{ env.PREFIX }})
+    - name: Codesign and notarize (${{ env.ZIP }})
       if: startsWith(github.ref, 'refs/tags/v')
       env:
         MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}

--- a/scripts/ci-update-homebrew-tap.sh
+++ b/scripts/ci-update-homebrew-tap.sh
@@ -10,10 +10,10 @@ if [ "$HOMEBREW_TAP_DEPLOY_KEY" = "" ] || [ "$TAG" = "" ]; then
   exit 1
 fi
 
-AMD64_ZIP="zsv-$TAG-amd64-macosx-gcc.zip"
-AMD64_URL="https://github.com/liquidaty/zsv/releases/download/v$TAG/$AMD64_ZIP"
-ARM64_ZIP="zsv-$TAG-arm64-macosx-gcc.zip"
-ARM64_URL="https://github.com/liquidaty/zsv/releases/download/v$TAG/$ARM64_ZIP"
+AMD64_ARCHIVE="zsv-$TAG-amd64-macosx-gcc.tar.gz"
+AMD64_URL="https://github.com/liquidaty/zsv/releases/download/v$TAG/$AMD64_ARCHIVE"
+ARM64_ARCHIVE="zsv-$TAG-arm64-macosx-gcc.tar.gz"
+ARM64_URL="https://github.com/liquidaty/zsv/releases/download/v$TAG/$ARM64_ARCHIVE"
 
 HOMEBREW_TAP_REPO="git@github.com:liquidaty/homebrew-zsv.git"
 HOMEBREW_TAP_DIR="homebrew-zsv"
@@ -24,22 +24,22 @@ echo "[INF] Updating homebrew tap"
 
 echo "[INF] PWD:                  $PWD"
 echo "[INF] TAG:                  $TAG"
-echo "[INF] AMD64_ZIP:            $AMD64_ZIP"
+echo "[INF] AMD64_ARCHIVE:        $AMD64_ARCHIVE"
 echo "[INF] AMD64_URL:            $AMD64_URL"
-echo "[INF] ARM64_ZIP:            $ARM64_ZIP"
+echo "[INF] ARM64_ARCHIVE:        $ARM64_ARCHIVE"
 echo "[INF] ARM64_URL:            $ARM64_URL"
 echo "[INF] HOMEBREW_TAP_REPO:    $HOMEBREW_TAP_REPO"
 echo "[INF] HOMEBREW_TAP_DIR:     $HOMEBREW_TAP_DIR"
 echo "[INF] HOMEBREW_TAP_FORMULA: $HOMEBREW_TAP_FORMULA"
 
-echo "[INF] Downloading release archives [$AMD64_ZIP, $ARM64_ZIP]"
+echo "[INF] Downloading release archives [$AMD64_ARCHIVE, $ARM64_ARCHIVE]"
 wget -q "$AMD64_URL" "$ARM64_URL"
-ls -hl "$AMD64_ZIP" "$ARM64_ZIP"
+ls -hl "$AMD64_ARCHIVE" "$ARM64_ARCHIVE"
 
-echo "[INF] Calculating SHA256 hashes [$AMD64_ZIP, $ARM64_ZIP]"
-AMD64_HASH=$(openssl dgst -sha256 "$AMD64_ZIP" | cut -d ' ' -f2 | tr -d '\n')
-ARM64_HASH=$(openssl dgst -sha256 "$ARM64_ZIP" | cut -d ' ' -f2 | tr -d '\n')
-rm -f "$AMD64_ZIP" "$ARM64_ZIP"
+echo "[INF] Calculating SHA256 hashes [$AMD64_ARCHIVE, $ARM64_ARCHIVE]"
+AMD64_HASH=$(openssl dgst -sha256 "$AMD64_ARCHIVE" | cut -d ' ' -f2 | tr -d '\n')
+ARM64_HASH=$(openssl dgst -sha256 "$ARM64_ARCHIVE" | cut -d ' ' -f2 | tr -d '\n')
+rm -f "$AMD64_ARCHIVE" "$ARM64_ARCHIVE"
 
 echo "[INF] AMD64_HASH:           $AMD64_HASH"
 echo "[INF] ARM64_HASH:           $ARM64_HASH"


### PR DESCRIPTION
- Generated artifacts:
  - ZIP: **with** codesigning and notarization
  - TAR: **without** codesigning and notarization (default for `homebrew-zsv` tap)

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>