### PR TITLE
[CI] Use macOS 15 runners (X64 and ARM64)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   amd64-macos-gcc:
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-15-intel, macos-latest]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/setup-action.yml
+++ b/.github/workflows/setup-action.yml
@@ -16,7 +16,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     defaults:


### PR DESCRIPTION
Related: #403

- Used `macos-15-intel` runner instead of `macos-13`
  - https://github.com/actions/runner-images/issues/13045
  - https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
- Updated automatic formula for https://github.com/liquidaty/homebrew-zsv/pull/3

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>