### PR TITLE
[CI] Fix musl build version issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,599 +72,598 @@ jobs:
         TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
       run: ./scripts/ci-set-tag-output-parameter.sh
 
-  # clang-format:
-  #   runs-on: ubuntu-22.04
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-
-  #   - name: Run clang-format
-  #     run: |
-  #       sudo ln -sf /usr/bin/clang-format-15 /usr/bin/clang-format
-  #       ./scripts/ci-run-clang-format.sh
-
-  # cppcheck:
-  #   runs-on: ubuntu-22.04
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-
-  #   - name: Install cppcheck
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y cppcheck
-  #       cppcheck --version
-
-  #   - name: Run cppcheck
-  #     run: ./scripts/ci-run-cppcheck.sh
-
-  #   - name: Upload (${{ env.CPPCHECK_XML_ARTIFACT_NAME }})
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
-  #       path: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (${{ env.CPPCHECK_HTML_ARTIFACT_NAME }})
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
-  #       path: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  # shellcheck:
-  #   runs-on: ubuntu-22.04
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-
-  #   - name: Run shellcheck
-  #     run: ./scripts/ci-run-shellcheck.sh
-
-  # ci-linux:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   outputs:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-
-  #   - name: Set up apt dependencies
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y rpm alien tmux
-  #       sudo apt remove -y jq
-
-  #   - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_GCC }}
-  #       CC: gcc
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: |
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-debian-package.sh
-  #       ./scripts/ci-create-rpm-package.sh
-
-  #   - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_CLANG }}
-  #       CC: clang
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: |
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-debian-package.sh
-  #       ./scripts/ci-create-rpm-package.sh
-
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v3
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
-
-  # prepare-linux-packages:
-  #   if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
-  #   needs: [ci-linux]
-  #   runs-on: ubuntu-latest
-
-  #   env:
-  #     TAG: ${{ needs.ci-linux.outputs.TAG }}
-  #     AMD64_ZIP: zsv-${{ needs.ci-linux.outputs.TAG }}-amd64-linux-gcc.zip
-
-  #   steps:
-  #   - name: Install dependencies
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y rpm dpkg-dev createrepo-c
-  #       sudo gem install --no-document fpm
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-  #     with:
-  #       sparse-checkout: |
-  #         .fpm
-  #         scripts/ci-prepare-deb-rpm-repos.sh
-
-  #   - name: Download ${{ env.AMD64_ZIP }}
-  #     uses: actions/download-artifact@v5
-  #     with:
-  #       name: ${{ env.AMD64_ZIP }}
-  #       path: ${{ env.ARTIFACT_DIR }}
-
-  #   - name: Prepare DEB and RPM package repos
-  #     run: ./scripts/ci-prepare-deb-rpm-repos.sh
-
-  #   - name: Upload packages artifact
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: packages
-  #       path: ${{ env.ARTIFACT_DIR }}/packages
-
-  # ci-macos:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-
-  #   strategy:
-  #     matrix:
-  #       os: [macos-15-intel, macos-latest]
-
-  #   runs-on: ${{ matrix.os }}
-  #   timeout-minutes: 30
-
-  #   outputs:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-
-  #   - name: Set up homebrew dependencies
-  #     run: brew install --quiet coreutils tree autoconf automake libtool tmux sqlite3
-
-  #   - name: Set PREFIX and ZIP env var
-  #     env:
-  #       PREFIX: ${{ runner.arch == 'X64' && env.AMD64_MACOSX_GCC || env.ARM64_MACOSX_GCC }}
-  #     run: |
-  #       {
-  #         echo "PREFIX=$PREFIX"
-  #         echo "ZIP=zsv-$TAG-$PREFIX.zip"
-  #         echo "TAR=zsv-$TAG-$PREFIX.tar.gz"
-  #       } | tee -a "$GITHUB_ENV"
-
-  #   - name: Build on macOS (${{ env.AMD64_MACOSX_GCC }})
-  #     env:
-  #       CC: gcc-13
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #     run: ./scripts/ci-build.sh
-
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-  #   - name: Codesign and notarize (${{ env.ZIP }})
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     env:
-  #       MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
-  #       MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-  #       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-  #     run: ./scripts/ci-macos-codesign-and-notarize.sh "$PWD/$ARTIFACT_DIR/$ZIP"
-
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v3
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
-
-  #   - name: Upload (${{ env.ZIP }})
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: ${{ env.ZIP }}
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (${{ env.TAR }})
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: ${{ env.TAR }}
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
-
-  # update-homebrew-tap:
-  #   if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-  #   needs: ci-macos
-  #   runs-on: ubuntu-22.04
-
-  #   env:
-  #     TAG: ${{ needs.ci-macos.outputs.TAG }}
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-  #     with:
-  #       sparse-checkout: |
-  #         scripts/ci-update-homebrew-tap.sh
-
-  #   - name: Update
-  #     env:
-  #       HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
-  #     run: ./scripts/ci-update-homebrew-tap.sh
-
-  # ci-bsd:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-
-  #   - name: Build (${{ env.AMD64_FREEBSD_GCC }})
-  #     uses: cross-platform-actions/action@v0.29.0
-  #     env:
-  #       PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
-  #       CC: gcc
-  #       MAKE: gmake
-  #       RUN_TESTS: true
-  #     with:
-  #       operating_system: freebsd
-  #       version: '13.2'
-  #       environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
-  #       shell: sh
-  #       run: |
-  #         ./scripts/ci-freebsd-setup.sh
-  #         ./scripts/ci-build.sh
-
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v3
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
-
-  # mingw-ncurses:
-  #   runs-on: ubuntu-22.04
-
-  #   steps:
-  #   - name: Cache
-  #     uses: actions/cache@v4
-  #     id: cache
-  #     with:
-  #       key: mingw-ncurses.zip
-  #       path: ${{ github.workspace }}/mingw-ncurses.zip
-
-  #   - name: Install MinGW
-  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y mingw-w64
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-  #     with:
-  #       sparse-checkout: |
-  #         scripts/ci-build-ncurses-with-mingw.sh
-
-  #   - name: Build ncurses with MinGW
-  #     if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-  #     run: ./scripts/ci-build-ncurses-with-mingw.sh
-
-  #   - name: Upload mingw-ncurses.zip
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: mingw-ncurses.zip
-  #       path: ${{ github.workspace }}/mingw-ncurses.zip
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  # ci-linux-mingw:
-  #   needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   outputs:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   steps:
-  #   - name: Set up apt dependencies
-  #     run: |
-  #       sudo apt update
-  #       sudo apt install -y mingw-w64 nuget
-  #       sudo apt remove -y jq
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-
-  #   - name: Download mingw-ncurses.zip
-  #     uses: actions/download-artifact@v5
-  #     with:
-  #       name: mingw-ncurses.zip
-  #       path: ${{ github.workspace }}/app/external
-
-  #   - name: Unzip mingw-ncurses.zip in app/external
-  #     run: |
-  #       cd app/external
-  #       unzip mingw-ncurses.zip
-
-  #   - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
-  #       CC: x86_64-w64-mingw32-gcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #     run: |
-  #       export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
-  #       export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
-  #       ./scripts/ci-build.sh
-  #       ./scripts/ci-create-nuget-package.sh
-
-  #   - name: Prepare build artifacts for upload
-  #     run: ./scripts/ci-prepare-artifacts-for-upload.sh
-
-  #   - name: Attest build artifacts for release
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     uses: actions/attest-build-provenance@v3
-  #     with:
-  #       subject-path: ${{ env.ARTIFACT_DIR }}/*
-
-  #   - name: Verify attestations of release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-verify-attestations.sh
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
-  #     uses: actions/upload-artifact@v4
-  #     env:
-  #       ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
-  #     with:
-  #       name: ${{ env.ARTIFACT_NAME }}
-  #       path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
-
-  #   - name: Upload release artifacts
-  #     if: startsWith(github.ref, 'refs/tags/v')
-  #     run: ./scripts/ci-upload-release-artifacts.sh
-
-  # ci-wsl-mingw:
-  #   if: ${{ github.event_name == 'workflow_dispatch' && inputs.wsl == true }}
-  #   needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
-  #   runs-on: windows-2025
-  #   timeout-minutes: 30
-
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
-
-  #   defaults:
-  #     run:
-  #       shell: bash
-
-  #   steps:
-  #   - name: Set up WSL 2
-  #     uses: Vampire/setup-wsl@v6
-  #     with:
-  #       wsl-version: 2
-  #       wsl-shell-command: bash --noprofile --norc -eo pipefail {0}
-  #       set-as-default: true
-  #       distribution: Ubuntu-22.04
-  #       additional-packages: |
-  #         build-essential
-  #         mingw-w64
-  #         sqlite3
-  #         nuget
-  #         tree
-  #         zip
-  #         tar
-  #         tmux
-
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
-
-  #   - name: Download mingw-ncurses.zip
-  #     uses: actions/download-artifact@v5
-  #     with:
-  #       name: mingw-ncurses.zip
-  #       path: ${{ github.workspace }}/app/external
-
-  #   - name: Unzip mingw-ncurses.zip in app/external
-  #     run: |
-  #       cd app/external
-  #       unzip mingw-ncurses.zip
-
-  #   - name: Build (${{ env.AMD64_WSL_MINGW }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_WSL_MINGW }}
-  #       CC: x86_64-w64-mingw32-gcc
-  #       MAKE: make
-  #       RUN_TESTS: true
-  #       SKIP_BUILD: true
-  #       SKIP_ZIP_ARCHIVE: false
-  #       SKIP_TAR_ARCHIVE: true
-  #       WSLENV: ARTIFACT_DIR:TAG:PREFIX:CC:MAKE:RUN_TESTS:SKIP_BUILD:SKIP_ZIP_ARCHIVE:SKIP_TAR_ARCHIVE
-  #     shell: wsl-bash {0}
-  #     run: |
-  #       export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
-  #       export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
-  #       ./scripts/ci-build.sh
+  clang-format:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Run clang-format
+      run: |
+        sudo ln -sf /usr/bin/clang-format-15 /usr/bin/clang-format
+        ./scripts/ci-run-clang-format.sh
+
+  cppcheck:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Install cppcheck
+      run: |
+        sudo apt update
+        sudo apt install -y cppcheck
+        cppcheck --version
+
+    - name: Run cppcheck
+      run: ./scripts/ci-run-cppcheck.sh
+
+    - name: Upload (${{ env.CPPCHECK_XML_ARTIFACT_NAME }})
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
+        path: ${{ env.CPPCHECK_XML_ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (${{ env.CPPCHECK_HTML_ARTIFACT_NAME }})
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
+        path: ${{ env.CPPCHECK_HTML_ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+  shellcheck:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Run shellcheck
+      run: ./scripts/ci-run-shellcheck.sh
+
+  ci-linux:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    outputs:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Set up apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y rpm alien tmux
+        sudo apt remove -y jq
+
+    - name: Build on Linux (${{ env.AMD64_LINUX_GCC }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_GCC }}
+        CC: gcc
+        MAKE: make
+        RUN_TESTS: true
+      run: |
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-debian-package.sh
+        ./scripts/ci-create-rpm-package.sh
+
+    - name: Build on Linux (${{ env.AMD64_LINUX_CLANG }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_CLANG }}
+        CC: clang
+        MAKE: make
+        RUN_TESTS: true
+      run: |
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-debian-package.sh
+        ./scripts/ci-create-rpm-package.sh
+
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    - name: Attest build artifacts for release
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      uses: actions/attest-build-provenance@v3
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+    - name: Verify attestations of release artifacts
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: ./scripts/ci-verify-attestations.sh
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.deb
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.deb
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.rpm
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.rpm
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_GCC }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_LINUX_CLANG }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload release artifacts
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: ./scripts/ci-upload-release-artifacts.sh
+
+  prepare-linux-packages:
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
+    needs: [ci-linux]
+    runs-on: ubuntu-latest
+
+    env:
+      TAG: ${{ needs.ci-linux.outputs.TAG }}
+      AMD64_ZIP: zsv-${{ needs.ci-linux.outputs.TAG }}-amd64-linux-gcc.zip
+
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y rpm dpkg-dev createrepo-c
+        sudo gem install --no-document fpm
+
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        sparse-checkout: |
+          .fpm
+          scripts/ci-prepare-deb-rpm-repos.sh
+
+    - name: Download ${{ env.AMD64_ZIP }}
+      uses: actions/download-artifact@v5
+      with:
+        name: ${{ env.AMD64_ZIP }}
+        path: ${{ env.ARTIFACT_DIR }}
+
+    - name: Prepare DEB and RPM package repos
+      run: ./scripts/ci-prepare-deb-rpm-repos.sh
+
+    - name: Upload packages artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: ${{ env.ARTIFACT_DIR }}/packages
+
+  ci-macos:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+
+    strategy:
+      matrix:
+        os: [macos-15-intel, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    outputs:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Set up homebrew dependencies
+      run: brew install --quiet coreutils tree autoconf automake libtool tmux sqlite3
+
+    - name: Set PREFIX and ZIP env var
+      env:
+        PREFIX: ${{ runner.arch == 'X64' && env.AMD64_MACOSX_GCC || env.ARM64_MACOSX_GCC }}
+      run: |
+        {
+          echo "PREFIX=$PREFIX"
+          echo "ZIP=zsv-$TAG-$PREFIX.zip"
+          echo "TAR=zsv-$TAG-$PREFIX.tar.gz"
+        } | tee -a "$GITHUB_ENV"
+
+    - name: Build on macOS (${{ env.AMD64_MACOSX_GCC }})
+      env:
+        CC: gcc-13
+        MAKE: make
+        RUN_TESTS: true
+      run: ./scripts/ci-build.sh
+
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    - name: Codesign and notarize (${{ env.ZIP }})
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      env:
+        MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+        MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+        APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      run: ./scripts/ci-macos-codesign-and-notarize.sh "$PWD/$ARTIFACT_DIR/$ZIP"
+
+    - name: Attest build artifacts for release
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      uses: actions/attest-build-provenance@v3
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+    - name: Verify attestations of release artifacts
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: ./scripts/ci-verify-attestations.sh
+
+    - name: Upload (${{ env.ZIP }})
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: ${{ env.ZIP }}
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (${{ env.TAR }})
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: ${{ env.TAR }}
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload release artifacts
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: ./scripts/ci-upload-release-artifacts.sh
+
+  update-homebrew-tap:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    needs: ci-macos
+    runs-on: ubuntu-22.04
+
+    env:
+      TAG: ${{ needs.ci-macos.outputs.TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        sparse-checkout: |
+          scripts/ci-update-homebrew-tap.sh
+
+    - name: Update
+      env:
+        HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+      run: ./scripts/ci-update-homebrew-tap.sh
+
+  ci-bsd:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Build (${{ env.AMD64_FREEBSD_GCC }})
+      uses: cross-platform-actions/action@v0.29.0
+      env:
+        PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
+        CC: gcc
+        MAKE: gmake
+        RUN_TESTS: true
+      with:
+        operating_system: freebsd
+        version: '13.2'
+        environment_variables: 'PREFIX CC MAKE RUN_TESTS ARTIFACT_DIR'
+        shell: sh
+        run: |
+          ./scripts/ci-freebsd-setup.sh
+          ./scripts/ci-build.sh
+
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    - name: Attest build artifacts for release
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      uses: actions/attest-build-provenance@v3
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+    - name: Verify attestations of release artifacts
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: ./scripts/ci-verify-attestations.sh
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_FREEBSD_GCC }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload release artifacts
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: ./scripts/ci-upload-release-artifacts.sh
+
+  mingw-ncurses:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Cache
+      uses: actions/cache@v4
+      id: cache
+      with:
+        key: mingw-ncurses.zip
+        path: ${{ github.workspace }}/mingw-ncurses.zip
+
+    - name: Install MinGW
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      run: |
+        sudo apt update
+        sudo apt install -y mingw-w64
+
+    - name: Checkout
+      uses: actions/checkout@v5
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      with:
+        sparse-checkout: |
+          scripts/ci-build-ncurses-with-mingw.sh
+
+    - name: Build ncurses with MinGW
+      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      run: ./scripts/ci-build-ncurses-with-mingw.sh
+
+    - name: Upload mingw-ncurses.zip
+      uses: actions/upload-artifact@v4
+      with:
+        name: mingw-ncurses.zip
+        path: ${{ github.workspace }}/mingw-ncurses.zip
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+  ci-linux-mingw:
+    needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    outputs:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    steps:
+    - name: Set up apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y mingw-w64 nuget
+        sudo apt remove -y jq
+
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Download mingw-ncurses.zip
+      uses: actions/download-artifact@v5
+      with:
+        name: mingw-ncurses.zip
+        path: ${{ github.workspace }}/app/external
+
+    - name: Unzip mingw-ncurses.zip in app/external
+      run: |
+        cd app/external
+        unzip mingw-ncurses.zip
+
+    - name: Build (${{ env.AMD64_WINDOWS_MINGW }})
+      env:
+        PREFIX: ${{ env.AMD64_WINDOWS_MINGW }}
+        CC: x86_64-w64-mingw32-gcc
+        MAKE: make
+        RUN_TESTS: false
+      run: |
+        export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
+        export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
+        ./scripts/ci-build.sh
+        ./scripts/ci-create-nuget-package.sh
+
+    - name: Prepare build artifacts for upload
+      run: ./scripts/ci-prepare-artifacts-for-upload.sh
+
+    - name: Attest build artifacts for release
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      uses: actions/attest-build-provenance@v3
+      with:
+        subject-path: ${{ env.ARTIFACT_DIR }}/*
+
+    - name: Verify attestations of release artifacts
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: ./scripts/ci-verify-attestations.sh
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.zip
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.tar.gz
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload (zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg)
+      uses: actions/upload-artifact@v4
+      env:
+        ARTIFACT_NAME: zsv-${{ env.TAG }}-${{ env.AMD64_WINDOWS_MINGW }}.nupkg
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        path: ${{ env.ARTIFACT_DIR }}/${{ env.ARTIFACT_NAME }}
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error
+
+    - name: Upload release artifacts
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: ./scripts/ci-upload-release-artifacts.sh
+
+  ci-wsl-mingw:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.wsl == true }}
+    needs: [tag, clang-format, cppcheck, shellcheck, mingw-ncurses]
+    runs-on: windows-2025
+    timeout-minutes: 30
+
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Set up WSL 2
+      uses: Vampire/setup-wsl@v6
+      with:
+        wsl-version: 2
+        wsl-shell-command: bash --noprofile --norc -eo pipefail {0}
+        set-as-default: true
+        distribution: Ubuntu-22.04
+        additional-packages: |
+          build-essential
+          mingw-w64
+          sqlite3
+          nuget
+          tree
+          zip
+          tar
+          tmux
+
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Download mingw-ncurses.zip
+      uses: actions/download-artifact@v5
+      with:
+        name: mingw-ncurses.zip
+        path: ${{ github.workspace }}/app/external
+
+    - name: Unzip mingw-ncurses.zip in app/external
+      run: |
+        cd app/external
+        unzip mingw-ncurses.zip
+
+    - name: Build (${{ env.AMD64_WSL_MINGW }})
+      env:
+        PREFIX: ${{ env.AMD64_WSL_MINGW }}
+        CC: x86_64-w64-mingw32-gcc
+        MAKE: make
+        RUN_TESTS: true
+        SKIP_BUILD: true
+        SKIP_ZIP_ARCHIVE: false
+        SKIP_TAR_ARCHIVE: true
+        WSLENV: ARTIFACT_DIR:TAG:PREFIX:CC:MAKE:RUN_TESTS:SKIP_BUILD:SKIP_ZIP_ARCHIVE:SKIP_TAR_ARCHIVE
+      shell: wsl-bash {0}
+      run: |
+        export CFLAGS="-I$PWD/app/external/mingw-ncurses/include"
+        export LDFLAGS="-L$PWD/app/external/mingw-ncurses/lib"
+        ./scripts/ci-build.sh
 
   ci-musl:
-    # needs: [tag, clang-format, cppcheck, shellcheck]
-    needs: [tag]
+    needs: [tag, clang-format, cppcheck, shellcheck]
     runs-on: ubuntu-latest
     container: alpine:latest
     timeout-minutes: 15
@@ -699,7 +698,7 @@ jobs:
       run: ./scripts/ci-prepare-artifacts-for-upload.sh
 
     - name: Attest build artifacts for release
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       uses: actions/attest-build-provenance@v3
       with:
         subject-path: ${{ env.ARTIFACT_DIR }}/*
@@ -805,140 +804,140 @@ jobs:
           ghcr.io/liquidaty/zsv:${{ env.TAG }}
           ghcr.io/liquidaty/zsv:latest
 
-  # ci-wasm-playground:
-  #   needs: [tag, clang-format, cppcheck, shellcheck]
-  #   runs-on: ubuntu-22.04
-  #   timeout-minutes: 15
+  ci-wasm-playground:
+    needs: [tag, clang-format, cppcheck, shellcheck]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
-  #   env:
-  #     TAG: ${{ needs.tag.outputs.TAG }}
+    env:
+      TAG: ${{ needs.tag.outputs.TAG }}
 
-  #   steps:
-  #   - name: Set up emsdk
-  #     uses: mymindstorm/setup-emsdk@v14
+    steps:
+    - name: Set up emsdk
+      uses: mymindstorm/setup-emsdk@v14
 
-  #   - name: Checkout
-  #     uses: actions/checkout@v5
+    - name: Checkout
+      uses: actions/checkout@v5
 
-  #   - name: Update version in index.html
-  #     run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
+    - name: Update version in index.html
+      run: sed "s|__VERSION__|$TAG|g" -i playground/index.html
 
-  #   - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
-  #       CC: emcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #       CONFIGFILE: "config.emcc"
-  #       CFLAGS: "-msse2 -msimd128"
-  #       CROSS_COMPILING: "yes"
-  #       NO_THREADING: "1"
-  #       STATIC_BUILD: "1"
-  #     run: |
-  #       emconfigure ./configure --enable-pic --disable-pie
-  #       emmake make install NO_STDIN=1 NO_PLAYGROUND=0
-  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground
+    - name: Build with SIMD (${{ env.AMD64_LINUX_WASM }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_WASM }}
+        CC: emcc
+        MAKE: make
+        RUN_TESTS: false
+        CONFIGFILE: "config.emcc"
+        CFLAGS: "-msse2 -msimd128"
+        CROSS_COMPILING: "yes"
+        NO_THREADING: "1"
+        STATIC_BUILD: "1"
+      run: |
+        emconfigure ./configure --enable-pic --disable-pie
+        emmake make install NO_STDIN=1 NO_PLAYGROUND=0
+        cp "$PREFIX"/bin/cli.em.{js,wasm} playground
 
-  #   - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
-  #     env:
-  #       PREFIX: ${{ env.AMD64_LINUX_WASM }}
-  #       CC: emcc
-  #       MAKE: make
-  #       RUN_TESTS: false
-  #       CONFIGFILE: "config.emcc"
-  #       CROSS_COMPILING: "yes"
-  #       NO_THREADING: "1"
-  #       STATIC_BUILD: "1"
-  #     run: |
-  #       emconfigure ./configure --enable-pic --disable-pie
-  #       emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
-  #       mkdir -p playground/non-simd
-  #       cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
+    - name: Build without SIMD (${{ env.AMD64_LINUX_WASM }})
+      env:
+        PREFIX: ${{ env.AMD64_LINUX_WASM }}
+        CC: emcc
+        MAKE: make
+        RUN_TESTS: false
+        CONFIGFILE: "config.emcc"
+        CROSS_COMPILING: "yes"
+        NO_THREADING: "1"
+        STATIC_BUILD: "1"
+      run: |
+        emconfigure ./configure --enable-pic --disable-pie
+        emmake make clean install NO_STDIN=1 NO_PLAYGROUND=0
+        mkdir -p playground/non-simd
+        cp "$PREFIX"/bin/cli.em.{js,wasm} playground/non-simd
 
-  #   - name: Upload playground artifact
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: playground
-  #       path: playground
+    - name: Upload playground artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: playground
+        path: playground
 
-  # upload-github-pages-artifact:
-  #   if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
-  #   needs: [prepare-linux-packages, ci-wasm-playground]
-  #   runs-on: ubuntu-latest
+  upload-github-pages-artifact:
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
+    needs: [prepare-linux-packages, ci-wasm-playground]
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #   - name: Download packages artifact
-  #     uses: actions/download-artifact@v5
-  #     with:
-  #       name: packages
-  #       path: ${{ env.ARTIFACT_DIR }}/packages
+    steps:
+    - name: Download packages artifact
+      uses: actions/download-artifact@v5
+      with:
+        name: packages
+        path: ${{ env.ARTIFACT_DIR }}/packages
 
-  #   - name: Download playground artifact
-  #     uses: actions/download-artifact@v5
-  #     with:
-  #       name: playground
-  #       path: ${{ env.ARTIFACT_DIR }}
+    - name: Download playground artifact
+      uses: actions/download-artifact@v5
+      with:
+        name: playground
+        path: ${{ env.ARTIFACT_DIR }}
 
-  #   - name: Upload GitHub Pages artifacts
-  #     uses: actions/upload-pages-artifact@v4
-  #     with:
-  #       path: ${{ env.ARTIFACT_DIR }}
+    - name: Upload GitHub Pages artifacts
+      uses: actions/upload-pages-artifact@v4
+      with:
+        path: ${{ env.ARTIFACT_DIR }}
 
-  # deploy-to-github-pages:
-  #   if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
-  #   needs: [upload-github-pages-artifact]
-  #   runs-on: ubuntu-latest
+  deploy-to-github-pages:
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
+    needs: [upload-github-pages-artifact]
+    runs-on: ubuntu-latest
 
-  #   permissions:
-  #     pages: write
-  #     id-token: write
+    permissions:
+      pages: write
+      id-token: write
 
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
-  #   steps:
-  #   - name: Deploy to GitHub Pages
-  #     id: deployment
-  #     uses: actions/deploy-pages@v4
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
 
-  # publish-winget-package:
-  #   if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
-  #   needs: [ci-linux-mingw]
-  #   runs-on: windows-latest
+  publish-winget-package:
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    needs: [ci-linux-mingw]
+    runs-on: windows-latest
 
-  #   env:
-  #     TAG: ${{ needs.ci-linux-mingw.outputs.TAG }}
+    env:
+      TAG: ${{ needs.ci-linux-mingw.outputs.TAG }}
 
-  #   defaults:
-  #     run:
-  #       shell: bash
+    defaults:
+      run:
+        shell: bash
 
-  #   steps:
-  #   - name: Install wingetcreate
-  #     run: |
-  #       curl -L https://aka.ms/wingetcreate/latest -o wingetcreate
-  #       chmod +x wingetcreate
-  #       ./wingetcreate info
+    steps:
+    - name: Install wingetcreate
+      run: |
+        curl -L https://aka.ms/wingetcreate/latest -o wingetcreate
+        chmod +x wingetcreate
+        ./wingetcreate info
 
-  #   - name: Update
-  #     env:
-  #       PAT: ${{ secrets.WINGET_PAT }}
-  #       PKG_ID: "liquidaty.zsv"
-  #     run: |
-  #       URL="https://github.com/liquidaty/zsv/releases/download/v$TAG/zsv-$TAG-amd64-windows-mingw.zip"
-  #       ./wingetcreate update "$PKG_ID" \
-  #         --version "$TAG" \
-  #         --urls "$URL" \
-  #         --out "$GITHUB_WORKSPACE/manifests" \
-  #         --token "$PAT" \
-  #         --prtitle "New version: $PKG_ID v$TAG" \
-  #         --submit
+    - name: Update
+      env:
+        PAT: ${{ secrets.WINGET_PAT }}
+        PKG_ID: "liquidaty.zsv"
+      run: |
+        URL="https://github.com/liquidaty/zsv/releases/download/v$TAG/zsv-$TAG-amd64-windows-mingw.zip"
+        ./wingetcreate update "$PKG_ID" \
+          --version "$TAG" \
+          --urls "$URL" \
+          --out "$GITHUB_WORKSPACE/manifests" \
+          --token "$PAT" \
+          --prtitle "New version: $PKG_ID v$TAG" \
+          --submit
 
-  #   - name: Upload manifest
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: zsv-${{ env.TAG }}-winget-manifest
-  #       path: ${{ github.workspace }}/manifests
-  #       retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
-  #       if-no-files-found: error
+    - name: Upload manifest
+      uses: actions/upload-artifact@v4
+      with:
+        name: zsv-${{ env.TAG }}-winget-manifest
+        path: ${{ github.workspace }}/manifests
+        retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+        if-no-files-found: error


### PR DESCRIPTION
Related: #428

The musl build uses `alpine:latest` container.
In the container, `actions/checkout` isn't able to add the workspace directory as safe hence the error:

```shell
fatal: detected dubious ownership in repository at '/__w/zsv/zsv'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/zsv/zsv
Error: Process completed with exit code 128.
```

Setting `set-safe-directory: ${{ github.workspace }}` also results in the same error:

```shell
Initializing the repository
  /usr/bin/git init /__w/zsv/zsv
  hint: Using 'master' as the name for the initial branch. This default branch name
  hint: is subject to change. To configure the initial branch name to use in all
  hint: of your new repositories, which will suppress this warning, call:
  hint:
  hint: 	git config --global init.defaultBranch <name>
  hint:
  hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
  hint: 'development'. The just-created branch can be renamed via this command:
  hint:
  hint: 	git branch -m <name>
  Initialized empty Git repository in /__w/zsv/zsv/.git/
  /usr/bin/git remote add origin https://github.com/liquidaty/zsv
  Error: fatal: detected dubious ownership in repository at '/__w/zsv/zsv'
  To add an exception for this directory, call:
  
  	git config --global --add safe.directory /__w/zsv/zsv
  Error: The process '/usr/bin/git' failed with exit code 128
```

Adding a separate step with `git config --global --add safe.directory "$GITHUB_WORKSPACE"` works fine.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>