### PR TITLE
util: Add rename fallback for copying across devices

### DIFF
--- a/include/zsv/utils/os.h
+++ b/include/zsv/utils/os.h
@@ -12,7 +12,8 @@
 void zsv_perror(const char *);
 
 #ifndef _WIN32
-#define zsv_replace_file(src, dest) (rename((const char *)src, (const char *)dest))
+
+int zsv_replace_file(const char *src, const char *dest);
 
 #else
 


### PR DESCRIPTION
If a file is being moved across devices then rename() won't work. The
file needs to be copied instead.

/tmp and /home are on separate drives on one of my machines. I can't save the config and load extensions without on that machine without this.
