### PR TITLE
[playground] Enable buffering; add `less` command and elapsed time

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -311,11 +311,40 @@
       }
     }
 
+    function dumpOutputWithTruncatedBytes() {
+      const maxBytes = 4 * 1024;
+      const buffer = $('body').terminal().get_output_buffer();
+      const bufferLen = buffer.length;
+      if (bufferLen > 0) {
+        $('body').terminal().clear_buffer();
+        var truncated = buffer.slice(0, maxBytes);
+        truncated = truncated.slice(0, truncated.lastIndexOf('\n'));
+        $('body').terminal().echo(truncated);
+        if (bufferLen > maxBytes) {
+          $('body').terminal().echo(`[[;yellow;]... truncated ${bufferLen - truncated.length} bytes]`);
+        }
+      }
+    }
+
+    function dumpOutputWithTruncatedLines() {
+      const maxLines = 100;
+      const lines = $('body').terminal().get_output_buffer().split('\n');
+      if (lines.length > 0) {
+        $('body').terminal().clear_buffer();
+        const truncated = lines.slice(0, maxLines);
+        $('body').terminal().echo(truncated);
+        if (lines.length > maxLines) {
+          $('body').terminal().echo(`[[;yellow;]... truncated ${lines.length - truncated.length} lines]`);
+        }
+      }
+    }
+
     function zsv(args) {
       const start = performance.now();
       const exitCode = Module.callMain(args);
       if (exitCode === 0) {
-        $('body').terminal().flush();
+        // dumpOutputWithTruncatedLines();
+        dumpOutputWithTruncatedBytes();
       }
       const end = performance.now();
       const elapsed = (end - start).toFixed(2);

--- a/playground/index.html
+++ b/playground/index.html
@@ -11,10 +11,12 @@
   <title>zsv playground v__VERSION__</title>
 
   <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
+
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/ascii_table.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/less.min.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css" />
+  <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/pipe.min.js"></script>
 
   <script type="text/javascript">
     // https://stackoverflow.com/questions/9038625/detect-if-device-is-ios
@@ -142,7 +144,7 @@
           const output = args.join(' ');
           $('body').terminal().error(output);
         };
-      })()
+      })(),
     };
 
     Module['onRuntimeInitialized'] = () => {
@@ -296,18 +298,31 @@
       }
     }
 
+    async function lessWithStdin() {
+      var header = `[[;red;]Type your content here.]\n`;
+      header += `[[;red;]Press SHIFT+ENTER for a newline.]\n`;
+      header += `[[;red;]Press ENTER to finish.]\n`;
+      await $('body').terminal().read(header).then((stdin) => {
+        if (stdin.length > 0) {
+          $('body').terminal().less(stdin);
+        }
+      });
+    }
+
     function less(args) {
       if (args.length === 0) {
-        $('body').terminal().error('less: missing file operand');
-        return;
-      }
-      const file = args[0];
-      if (FS.analyzePath(file).exists) {
-        const data = FS.readFile(file);
-        const text = new TextDecoder('utf-8').decode(data);
-        $('body').terminal().less(text);
+        lessWithStdin();
+      } else if (args.length === 1) {
+        const file = args[0];
+        if (FS.analyzePath(file).exists) {
+          const data = FS.readFile(file);
+          const text = new TextDecoder('utf-8').decode(data);
+          $('body').terminal().less(text);
+        } else {
+          $('body').terminal().error(`less: file not found [${file}]`);
+        }
       } else {
-        $('body').terminal().error(`less: file not found [${file}]`);
+        $('body').terminal().error('less: too many arguments');
       }
     }
 
@@ -405,7 +420,7 @@
     }, {
       checkArity: false,
       greetings: greetings,
-      prompt: "[[;lightgreen;]zsv@playground$ ]",
+      prompt: "[[;lightgreen;]zsv@playground$] ",
       completion: function (string, callback) {
         const command = this.get_command().trimLeft();
         if (command.match(/^(info|help|load|ls|download) /)) {
@@ -417,7 +432,8 @@
         } else {
           callback(Object.keys(playgroundCommands));
         }
-      }
+      },
+      pipe: true,
     });
   </script>
 </body>

--- a/playground/index.html
+++ b/playground/index.html
@@ -12,6 +12,8 @@
 
   <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
   <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/jquery.terminal.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/ascii_table.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jquery.terminal/js/less.min.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.terminal/css/jquery.terminal.min.css" />
 
   <script type="text/javascript">
@@ -129,7 +131,7 @@
         return (...args) => {
           const output = args.join(' ');
           if (zsvAutocompletionsPopulated) {
-            $('body').terminal().echo(output);
+            $('body').terminal().echo(output, { flush: false });
           } else {
             parseFlagsAndCommands(output);
           }
@@ -206,23 +208,23 @@
     }
 
     const playgroundCommands = {
-      info: '    : show playground info',
-      help: '    : show help',
-      clear: '   : clear screen',
-      load: '    : load CSV file(s) from disk (overwrite mode)',
-      save: '    : save file(s) to disk',
-      download: ': download file(s) from URL(s) (overwrite mode)',
-      ls: '      : list current directory (/home/zsv/)',
-      rm: '      : remove file(s) (force mode)',
-      zsv: '     : run zsv CLI app',
+      info: 'show playground info',
+      help: 'show help',
+      clear: 'clear screen',
+      load: 'load CSV file(s) from disk (overwrite mode)',
+      save: 'save file(s) to disk',
+      download: 'download file(s) from URL(s) (overwrite mode)',
+      ls: 'list current directory (/home/zsv/)',
+      rm: 'remove file(s) (force mode)',
+      less: 'view file content',
+      zsv: 'run zsv CLI app',
     };
 
     function help() {
-      var help = "[[;red;]zsv playground help]";
-      for (const key in playgroundCommands) {
-        help += `\n  [[;blue;]${key}] ${playgroundCommands[key]}`;
-      }
-      $('body').terminal().echo(help);
+      const header = ['[[;red;]command]', '[[;red;]description]'];
+      const help = Object.entries(playgroundCommands);
+      help.unshift(header);
+      $('body').terminal().echo(ascii_table(help, true));
     }
 
     function load() {
@@ -294,9 +296,33 @@
       }
     }
 
+    function less(args) {
+      if (args.length === 0) {
+        $('body').terminal().error('less: missing file operand');
+        return;
+      }
+      const file = args[0];
+      if (FS.analyzePath(file).exists) {
+        const data = FS.readFile(file);
+        const text = new TextDecoder('utf-8').decode(data);
+        $('body').terminal().less(text);
+      } else {
+        $('body').terminal().error(`less: file not found [${file}]`);
+      }
+    }
+
     function zsv(args) {
+      const start = performance.now();
       const exitCode = Module.callMain(args);
-      // TODO: Handle/log exit code if needed
+      if (exitCode === 0) {
+        $('body').terminal().flush();
+      }
+      const end = performance.now();
+      const elapsed = (end - start).toFixed(2);
+      const command = "zsv " + args.slice(1).join(' ');
+      const status = `>> ${command} [exit code: ${exitCode}, elapsed time: ${elapsed} ms]`;
+      $('body').terminal().error(status);
+      console.log(status);
     }
 
     $('body').terminal(function (command) {
@@ -332,6 +358,10 @@
           rm(args);
           break;
 
+        case 'less':
+          less(args);
+          break;
+
         case 'zsv':
           zsv(args);
           break;
@@ -351,7 +381,7 @@
         const command = this.get_command().trimLeft();
         if (command.match(/^(info|help|load|ls|download) /)) {
           callback([]);
-        } else if (command.match(/^save /) || command.match(/^rm /)) {
+        } else if (command.match(/^save /) || command.match(/^rm /) || command.match(/^less /)) {
           callback(getFiles());
         } else if (command.startsWith('zsv')) {
           callback(autocomplete(string, command));

--- a/playground/index.html
+++ b/playground/index.html
@@ -274,20 +274,17 @@
         "- The `zsv sheet` command is not available in the playground.",
         "- Each browser tab is a new session i.e. nothing is retained.",
         "- Storing large `zsv` output to a file is much faster than STDOUT.",
-        "  - e.g.:",
-        "    - `zsv echo -L 100000 worldcitiespop_mil.csv -o w100k.csv`",
-        "- For large files, use `less` command.",
-        "  For large outputs, pipe it through `less` command.",
-        "  - e.g.:",
-        "    - `less worldcitiespop_mil.csv`",
-        "    - `zsv 2json w100k.csv | less`",
+        "  Example: `zsv echo -L 100000 worldcitiespop_mil.csv -o w100k.csv`",
+        "- For navigating the large files, use `less` command.",
+        "  Example: `less worldcitiespop_mil.csv`",
+        "  For the large `zsv` output, pipe it to `less` command.",
+        "  Example: `zsv 2json w100k.csv | less`",
         "- Configure large outputs to be truncated using `config` command.",
-        "  - e.g.:",
-        "    - `config enable zsv_truncate_output`",
-        "- Run `clear` command often if the terminal feels sluggish.",
-        "  - It may happen over time while working with large outputs to STDOUT.",
+        "  Example: `config enable zsv_truncate_output`",
+        "- Run `clear` command often if the terminal feels a bit sluggish.",
+        "  It may happen over time while working with large outputs to STDOUT.",
       ];
-      $('body').terminal().echo(notes.join('\n').replace(/`(.*)`/g, '`[[;yellow;]$1]`'));
+      $('body').terminal().echo(notes.join('\n').replace(/`([^`]+)`/g, '`[[;yellow;]$1]`'));
     }
 
     function load() {

--- a/playground/index.html
+++ b/playground/index.html
@@ -218,13 +218,16 @@
       download: 'download file(s) from URL(s) (overwrite mode)',
       ls: 'list current directory (/home/zsv/)',
       rm: 'remove file(s) (force mode)',
-      less: 'view file content',
+      less: 'view and search a file efficiently',
+      config: 'configure playground',
       zsv: 'run zsv CLI app',
     };
 
     function help() {
       const header = ['[[;red;]command]', '[[;red;]description]'];
-      const help = Object.entries(playgroundCommands);
+      const help = Object.entries(playgroundCommands).map(([key, value]) => {
+        return [`[[;blue;]${key}]`, `${value}`];
+      });
       help.unshift(header);
       $('body').terminal().echo(ascii_table(help, true));
     }
@@ -354,18 +357,104 @@
       }
     }
 
+    class Configuration {
+      constructor() {
+        this.actions = {
+          enable: (name) => { this.configs[name] = true; },
+          disable: (name) => { this.configs[name] = false; },
+        };
+        this.configs = {
+          zsv_print_elapsed_time: false,
+          zsv_truncate_output: false,
+        };
+      }
+
+      isZsvPrintElapsedTimeEnabled() {
+        return this.configs.zsv_print_elapsed_time;
+      }
+
+      isZsvTruncateOutputEnabled() {
+        return this.configs.zsv_truncate_output;
+      }
+
+      validate(action, name) {
+        if (action === undefined) {
+          $('body').terminal().error(`config: missing action`);
+          return false;
+        } else if (!this.actions.hasOwnProperty(action)) {
+          $('body').terminal().error(`config: invalid action [${action}]`);
+          return false;
+        } else if (name === undefined) {
+          $('body').terminal().error(`config: missing config name`);
+          return false;
+        } else if (!this.configs.hasOwnProperty(name)) {
+          $('body').terminal().error(`config: invalid config name [${name}]`);
+          return false;
+        }
+        return true;
+      }
+
+      apply(action, name) {
+        if (this.validate(action, name)) {
+          this.actions[action](name);
+          $('body').terminal().echo(`config: [[;yellow;]${name}] [updated]`);
+        }
+      }
+
+      show() {
+        const header = ['[[;red;]config]', '[[;red;]status]'];
+        const entries = Object.entries(this.configs).map(([key, value]) => {
+          return [`${key}`, `${value ? '[[;green;]enabled]' : 'disabled'}`];
+        });
+        entries.unshift(header);
+        $('body').terminal().echo(ascii_table(entries, true));
+      }
+
+      autocomplete(string, command) {
+        if (command.match(/^config\s+$/) || command.match(/^config\s+\w+$/)) {
+          return Object.keys(this.actions);
+        }
+
+        if (command.match(/^config\s+(enable|disable)\s+$/) || command.match(/^config\s+(enable|disable)\s+\w+$/)) {
+          return Object.keys(this.configs);
+        }
+
+        return [];
+      }
+    }
+
+    const configuration = new Configuration();
+
+    function config(args) {
+      if (args.length === 0) {
+        configuration.show();
+      } else if (args.length > 2) {
+        $('body').terminal().error('config: too many arguments');
+      } else {
+        const action = args[0];
+        const name = args[1];
+        configuration.apply(action, name);
+      }
+    }
+
     function zsv(args) {
       const start = performance.now();
       const exitCode = Module.callMain(args);
       if (exitCode === 0) {
-        // dumpOutputWithTruncatedLines();
-        dumpOutputWithTruncatedBytes();
+        if (configuration.isZsvTruncateOutputEnabled()) {
+          // dumpOutputWithTruncatedLines();
+          dumpOutputWithTruncatedBytes();
+        } else {
+          $('body').terminal().flush();
+        }
       }
       const end = performance.now();
       const elapsed = (end - start).toFixed(2);
       const command = "zsv " + args.slice(1).join(' ');
       const status = `>> ${command} [exit code: ${exitCode}, elapsed time: ${elapsed} ms]`;
-      $('body').terminal().error(status);
+      if (configuration.isZsvPrintElapsedTimeEnabled()) {
+        $('body').terminal().error(status);
+      }
       console.log(status);
     }
 
@@ -406,6 +495,10 @@
           less(args);
           break;
 
+        case 'config':
+          config(args);
+          break;
+
         case 'zsv':
           zsv(args);
           break;
@@ -427,6 +520,8 @@
           callback([]);
         } else if (command.match(/^save /) || command.match(/^rm /) || command.match(/^less /)) {
           callback(getFiles());
+        } else if (command.startsWith('config')) {
+          callback(configuration.autocomplete(string, command));
         } else if (command.startsWith('zsv')) {
           callback(autocomplete(string, command));
         } else {

--- a/playground/index.html
+++ b/playground/index.html
@@ -210,26 +210,84 @@
     }
 
     const playgroundCommands = {
-      info: 'show playground info',
-      help: 'show help',
-      clear: 'clear screen',
-      load: 'load CSV file(s) from disk (overwrite mode)',
-      save: 'save file(s) to disk',
-      download: 'download file(s) from URL(s) (overwrite mode)',
-      ls: 'list current directory (/home/zsv/)',
-      rm: 'remove file(s) (force mode)',
-      less: 'view and search a file efficiently',
-      config: 'configure playground',
-      zsv: 'run zsv CLI app',
+      info: {
+        description: 'show playground info',
+        usage: 'info'
+      },
+      help: {
+        description: 'show help',
+        usage: 'help'
+      },
+      clear: {
+        description: 'clear screen',
+        usage: 'clear'
+      },
+      load: {
+        description: 'load CSV file(s) from disk (overwrite mode)',
+        usage: 'load'
+      },
+      save: {
+        description: 'save file(s) to disk',
+        usage: 'save <filename> ...'
+      },
+      download: {
+        description: 'download file(s) from URL(s) (overwrite mode)',
+        usage: 'download <url> ...'
+      },
+      ls: {
+        description: 'list current directory (/home/zsv/)',
+        usage: 'ls'
+      },
+      rm: {
+        description: 'remove file(s) (force mode)',
+        usage: 'rm <filename> ...'
+      },
+      less: {
+        description: 'view/search content of a file or stdin efficiently',
+        usage: 'less [<filename>]'
+      },
+      config: {
+        description: 'show/enable/disable playground configurations',
+        usage: 'config [enable|disable <config-name>]'
+      },
+      zsv: {
+        description: 'run zsv CLI app',
+        usage: 'zsv <command> [arguments]'
+      }
     };
 
     function help() {
-      const header = ['[[;red;]command]', '[[;red;]description]'];
+      const header = ['[[;red;]command]', '[[;red;]usage]', '[[;red;]description]'];
       const help = Object.entries(playgroundCommands).map(([key, value]) => {
-        return [`[[;blue;]${key}]`, `${value}`];
+        return [
+          `[[;yellow;]${key}]`,
+          `${value.usage}`,
+          `${value.description}`
+        ];
       });
       help.unshift(header);
       $('body').terminal().echo(ascii_table(help, true));
+
+      const notes = [
+        "[[;red;]NOTES:]",
+        "- For iOS, SIMD support is not available for `zsv`.",
+        "- The `zsv sheet` command is not available in the playground.",
+        "- Each browser tab is a new session i.e. nothing is retained.",
+        "- Storing large `zsv` output to a file is much faster than STDOUT.",
+        "  - e.g.:",
+        "    - `zsv echo -L 100000 worldcitiespop_mil.csv -o w100k.csv`",
+        "- For large files, use `less` command.",
+        "  For large outputs, pipe it through `less` command.",
+        "  - e.g.:",
+        "    - `less worldcitiespop_mil.csv`",
+        "    - `zsv 2json w100k.csv | less`",
+        "- Configure large outputs to be truncated using `config` command.",
+        "  - e.g.:",
+        "    - `config enable zsv_truncate_output`",
+        "- Run `clear` command often if the terminal feels sluggish.",
+        "  - It may happen over time while working with large outputs to STDOUT.",
+      ];
+      $('body').terminal().echo(notes.join('\n').replace(/`(.*)`/g, '`[[;yellow;]$1]`'));
     }
 
     function load() {


### PR DESCRIPTION
Related: #374

- Enabled buffering and truncation for STDOUT
- Added `less` command to optimize the viewing of large files
  - Enabled autocompletion and added in `help` text
  - Added STDIN and pipe support
    - e.g. `zsv echo file.csv | less`
  - Removed wiki page
    - Added usage and notes in `help` text instead to keep it at one place together
- Added ASCII table for to automate and beautify the `help` command text and `config` output
- Added elapsed time for `zsv` commands (terminal + developer console)
- Added `config` command to configure elapsed time and output truncation

## Comparisons without truncation

Following are the comparisons when the output is buffered first and flushed only
after it is available i.e. no frequent calls for flushing output.

```shell
# Generate a CSV file with 500 lines
zsv echo -L 500 worldcitiespop_mil.csv -o w500.csv

# Command invocation for comparisons
zsv 2json w500.csv
```

Test CSV file: [w500.csv](https://github.com/user-attachments/files/19921077/w500.csv)

Notes:

- The three (3) consecutive command invocations have been recorded.
- These tests have been run locally.
  - For `v0.4.4-alpha`, the generated artifact has been downloaded.
- The browser in incognito (private) mode has been used.
- New browser tabs have been used for before and after comparisons.
- The time recorded is in milliseconds.

## Without `clear` after every command invocation

|   #   | before (`v0.4.4-alpha`) | after (`PR#395`) | % improvement |
| :---: | ----------------------: | ---------------: | ------------: |
|   1   |                12357.30 |           688.00 |         94.43 |
|   2   |                45288.20 |          1679.80 |         96.29 |
|   3   |                80426.70 |          3290.00 |         95.91 |

## With `clear` after every command invocation

|   #   | before (`v0.4.4-alpha`) | after (`PR#395`) | % improvement |
| :---: | ----------------------: | ---------------: | ------------: |
|   1   |                12551.10 |           734.70 |         94.15 |
|   2   |                13654.10 |           689.00 |         94.95 |
|   3   |                16984.40 |           702.10 |         95.87 |

## Demos (screenshots/GIFs)

### updated `help` text with `less`, `config` and notes

![Screenshot from 2025-04-28 11-21-57](https://github.com/user-attachments/assets/0b35106f-de35-4172-89e2-51c12a42a245)

### truncated output

![zsv-playground-demo-truncated-bytes](https://github.com/user-attachments/assets/2fb499b1-2d37-4873-a17c-6277488041c8)

### `less` command

![zsv-playground-demo-less](https://github.com/user-attachments/assets/488e6c84-1940-43a7-bd99-3b8b3e091a0c)

### `less` command with `stdin` and pipe support

![zsv-playground-demo-less-command](https://github.com/user-attachments/assets/87233146-a410-43fa-a360-f588792e6103)

### elapsed time

![zsv-playground-demo-elapsed-time](https://github.com/user-attachments/assets/d51a9f04-383c-4bec-8966-68ec2fbf55b6)

### `config` command

![zsv-playground-demo-config-command](https://github.com/user-attachments/assets/61217cba-01c6-47bb-8e9b-9694e7d25476)

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>