### PR TITLE
[CI] Verify macOS tests (time handling issue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
     strategy:
       matrix:
         # os: [macos-13, macos-14]
-        os: [macos-13]
+        os: [macos-14]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,205 +65,203 @@ jobs:
         TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
       run: ./scripts/ci-set-tag-output-parameter.sh
 
-  # clang-format:
-  #   runs-on: ubuntu-22.04
+  clang-format:
+    runs-on: ubuntu-22.04
 
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-  #   - name: Run clang-format
-  #     run: |
-  #       sudo ln -sf /usr/bin/clang-format-15 /usr/bin/clang-format
-  #       ./scripts/ci-run-clang-format.sh
+    - name: Run clang-format
+      run: |
+        sudo ln -sf /usr/bin/clang-format-15 /usr/bin/clang-format
+        ./scripts/ci-run-clang-format.sh
 
-  # cppcheck:
-  #   runs-on: ubuntu-22.04
+  cppcheck:
+    runs-on: ubuntu-22.04
 
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-  #   - name: Install cppcheck
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y cppcheck
-  #       cppcheck --version
+    - name: Install cppcheck
+      run: |
+        sudo apt update
+        sudo apt install -y cppcheck
+        cppcheck --version
 
-  #   - name: Run cppcheck
-  #     run: ./scripts/ci-run-cppcheck.sh
+    - name: Run cppcheck
+      run: ./scripts/ci-run-cppcheck.sh
 
-  #   - name: Upload (${{ env.CPPCHECK_XML_ARTIFACT_NAME }})
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
-  #       path: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (${{ env.CPPCHECK_XML_ARTIFACT_NAME }})
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
+        path: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (${{ env.CPPCHECK_HTML_ARTIFACT_NAME }})
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
-  #       path: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (${{ env.CPPCHECK_HTML_ARTIFACT_NAME }})
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
+        path: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  # shellcheck:
-  #   runs-on: ubuntu-22.04
+  shellcheck:
+    runs-on: ubuntu-22.04
 
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-  #   - name: Run shellcheck
-  #     run: ./scripts/ci-run-shellcheck.sh
+    - name: Run shellcheck
+      run: ./scripts/ci-run-shellcheck.sh
 
-  # ci-linux:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
+  ci-linux:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
 
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-  #   - name: Set up apt dependencies
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y rpm alien tmux
-  #       sudo apt remove -y jq
+    - name: Set up apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y rpm alien tmux
+        sudo apt remove -y jq
 
-  #   - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_GCC }}
-  #       CC: gcc
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: |
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-debian-package.sh
-  #       ./scripts/ci-create-rpm-package.sh
+    - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_GCC }}
+        CC: gcc
+        MAKE: make
+        RUN_TESTS: true
+      run: |
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-debian-package.sh
+        ./scripts/ci-create-rpm-package.sh
 
-  #   - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_CLANG }}
-  #       CC: clang
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: |
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-debian-package.sh
-  #       ./scripts/ci-create-rpm-package.sh
+    - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_CLANG }}
+        CC: clang
+        MAKE: make
+        RUN_TESTS: true
+      run: |
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-debian-package.sh
+        ./scripts/ci-create-rpm-package.sh
 
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v2
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
 
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
+    - name: Upload release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-upload-release-artifacts.sh
 
   ci-macos:
-    # needs: [tag, clang-format, cppcheck, shellcheck]
-    needs: [tag]
+    needs: [tag, clang-format, cppcheck, shellcheck]
 
     strategy:
       matrix:
-        # os: [macos-13, macos-14]
-        os: [macos-14]
+        os: [macos-13, macos-14]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -343,496 +341,496 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       run: ./scripts/ci-upload-release-artifacts.sh
 
-  # update-homebrew-tap:
-  #   if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  #   needs: ci-macos
-  #   runs-on: ubuntu-22.04
-
-  #   env:
-  #     TAG: ${{ needs.ci-macos.outputs.TAG }}
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-  #     with:
-  #       sparse-checkout: |
-  #         scripts/ci-update-homebrew-tap.sh
-
-  #   - name: Update
-  #     env:
-  #       HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
-  #     run: ./scripts/ci-update-homebrew-tap.sh
-
-  # ci-bsd:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-
-  #   - name: Build (${{ env.AMD64_FREEBSD_GCC }})
-  #     uses: cross-platform-actions/action@v0.27.0
-  #     env:
-  #       PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
-  #       CC: gcc
-  #       MAKE: gmake
-  #       RUN_TESTS: true
-  #     with:
-  #       operating_system: freebsd
-  #       version: '13.2'
-  #       environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
-  #       shell: sh
-  #       run: |
-  #         ./scripts/ci-freebsd-setup.sh
-  #         ./scripts/ci-build.sh
-
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v2
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
-
-  # mingw-ncurses:
-  #   runs-on: ubuntu-22.04
-
-  #   steps:
-  #   - name: Cache
-  #     uses: actions/cache@v4
-  #     id: cache
-  #     with:
-  #       key: mingw-ncurses.zip
-  #       path: ${{ github.workspace }}/mingw-ncurses.zip
-
-  #   - name: Install MinGW
-  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y mingw-w64
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-  #     with:
-  #       sparse-checkout: |
-  #         scripts/ci-build-ncurses-with-mingw.sh
-
-  #   - name: Build ncurses with MinGW
-  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-  #     run: ./scripts/ci-build-ncurses-with-mingw.sh
-
-  #   - name: Upload mingw-ncurses.zip
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: mingw-ncurses.zip
-  #       path: ${{ github.workspace }}/mingw-ncurses.zip
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  # ci-linux-mingw:
-  #   needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   steps:
-  #   - name: Set up apt dependencies
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y mingw-w64 nuget
-  #       sudo apt remove -y jq
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-
-  #   - name: Download mingw-ncurses.zip
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: mingw-ncurses.zip
-  #       path: ${{ github.workspace }}/app/external
-
-  #   - name: Unzip mingw-ncurses.zip in app/external
-  #     run: |
-  #       cd app/external
-  #       unzip mingw-ncurses.zip
-
-  #   - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
-  #       CC: x86_64-w64-mingw32-gcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #     run: |
-  #       export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
-  #       export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-nuget-package.sh
-
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v2
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
-
-  # ci-wsl-mingw:
-  #   needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
-  #   runs-on: windows-2025
-  #   timeout-minutes: 30
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   defaults:
-  #     run:
-  #       shell: bash
-
-  #   steps:
-  #   - name: Set up WSL 2
-  #     uses: Vampire/setup-wsl@v5
-  #     with:
-  #       wsl-version: 2
-  #       wsl-shell-command: bash --noprofile --norc -eo pipefail {0}
-  #       set-as-default: true
-  #       distribution: Ubuntu-22.04
-  #       additional-packages: |
-  #         build-essential
-  #         mingw-w64
-  #         sqlite3
-  #         nuget
-  #         tree
-  #         zip
-  #         tar
-  #         tmux
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-
-  #   - name: Download mingw-ncurses.zip
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: mingw-ncurses.zip
-  #       path: ${{ github.workspace }}/app/external
-
-  #   - name: Unzip mingw-ncurses.zip in app/external
-  #     run: |
-  #       cd app/external
-  #       unzip mingw-ncurses.zip
-
-  #   - name: Build (${{ env.AMD64_WSL_MINGW }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_WSL_MINGW }}
-  #       CC: x86_64-w64-mingw32-gcc
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #       SKIP_BUILD: true
-  #       SKIP_ZIP_ARCHIVE: false
-  #       SKIP_TAR_ARCHIVE: true
-  #       WSLENV: ARTIFACT_DIR:TAG:PREFIX:CC:MAKE:RUN_TESTS:SKIP_BUILD:SKIP_ZIP_ARCHIVE:SKIP_TAR_ARCHIVE
-  #     shell: wsl-bash {0}
-  #     run: |
-  #       export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
-  #       export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
-  #       ./scripts/ci-build.sh
-
-  #   # - name: Prepare build artifacts for upload
-  #   #   run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-  #   # - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WSL_MINGW }}.zip)
-  #   #   uses: actions/upload-artifact@v4
-  #   #   env:
-  #   #     ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WSL_MINGW }}.zip
-  #   #   with:
-  #   #     name: ${{ env.ARTIFACT_NAME }}
-  #   #     path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #   #     retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #   #     if-no-files-found: error
-
-  # ci-musl:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   container: alpine:latest
-  #   timeout-minutes: 15
-
-  #   outputs:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   steps:
-  #   - name: Set up dependencies
-  #     shell: sh
-  #     run: apk add bash gcc make musl-dev perl ncurses-dev ncurses-static tmux file sqlite curl zip wget tar git
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-
-  #   - name: Build (${{ env.AMD64_LINUX_MUSL }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_MUSL }}
-  #       CC: gcc
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #       STATIC_BUILD: "1"
-  #     run: ./scripts/ci-build.sh
-
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v2
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-  #   - name: Set up GitHub CLI
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: |
-  #       wget https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.tar.gz
-  #       tar xvf gh_2.63.2_linux_amd64.tar.gz
-  #       cp gh_2.63.2_linux_amd64/bin/gh /usr/bin
-  #       rm -rf gh_2.63.2_linux_amd64
-
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: |
-  #       git config --global --add safe.directory "$PWD"
-  #       ./scripts/ci-upload-release-artifacts.sh
-
-  # ghcr:
-  #   needs: ci-musl
-  #   runs-on: ubuntu-22.04
-
-  #   permissions:
-  #     packages: write
-
-  #   env:
-  #     TAG: ${{ needs.ci-musl.outputs.TAG }}
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-  #     with:
-  #       sparse-checkout: |
-  #         Dockerfile.ci
-
-  #   - name: Download (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       name: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-  #       path: ${{ env.AMD64_LINUX_MUSL }}
-
-  #   - name: Unzip
-  #     env:
-  #       ZIP: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-  #       DIR: ${{ env.AMD64_LINUX_MUSL }}
-  #     run: |
-  #       cd "$DIR"
-  #       unzip -o "$ZIP"
-  #       cd ..
-  #       mkdir -p ./ci
-  #       mv ./"$DIR"/bin/zsv ./ci/
-  #       rm -rf ./"$DIR"
-
-  #   - name: Set up QEMU
-  #     uses: docker/setup-qemu-action@v3
-
-  #   - name: Set up Docker Buildx
-  #     uses: docker/setup-buildx-action@v3
-
-  #   - name: Login to GitHub Container Registry
-  #     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  #     uses: docker/login-action@v3
-  #     with:
-  #       registry: ghcr.io
-  #       username: ${{ github.repository_owner }}
-  #       password: ${{ secrets.GITHUB_TOKEN }}
-
-  #   - name: Build and push (on release)
-  #     uses: docker/build-push-action@v6
-  #     env:
-  #       DOCKER_BUILD_RECORD_UPLOAD: false
-  #     with:
-  #       no-cache: true
-  #       context: .
-  #       file: Dockerfile.ci
-  #       platforms: linux/amd64
-  #       push: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  #       tags: |
-  #         ghcr.io/liquidaty/zsv:${{ env.TAG }}
-  #         ghcr.io/liquidaty/zsv:latest
-
-  # ci-wasm:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   steps:
-  #   - name: Set up emsdk
-  #     uses: mymindstorm/setup-emsdk@v14
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v4
-
-  #   - name: Update version in index.html
-  #     run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
-
-  #   - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
-  #       CC: emcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #       CONFIGFILE: "config.emcc"
-  #       CFLAGS: "-msse2 -msimd128"
-  #       CROSS_COMPILING: "yes"
-  #       NO_THREADING: "1"
-  #       STATIC_BUILD: "1"
-  #     run: |
-  #       emconfigure ./configure --enable-pic --disable-pie
-  #       emmake make install NO_STDIN=1 NO_PLAYGROUND=0
-  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground
-
-  #   - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
-  #       CC: emcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #       CONFIGFILE: "config.emcc"
-  #       CROSS_COMPILING: "yes"
-  #       NO_THREADING: "1"
-  #       STATIC_BUILD: "1"
-  #     run: |
-  #       emconfigure ./configure --enable-pic --disable-pie
-  #       emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
-  #       mkdir -p playground/non-simd
-  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
-
-  #   - name: Upload GitHub Pages artifacts
-  #     uses: actions/upload-pages-artifact@v3
-  #     with:
-  #       path: playground
-
-  # deploy-wasm-playground:
-  #   if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
-  #   needs: ci-wasm
-  #   runs-on: ubuntu-22.04
-
-  #   permissions:
-  #     pages: write
-  #     id-token: write
-
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
-
-  #   steps:
-  #   - name: Deploy to GitHub Pages
-  #     id: deployment
-  #     uses: actions/deploy-pages@v4
+  update-homebrew-tap:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: ci-macos
+    runs-on: ubuntu-22.04
+
+    env:
+      TAG: ${{ needs.ci-macos.outputs.TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/ci-update-homebrew-tap.sh
+
+    - name: Update
+      env:
+        HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+      run: ./scripts/ci-update-homebrew-tap.sh
+
+  ci-bsd:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build (${{ env.AMD64_FREEBSD_GCC }})
+      uses: cross-platform-actions/action@v0.27.0
+      env:
+        PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
+        CC: gcc
+        MAKE: gmake
+        RUN_TESTS: true
+      with:
+        operating_system: freebsd
+        version: '13.2'
+        environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
+        shell: sh
+        run: |
+          ./scripts/ci-freebsd-setup.sh
+          ./scripts/ci-build.sh
+
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-upload-release-artifacts.sh
+
+  mingw-ncurses:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Cache
+      uses: actions/cache@v4
+      id: cache
+      with:
+        key: mingw-ncurses.zip
+        path: ${{ github.workspace }}/mingw-ncurses.zip
+
+    - name: Install MinGW
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      run: |
+        sudo apt update
+        sudo apt install -y mingw-w64
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      with:
+        sparse-checkout: |
+          scripts/ci-build-ncurses-with-mingw.sh
+
+    - name: Build ncurses with MinGW
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      run: ./scripts/ci-build-ncurses-with-mingw.sh
+
+    - name: Upload mingw-ncurses.zip
+      uses: actions/upload-artifact@v4
+      with:
+        name: mingw-ncurses.zip
+        path: ${{ github.workspace }}/mingw-ncurses.zip
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+  ci-linux-mingw:
+    needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Set up apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y mingw-w64 nuget
+        sudo apt remove -y jq
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download mingw-ncurses.zip
+      uses: actions/download-artifact@v4
+      with:
+        name: mingw-ncurses.zip
+        path: ${{ github.workspace }}/app/external
+
+    - name: Unzip mingw-ncurses.zip in app/external
+      run: |
+        cd app/external
+        unzip mingw-ncurses.zip
+
+    - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
+      env:
+        PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
+        CC: x86_64-w64-mingw32-gcc
+        MAKE: make
+        RUN_TESTS: false
+      run: |
+        export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
+        export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-nuget-package.sh
+
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-upload-release-artifacts.sh
+
+  ci-wsl-mingw:
+    needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
+    runs-on: windows-2025
+    timeout-minutes: 30
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Set up WSL 2
+      uses: Vampire/setup-wsl@v5
+      with:
+        wsl-version: 2
+        wsl-shell-command: bash --noprofile --norc -eo pipefail {0}
+        set-as-default: true
+        distribution: Ubuntu-22.04
+        additional-packages: |
+          build-essential
+          mingw-w64
+          sqlite3
+          nuget
+          tree
+          zip
+          tar
+          tmux
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download mingw-ncurses.zip
+      uses: actions/download-artifact@v4
+      with:
+        name: mingw-ncurses.zip
+        path: ${{ github.workspace }}/app/external
+
+    - name: Unzip mingw-ncurses.zip in app/external
+      run: |
+        cd app/external
+        unzip mingw-ncurses.zip
+
+    - name: Build (${{ env.AMD64_WSL_MINGW }})
+      env:
+        PREFIX: ${{ env.AMD64_WSL_MINGW }}
+        CC: x86_64-w64-mingw32-gcc
+        MAKE: make
+        RUN_TESTS: true
+        SKIP_BUILD: true
+        SKIP_ZIP_ARCHIVE: false
+        SKIP_TAR_ARCHIVE: true
+        WSLENV: ARTIFACT_DIR:TAG:PREFIX:CC:MAKE:RUN_TESTS:SKIP_BUILD:SKIP_ZIP_ARCHIVE:SKIP_TAR_ARCHIVE
+      shell: wsl-bash {0}
+      run: |
+        export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
+        export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
+        ./scripts/ci-build.sh
+
+    # - name: Prepare build artifacts for upload
+    #   run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    # - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WSL_MINGW }}.zip)
+    #   uses: actions/upload-artifact@v4
+    #   env:
+    #     ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WSL_MINGW }}.zip
+    #   with:
+    #     name: ${{ env.ARTIFACT_NAME }}
+    #     path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+    #     retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+    #     if-no-files-found: error
+
+  ci-musl:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    container: alpine:latest
+    timeout-minutes: 15
+
+    outputs:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Set up dependencies
+      shell: sh
+      run: apk add bash gcc make musl-dev perl ncurses-dev ncurses-static tmux file sqlite curl zip wget tar git
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build (${{ env.AMD64_LINUX_MUSL }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_MUSL }}
+        CC: gcc
+        MAKE: make
+        RUN_TESTS: true
+        STATIC_BUILD: "1"
+      run: ./scripts/ci-build.sh
+
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    - name: Attest build artifacts for release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+    - name: Set up GitHub CLI
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        wget https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.tar.gz
+        tar xvf gh_2.63.2_linux_amd64.tar.gz
+        cp gh_2.63.2_linux_amd64/bin/gh /usr/bin
+        rm -rf gh_2.63.2_linux_amd64
+
+    - name: Verify attestations of release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: ./scripts/ci-verify-attestations.sh
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload release artifacts
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        git config --global --add safe.directory "$PWD"
+        ./scripts/ci-upload-release-artifacts.sh
+
+  ghcr:
+    needs: ci-musl
+    runs-on: ubuntu-22.04
+
+    permissions:
+      packages: write
+
+    env:
+      TAG: ${{ needs.ci-musl.outputs.TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          Dockerfile.ci
+
+    - name: Download (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
+      uses: actions/download-artifact@v4
+      with:
+        name: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+        path: ${{ env.AMD64_LINUX_MUSL }}
+
+    - name: Unzip
+      env:
+        ZIP: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+        DIR: ${{ env.AMD64_LINUX_MUSL }}
+      run: |
+        cd "$DIR"
+        unzip -o "$ZIP"
+        cd ..
+        mkdir -p ./ci
+        mv ./"$DIR"/bin/zsv ./ci/
+        rm -rf ./"$DIR"
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push (on release)
+      uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_RECORD_UPLOAD: false
+      with:
+        no-cache: true
+        context: .
+        file: Dockerfile.ci
+        platforms: linux/amd64
+        push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        tags: |
+          ghcr.io/liquidaty/zsv:${{ env.TAG }}
+          ghcr.io/liquidaty/zsv:latest
+
+  ci-wasm:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Set up emsdk
+      uses: mymindstorm/setup-emsdk@v14
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Update version in index.html
+      run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
+
+    - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_WASM }}
+        CC: emcc
+        MAKE: make
+        RUN_TESTS: false
+        CONFIGFILE: "config.emcc"
+        CFLAGS: "-msse2 -msimd128"
+        CROSS_COMPILING: "yes"
+        NO_THREADING: "1"
+        STATIC_BUILD: "1"
+      run: |
+        emconfigure ./configure --enable-pic --disable-pie
+        emmake make install NO_STDIN=1 NO_PLAYGROUND=0
+        cp "$PREFIX"/bin/cli.em.{js,wasm} playground
+
+    - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_WASM }}
+        CC: emcc
+        MAKE: make
+        RUN_TESTS: false
+        CONFIGFILE: "config.emcc"
+        CROSS_COMPILING: "yes"
+        NO_THREADING: "1"
+        STATIC_BUILD: "1"
+      run: |
+        emconfigure ./configure --enable-pic --disable-pie
+        emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
+        mkdir -p playground/non-simd
+        cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
+
+    - name: Upload GitHub Pages artifacts
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: playground
+
+  deploy-wasm-playground:
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
+    needs: ci-wasm
+    runs-on: ubuntu-22.04
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,203 +65,205 @@ jobs:
         TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
       run: ./scripts/ci-set-tag-output-parameter.sh
 
-  clang-format:
-    runs-on: ubuntu-22.04
+  # clang-format:
+  #   runs-on: ubuntu-22.04
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Run clang-format
-      run: |
-        sudo ln -sf /usr/bin/clang-format-15 /usr/bin/clang-format
-        ./scripts/ci-run-clang-format.sh
+  #   - name: Run clang-format
+  #     run: |
+  #       sudo ln -sf /usr/bin/clang-format-15 /usr/bin/clang-format
+  #       ./scripts/ci-run-clang-format.sh
 
-  cppcheck:
-    runs-on: ubuntu-22.04
+  # cppcheck:
+  #   runs-on: ubuntu-22.04
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Install cppcheck
-      run: |
-        sudo apt update
-        sudo apt install -y cppcheck
-        cppcheck --version
+  #   - name: Install cppcheck
+  #     run: |
+  #       sudo apt update
+  #       sudo apt install -y cppcheck
+  #       cppcheck --version
 
-    - name: Run cppcheck
-      run: ./scripts/ci-run-cppcheck.sh
+  #   - name: Run cppcheck
+  #     run: ./scripts/ci-run-cppcheck.sh
 
-    - name: Upload (${{ env.CPPCHECK_XML_ARTIFACT_NAME }})
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
-        path: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (${{ env.CPPCHECK_XML_ARTIFACT_NAME }})
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
+  #       path: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (${{ env.CPPCHECK_HTML_ARTIFACT_NAME }})
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
-        path: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (${{ env.CPPCHECK_HTML_ARTIFACT_NAME }})
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
+  #       path: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-  shellcheck:
-    runs-on: ubuntu-22.04
+  # shellcheck:
+  #   runs-on: ubuntu-22.04
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Run shellcheck
-      run: ./scripts/ci-run-shellcheck.sh
+  #   - name: Run shellcheck
+  #     run: ./scripts/ci-run-shellcheck.sh
 
-  ci-linux:
-    needs: [tag, clang-format, cppcheck, shellcheck]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
+  # ci-linux:
+  #   needs: [tag, clang-format, cppcheck, shellcheck]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
 
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
 
-    - name: Set up apt dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y rpm alien tmux
-        sudo apt remove -y jq
+  #   - name: Set up apt dependencies
+  #     run: |
+  #       sudo apt update
+  #       sudo apt install -y rpm alien tmux
+  #       sudo apt remove -y jq
 
-    - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_GCC }}
-        CC: gcc
-        MAKE: make
-        RUN_TESTS: true
-      run: |
-        ./scripts/ci-build.sh
-        ./scripts/ci-create-debian-package.sh
-        ./scripts/ci-create-rpm-package.sh
+  #   - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_GCC }}
+  #       CC: gcc
+  #       MAKE: make
+  #       RUN_TESTS: true
+  #     run: |
+  #       ./scripts/ci-build.sh
+  #       ./scripts/ci-create-debian-package.sh
+  #       ./scripts/ci-create-rpm-package.sh
 
-    - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_CLANG }}
-        CC: clang
-        MAKE: make
-        RUN_TESTS: true
-      run: |
-        ./scripts/ci-build.sh
-        ./scripts/ci-create-debian-package.sh
-        ./scripts/ci-create-rpm-package.sh
+  #   - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_CLANG }}
+  #       CC: clang
+  #       MAKE: make
+  #       RUN_TESTS: true
+  #     run: |
+  #       ./scripts/ci-build.sh
+  #       ./scripts/ci-create-debian-package.sh
+  #       ./scripts/ci-create-rpm-package.sh
 
-    - name: Prepare build artifacts for upload
-      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+  #   - name: Prepare build artifacts for upload
+  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
-    - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/attest-build-provenance@v2
-      with:
-        subject-path: ${{ env.ARTIFACT_DIR }}/*
+  #   - name: Attest build artifacts for release
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     uses: actions/attest-build-provenance@v2
+  #     with:
+  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
 
-    - name: Verify attestations of release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-verify-attestations.sh
+  #   - name: Verify attestations of release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-verify-attestations.sh
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
 
-    - name: Upload release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-upload-release-artifacts.sh
+  #   - name: Upload release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-upload-release-artifacts.sh
 
   ci-macos:
-    needs: [tag, clang-format, cppcheck, shellcheck]
+    # needs: [tag, clang-format, cppcheck, shellcheck]
+    needs: [tag]
 
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        # os: [macos-13, macos-14]
+        os: [macos-13]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -341,496 +343,496 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/v')
       run: ./scripts/ci-upload-release-artifacts.sh
 
-  update-homebrew-tap:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    needs: ci-macos
-    runs-on: ubuntu-22.04
-
-    env:
-      TAG: ${{ needs.ci-macos.outputs.TAG }}
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        sparse-checkout: |
-          scripts/ci-update-homebrew-tap.sh
-
-    - name: Update
-      env:
-        HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
-      run: ./scripts/ci-update-homebrew-tap.sh
-
-  ci-bsd:
-    needs: [tag, clang-format, cppcheck, shellcheck]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Build (${{ env.AMD64_FREEBSD_GCC }})
-      uses: cross-platform-actions/action@v0.27.0
-      env:
-        PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
-        CC: gcc
-        MAKE: gmake
-        RUN_TESTS: true
-      with:
-        operating_system: freebsd
-        version: '13.2'
-        environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
-        shell: sh
-        run: |
-          ./scripts/ci-freebsd-setup.sh
-          ./scripts/ci-build.sh
-
-    - name: Prepare build artifacts for upload
-      run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-    - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/attest-build-provenance@v2
-      with:
-        subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-    - name: Verify attestations of release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-verify-attestations.sh
-
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
-    - name: Upload release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-upload-release-artifacts.sh
-
-  mingw-ncurses:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - name: Cache
-      uses: actions/cache@v4
-      id: cache
-      with:
-        key: mingw-ncurses.zip
-        path: ${{ github.workspace }}/mingw-ncurses.zip
-
-    - name: Install MinGW
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      run: |
-        sudo apt update
-        sudo apt install -y mingw-w64
-
-    - name: Checkout
-      uses: actions/checkout@v4
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      with:
-        sparse-checkout: |
-          scripts/ci-build-ncurses-with-mingw.sh
-
-    - name: Build ncurses with MinGW
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      run: ./scripts/ci-build-ncurses-with-mingw.sh
-
-    - name: Upload mingw-ncurses.zip
-      uses: actions/upload-artifact@v4
-      with:
-        name: mingw-ncurses.zip
-        path: ${{ github.workspace }}/mingw-ncurses.zip
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
-  ci-linux-mingw:
-    needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
-
-    steps:
-    - name: Set up apt dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y mingw-w64 nuget
-        sudo apt remove -y jq
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Download mingw-ncurses.zip
-      uses: actions/download-artifact@v4
-      with:
-        name: mingw-ncurses.zip
-        path: ${{ github.workspace }}/app/external
-
-    - name: Unzip mingw-ncurses.zip in app/external
-      run: |
-        cd app/external
-        unzip mingw-ncurses.zip
-
-    - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
-      env:
-        PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
-        CC: x86_64-w64-mingw32-gcc
-        MAKE: make
-        RUN_TESTS: false
-      run: |
-        export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
-        export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
-        ./scripts/ci-build.sh
-        ./scripts/ci-create-nuget-package.sh
-
-    - name: Prepare build artifacts for upload
-      run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-    - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/attest-build-provenance@v2
-      with:
-        subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-    - name: Verify attestations of release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-verify-attestations.sh
-
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
-    - name: Upload release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-upload-release-artifacts.sh
-
-  ci-wsl-mingw:
-    needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
-    runs-on: windows-2025
-    timeout-minutes: 30
-
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-    - name: Set up WSL 2
-      uses: Vampire/setup-wsl@v5
-      with:
-        wsl-version: 2
-        wsl-shell-command: bash --noprofile --norc -eo pipefail {0}
-        set-as-default: true
-        distribution: Ubuntu-22.04
-        additional-packages: |
-          build-essential
-          mingw-w64
-          sqlite3
-          nuget
-          tree
-          zip
-          tar
-          tmux
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Download mingw-ncurses.zip
-      uses: actions/download-artifact@v4
-      with:
-        name: mingw-ncurses.zip
-        path: ${{ github.workspace }}/app/external
-
-    - name: Unzip mingw-ncurses.zip in app/external
-      run: |
-        cd app/external
-        unzip mingw-ncurses.zip
-
-    - name: Build (${{ env.AMD64_WSL_MINGW }})
-      env:
-        PREFIX: ${{ env.AMD64_WSL_MINGW }}
-        CC: x86_64-w64-mingw32-gcc
-        MAKE: make
-        RUN_TESTS: true
-        SKIP_BUILD: true
-        SKIP_ZIP_ARCHIVE: false
-        SKIP_TAR_ARCHIVE: true
-        WSLENV: ARTIFACT_DIR:TAG:PREFIX:CC:MAKE:RUN_TESTS:SKIP_BUILD:SKIP_ZIP_ARCHIVE:SKIP_TAR_ARCHIVE
-      shell: wsl-bash {0}
-      run: |
-        export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
-        export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
-        ./scripts/ci-build.sh
-
-    # - name: Prepare build artifacts for upload
-    #   run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-    # - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WSL_MINGW }}.zip)
-    #   uses: actions/upload-artifact@v4
-    #   env:
-    #     ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WSL_MINGW }}.zip
-    #   with:
-    #     name: ${{ env.ARTIFACT_NAME }}
-    #     path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-    #     retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-    #     if-no-files-found: error
-
-  ci-musl:
-    needs: [tag, clang-format, cppcheck, shellcheck]
-    runs-on: ubuntu-22.04
-    container: alpine:latest
-    timeout-minutes: 15
-
-    outputs:
-      TAG: ${{ needs.tag.outputs.TAG }}
-
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
-
-    steps:
-    - name: Set up dependencies
-      shell: sh
-      run: apk add bash gcc make musl-dev perl ncurses-dev ncurses-static tmux file sqlite curl zip wget tar git
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Build (${{ env.AMD64_LINUX_MUSL }})
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_MUSL }}
-        CC: gcc
-        MAKE: make
-        RUN_TESTS: true
-        STATIC_BUILD: "1"
-      run: ./scripts/ci-build.sh
-
-    - name: Prepare build artifacts for upload
-      run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-    - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: actions/attest-build-provenance@v2
-      with:
-        subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-    - name: Set up GitHub CLI
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: |
-        wget https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.tar.gz
-        tar xvf gh_2.63.2_linux_amd64.tar.gz
-        cp gh_2.63.2_linux_amd64/bin/gh /usr/bin
-        rm -rf gh_2.63.2_linux_amd64
-
-    - name: Verify attestations of release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: ./scripts/ci-verify-attestations.sh
-
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
-    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.tar.gz)
-      uses: actions/upload-artifact@v4
-      env:
-        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.tar.gz
-      with:
-        name: ${{ env.ARTIFACT_NAME }}
-        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-        if-no-files-found: error
-
-    - name: Upload release artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
-      run: |
-        git config --global --add safe.directory "$PWD"
-        ./scripts/ci-upload-release-artifacts.sh
-
-  ghcr:
-    needs: ci-musl
-    runs-on: ubuntu-22.04
-
-    permissions:
-      packages: write
-
-    env:
-      TAG: ${{ needs.ci-musl.outputs.TAG }}
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        sparse-checkout: |
-          Dockerfile.ci
-
-    - name: Download (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
-      uses: actions/download-artifact@v4
-      with:
-        name: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-        path: ${{ env.AMD64_LINUX_MUSL }}
-
-    - name: Unzip
-      env:
-        ZIP: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
-        DIR: ${{ env.AMD64_LINUX_MUSL }}
-      run: |
-        cd "$DIR"
-        unzip -o "$ZIP"
-        cd ..
-        mkdir -p ./ci
-        mv ./"$DIR"/bin/zsv ./ci/
-        rm -rf ./"$DIR"
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Login to GitHub Container Registry
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build and push (on release)
-      uses: docker/build-push-action@v6
-      env:
-        DOCKER_BUILD_RECORD_UPLOAD: false
-      with:
-        no-cache: true
-        context: .
-        file: Dockerfile.ci
-        platforms: linux/amd64
-        push: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        tags: |
-          ghcr.io/liquidaty/zsv:${{ env.TAG }}
-          ghcr.io/liquidaty/zsv:latest
-
-  ci-wasm:
-    needs: [tag, clang-format, cppcheck, shellcheck]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-
-    env:
-      TAG: ${{ needs.tag.outputs.TAG }}
-
-    steps:
-    - name: Set up emsdk
-      uses: mymindstorm/setup-emsdk@v14
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Update version in index.html
-      run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
-
-    - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_WASM }}
-        CC: emcc
-        MAKE: make
-        RUN_TESTS: false
-        CONFIGFILE: "config.emcc"
-        CFLAGS: "-msse2 -msimd128"
-        CROSS_COMPILING: "yes"
-        NO_THREADING: "1"
-        STATIC_BUILD: "1"
-      run: |
-        emconfigure ./configure --enable-pic --disable-pie
-        emmake make install NO_STDIN=1 NO_PLAYGROUND=0
-        cp "$PREFIX"/bin/cli.em.{js,wasm} playground
-
-    - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
-      env:
-        PREFIX: ${{ env.AMD64_LINUX_WASM }}
-        CC: emcc
-        MAKE: make
-        RUN_TESTS: false
-        CONFIGFILE: "config.emcc"
-        CROSS_COMPILING: "yes"
-        NO_THREADING: "1"
-        STATIC_BUILD: "1"
-      run: |
-        emconfigure ./configure --enable-pic --disable-pie
-        emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
-        mkdir -p playground/non-simd
-        cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
-
-    - name: Upload GitHub Pages artifacts
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: playground
-
-  deploy-wasm-playground:
-    if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
-    needs: ci-wasm
-    runs-on: ubuntu-22.04
-
-    permissions:
-      pages: write
-      id-token: write
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+  # update-homebrew-tap:
+  #   if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  #   needs: ci-macos
+  #   runs-on: ubuntu-22.04
+
+  #   env:
+  #     TAG: ${{ needs.ci-macos.outputs.TAG }}
+
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     with:
+  #       sparse-checkout: |
+  #         scripts/ci-update-homebrew-tap.sh
+
+  #   - name: Update
+  #     env:
+  #       HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+  #     run: ./scripts/ci-update-homebrew-tap.sh
+
+  # ci-bsd:
+  #   needs: [tag, clang-format, cppcheck, shellcheck]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
+
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
+
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+
+  #   - name: Build (${{ env.AMD64_FREEBSD_GCC }})
+  #     uses: cross-platform-actions/action@v0.27.0
+  #     env:
+  #       PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
+  #       CC: gcc
+  #       MAKE: gmake
+  #       RUN_TESTS: true
+  #     with:
+  #       operating_system: freebsd
+  #       version: '13.2'
+  #       environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
+  #       shell: sh
+  #       run: |
+  #         ./scripts/ci-freebsd-setup.sh
+  #         ./scripts/ci-build.sh
+
+  #   - name: Prepare build artifacts for upload
+  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+  #   - name: Attest build artifacts for release
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     uses: actions/attest-build-provenance@v2
+  #     with:
+  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+  #   - name: Verify attestations of release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-verify-attestations.sh
+
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
+
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
+
+  #   - name: Upload release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-upload-release-artifacts.sh
+
+  # mingw-ncurses:
+  #   runs-on: ubuntu-22.04
+
+  #   steps:
+  #   - name: Cache
+  #     uses: actions/cache@v4
+  #     id: cache
+  #     with:
+  #       key: mingw-ncurses.zip
+  #       path: ${{ github.workspace }}/mingw-ncurses.zip
+
+  #   - name: Install MinGW
+  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+  #     run: |
+  #       sudo apt update
+  #       sudo apt install -y mingw-w64
+
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+  #     with:
+  #       sparse-checkout: |
+  #         scripts/ci-build-ncurses-with-mingw.sh
+
+  #   - name: Build ncurses with MinGW
+  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+  #     run: ./scripts/ci-build-ncurses-with-mingw.sh
+
+  #   - name: Upload mingw-ncurses.zip
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: mingw-ncurses.zip
+  #       path: ${{ github.workspace }}/mingw-ncurses.zip
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
+
+  # ci-linux-mingw:
+  #   needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
+
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
+
+  #   steps:
+  #   - name: Set up apt dependencies
+  #     run: |
+  #       sudo apt update
+  #       sudo apt install -y mingw-w64 nuget
+  #       sudo apt remove -y jq
+
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+
+  #   - name: Download mingw-ncurses.zip
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: mingw-ncurses.zip
+  #       path: ${{ github.workspace }}/app/external
+
+  #   - name: Unzip mingw-ncurses.zip in app/external
+  #     run: |
+  #       cd app/external
+  #       unzip mingw-ncurses.zip
+
+  #   - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
+  #       CC: x86_64-w64-mingw32-gcc
+  #       MAKE: make
+  #       RUN_TESTS: false
+  #     run: |
+  #       export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
+  #       export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
+  #       ./scripts/ci-build.sh
+  #       ./scripts/ci-create-nuget-package.sh
+
+  #   - name: Prepare build artifacts for upload
+  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+  #   - name: Attest build artifacts for release
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     uses: actions/attest-build-provenance@v2
+  #     with:
+  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+  #   - name: Verify attestations of release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-verify-attestations.sh
+
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
+
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
+
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
+
+  #   - name: Upload release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-upload-release-artifacts.sh
+
+  # ci-wsl-mingw:
+  #   needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
+  #   runs-on: windows-2025
+  #   timeout-minutes: 30
+
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
+
+  #   defaults:
+  #     run:
+  #       shell: bash
+
+  #   steps:
+  #   - name: Set up WSL 2
+  #     uses: Vampire/setup-wsl@v5
+  #     with:
+  #       wsl-version: 2
+  #       wsl-shell-command: bash --noprofile --norc -eo pipefail {0}
+  #       set-as-default: true
+  #       distribution: Ubuntu-22.04
+  #       additional-packages: |
+  #         build-essential
+  #         mingw-w64
+  #         sqlite3
+  #         nuget
+  #         tree
+  #         zip
+  #         tar
+  #         tmux
+
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+
+  #   - name: Download mingw-ncurses.zip
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: mingw-ncurses.zip
+  #       path: ${{ github.workspace }}/app/external
+
+  #   - name: Unzip mingw-ncurses.zip in app/external
+  #     run: |
+  #       cd app/external
+  #       unzip mingw-ncurses.zip
+
+  #   - name: Build (${{ env.AMD64_WSL_MINGW }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_WSL_MINGW }}
+  #       CC: x86_64-w64-mingw32-gcc
+  #       MAKE: make
+  #       RUN_TESTS: true
+  #       SKIP_BUILD: true
+  #       SKIP_ZIP_ARCHIVE: false
+  #       SKIP_TAR_ARCHIVE: true
+  #       WSLENV: ARTIFACT_DIR:TAG:PREFIX:CC:MAKE:RUN_TESTS:SKIP_BUILD:SKIP_ZIP_ARCHIVE:SKIP_TAR_ARCHIVE
+  #     shell: wsl-bash {0}
+  #     run: |
+  #       export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
+  #       export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
+  #       ./scripts/ci-build.sh
+
+  #   # - name: Prepare build artifacts for upload
+  #   #   run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+  #   # - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WSL_MINGW }}.zip)
+  #   #   uses: actions/upload-artifact@v4
+  #   #   env:
+  #   #     ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WSL_MINGW }}.zip
+  #   #   with:
+  #   #     name: ${{ env.ARTIFACT_NAME }}
+  #   #     path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #   #     retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #   #     if-no-files-found: error
+
+  # ci-musl:
+  #   needs: [tag, clang-format, cppcheck, shellcheck]
+  #   runs-on: ubuntu-22.04
+  #   container: alpine:latest
+  #   timeout-minutes: 15
+
+  #   outputs:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
+
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
+
+  #   steps:
+  #   - name: Set up dependencies
+  #     shell: sh
+  #     run: apk add bash gcc make musl-dev perl ncurses-dev ncurses-static tmux file sqlite curl zip wget tar git
+
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+
+  #   - name: Build (${{ env.AMD64_LINUX_MUSL }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_MUSL }}
+  #       CC: gcc
+  #       MAKE: make
+  #       RUN_TESTS: true
+  #       STATIC_BUILD: "1"
+  #     run: ./scripts/ci-build.sh
+
+  #   - name: Prepare build artifacts for upload
+  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+  #   - name: Attest build artifacts for release
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     uses: actions/attest-build-provenance@v2
+  #     with:
+  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+  #   - name: Set up GitHub CLI
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: |
+  #       wget https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_amd64.tar.gz
+  #       tar xvf gh_2.63.2_linux_amd64.tar.gz
+  #       cp gh_2.63.2_linux_amd64/bin/gh /usr/bin
+  #       rm -rf gh_2.63.2_linux_amd64
+
+  #   - name: Verify attestations of release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: ./scripts/ci-verify-attestations.sh
+
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
+
+  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.tar.gz)
+  #     uses: actions/upload-artifact@v4
+  #     env:
+  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.tar.gz
+  #     with:
+  #       name: ${{ env.ARTIFACT_NAME }}
+  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+  #       if-no-files-found: error
+
+  #   - name: Upload release artifacts
+  #     if: startsWith(github.ref, 'refs/tags/v')
+  #     run: |
+  #       git config --global --add safe.directory "$PWD"
+  #       ./scripts/ci-upload-release-artifacts.sh
+
+  # ghcr:
+  #   needs: ci-musl
+  #   runs-on: ubuntu-22.04
+
+  #   permissions:
+  #     packages: write
+
+  #   env:
+  #     TAG: ${{ needs.ci-musl.outputs.TAG }}
+
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     with:
+  #       sparse-checkout: |
+  #         Dockerfile.ci
+
+  #   - name: Download (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip)
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       name: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+  #       path: ${{ env.AMD64_LINUX_MUSL }}
+
+  #   - name: Unzip
+  #     env:
+  #       ZIP: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_MUSL }}.zip
+  #       DIR: ${{ env.AMD64_LINUX_MUSL }}
+  #     run: |
+  #       cd "$DIR"
+  #       unzip -o "$ZIP"
+  #       cd ..
+  #       mkdir -p ./ci
+  #       mv ./"$DIR"/bin/zsv ./ci/
+  #       rm -rf ./"$DIR"
+
+  #   - name: Set up QEMU
+  #     uses: docker/setup-qemu-action@v3
+
+  #   - name: Set up Docker Buildx
+  #     uses: docker/setup-buildx-action@v3
+
+  #   - name: Login to GitHub Container Registry
+  #     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  #     uses: docker/login-action@v3
+  #     with:
+  #       registry: ghcr.io
+  #       username: ${{ github.repository_owner }}
+  #       password: ${{ secrets.GITHUB_TOKEN }}
+
+  #   - name: Build and push (on release)
+  #     uses: docker/build-push-action@v6
+  #     env:
+  #       DOCKER_BUILD_RECORD_UPLOAD: false
+  #     with:
+  #       no-cache: true
+  #       context: .
+  #       file: Dockerfile.ci
+  #       platforms: linux/amd64
+  #       push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  #       tags: |
+  #         ghcr.io/liquidaty/zsv:${{ env.TAG }}
+  #         ghcr.io/liquidaty/zsv:latest
+
+  # ci-wasm:
+  #   needs: [tag, clang-format, cppcheck, shellcheck]
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 15
+
+  #   env:
+  #     TAG: ${{ needs.tag.outputs.TAG }}
+
+  #   steps:
+  #   - name: Set up emsdk
+  #     uses: mymindstorm/setup-emsdk@v14
+
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+
+  #   - name: Update version in index.html
+  #     run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
+
+  #   - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
+  #       CC: emcc
+  #       MAKE: make
+  #       RUN_TESTS: false
+  #       CONFIGFILE: "config.emcc"
+  #       CFLAGS: "-msse2 -msimd128"
+  #       CROSS_COMPILING: "yes"
+  #       NO_THREADING: "1"
+  #       STATIC_BUILD: "1"
+  #     run: |
+  #       emconfigure ./configure --enable-pic --disable-pie
+  #       emmake make install NO_STDIN=1 NO_PLAYGROUND=0
+  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground
+
+  #   - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
+  #     env:
+  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
+  #       CC: emcc
+  #       MAKE: make
+  #       RUN_TESTS: false
+  #       CONFIGFILE: "config.emcc"
+  #       CROSS_COMPILING: "yes"
+  #       NO_THREADING: "1"
+  #       STATIC_BUILD: "1"
+  #     run: |
+  #       emconfigure ./configure --enable-pic --disable-pie
+  #       emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
+  #       mkdir -p playground/non-simd
+  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
+
+  #   - name: Upload GitHub Pages artifacts
+  #     uses: actions/upload-pages-artifact@v3
+  #     with:
+  #       path: playground
+
+  # deploy-wasm-playground:
+  #   if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
+  #   needs: ci-wasm
+  #   runs-on: ubuntu-22.04
+
+  #   permissions:
+  #     pages: write
+  #     id-token: write
+
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+
+  #   steps:
+  #   - name: Deploy to GitHub Pages
+  #     id: deployment
+  #     uses: actions/deploy-pages@v4

--- a/playground/index.html
+++ b/playground/index.html
@@ -148,6 +148,8 @@
     };
 
     Module['onRuntimeInitialized'] = () => {
+      console.log('Initializing zsv playground, please wait...');
+
       const root = '/home/zsv';
       FS.mkdir(root);
       FS.chdir(root);

--- a/scripts/test-expect.sh
+++ b/scripts/test-expect.sh
@@ -42,12 +42,12 @@ trap cleanup INT TERM QUIT
 printf "\n%s, %s" "$TARGET" "$STAGE" >>"$TIMINGS_CSV"
 
 set +e
-MATCHED_TIME=$(time -p timeout -k $((EXPECT_TIMEOUT + 1)) "$EXPECT_TIMEOUT" "$SCRIPT_DIR"/test-retry-capture-cmp.sh 2>&1)
+MATCHED_TIME=$($(which time) -p timeout -k $((EXPECT_TIMEOUT + 1)) "$EXPECT_TIMEOUT" "$SCRIPT_DIR"/test-retry-capture-cmp.sh 2>&1)
 STATUS=$?
 set -e
 
 if [ $STATUS -eq 0 ]; then
-  MATCHED_TIME=$(echo "$MATCHED_TIME" | head -n1 | cut -d' ' -f2)
+  MATCHED_TIME=$(echo "$MATCHED_TIME" | grep '^real' | cut -d' ' -f2)
   if echo "$MATCHED_TIME" | grep -qE '^[0-9]*\.?[0-9]+$' >/dev/null 2>&1; then
     MATCHED=true
     echo "$TARGET$STAGE took $MATCHED_TIME"

--- a/scripts/test-expect.sh
+++ b/scripts/test-expect.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/sh -eux
 
 SCRIPT_DIR=$(dirname "$0")
 
@@ -51,10 +51,10 @@ if [ $STATUS -eq 0 ]; then
   if echo "$MATCHED_TIME" | grep -qE '^[0-9]*\.?[0-9]+$' >/dev/null 2>&1; then
     MATCHED=true
     echo "$TARGET$STAGE took $MATCHED_TIME"
-    printf ", %s" "$MATCHED_TIME" >>"${TIMINGS_CSV}"
+    printf ", %s" "$MATCHED_TIME" >>"$TIMINGS_CSV"
   else
     echo "Invalid timing value! [$MATCHED_TIME]"
-    printf ", error" >>"${TIMINGS_CSV}"
+    printf ", error" >>"$TIMINGS_CSV"
   fi
 fi
 

--- a/scripts/test-expect.sh
+++ b/scripts/test-expect.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -eux
+#!/bin/sh -eu
 
 SCRIPT_DIR=$(dirname "$0")
 

--- a/scripts/test-expect.sh
+++ b/scripts/test-expect.sh
@@ -42,7 +42,7 @@ trap cleanup INT TERM QUIT
 printf "\n%s, %s" "$TARGET" "$STAGE" >>"$TIMINGS_CSV"
 
 set +e
-MATCHED_TIME=$($(which time) -p timeout -k $((EXPECT_TIMEOUT + 1)) "$EXPECT_TIMEOUT" "$SCRIPT_DIR"/test-retry-capture-cmp.sh 2>&1)
+MATCHED_TIME=$(/usr/bin/time -p timeout -k $((EXPECT_TIMEOUT + 1)) "$EXPECT_TIMEOUT" "$SCRIPT_DIR"/test-retry-capture-cmp.sh 2>&1)
 STATUS=$?
 set -e
 

--- a/scripts/test-expect.sh
+++ b/scripts/test-expect.sh
@@ -39,17 +39,17 @@ cleanup() {
 
 trap cleanup INT TERM QUIT
 
-printf "\n%s, %s" "$TARGET" "$STAGE" >>"${TIMINGS_CSV}"
+printf "\n%s, %s" "$TARGET" "$STAGE" >>"$TIMINGS_CSV"
 
 set +e
-MATCHED_TIME=$(time -p timeout -k $((EXPECT_TIMEOUT + 1)) "$EXPECT_TIMEOUT" "${SCRIPT_DIR}"/test-retry-capture-cmp.sh 2>&1)
+MATCHED_TIME=$(time -p timeout -k $((EXPECT_TIMEOUT + 1)) "$EXPECT_TIMEOUT" "$SCRIPT_DIR"/test-retry-capture-cmp.sh 2>&1)
 STATUS=$?
 set -e
 
 if [ $STATUS -eq 0 ]; then
-  MATCHED=true
-  MATCHED_TIME=$(echo "$MATCHED_TIME" | head -n 1 | cut -f 2 -d ' ')
+  MATCHED_TIME=$(echo "$MATCHED_TIME" | head -n1 | cut -d' ' -f2)
   if echo "$MATCHED_TIME" | grep -qE '^[0-9]*\.?[0-9]+$' >/dev/null 2>&1; then
+    MATCHED=true
     echo "$TARGET$STAGE took $MATCHED_TIME"
     printf ", %s" "$MATCHED_TIME" >>"${TIMINGS_CSV}"
   else

--- a/scripts/test-retry-capture-cmp.sh
+++ b/scripts/test-retry-capture-cmp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -eux
 
-while true; do
+while :; do
   tmux capture-pane -t "$TARGET" -p >"$CAPTURED_OUTPUT"
 
   if ${CMP} -s "$CAPTURED_OUTPUT" "$EXPECTED_OUTPUT"; then

--- a/scripts/test-retry-capture-cmp.sh
+++ b/scripts/test-retry-capture-cmp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -eux
+#!/bin/sh -eu
 
 while :; do
   tmux capture-pane -t "$TARGET" -p >"$CAPTURED_OUTPUT"

--- a/scripts/test-retry-capture-cmp.sh
+++ b/scripts/test-retry-capture-cmp.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/sh -eux
 
 while true; do
   tmux capture-pane -t "$TARGET" -p >"$CAPTURED_OUTPUT"


### PR DESCRIPTION
Apparently, the handling of time is different on macOS.

Observed following in https://github.com/liquidaty/zsv/actions/runs/15184719799/job/42703430039#step:5:1066:

```shell
test-sheet-2: 
real 0.40
user 0.02
sys 0.03
Invalid timing value! []
real 0.02
user 0.00
sys 0.01
Invalid timing value! []
...
```

The log `Invalid timing value! []` has recently been added while testing on WSL.
Looking at the older workflow runs, it seems like it's been broken for quite some time now.

Fixing this issue and adding more robust error handling to fail fast.

**UPDATE**

On macOS, the output of `time` command was not being redirected correctly due to the differences between `time` shell builtin and the `/usr/bin/time` executable.
See details here: https://askubuntu.com/questions/1054456/what-is-the-difference-between-time-and-usr-bin-time
Using `/usr/bin/time` instead of `time` fixed it.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>