### PR TITLE
[CI] Fix homebrew formula update (`v` prefix issue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,7 +426,7 @@ jobs:
         formula-name: zsv
         formula-path: Formula/z/zsv.rb
         push-to: liquidaty/homebrew-core
-        tag-name: ${{ env.TAG }}
+        tag-name: v${{ env.TAG }}
 
   ci-bsd:
     needs: [tag, clang-format, cppcheck, shellcheck]


### PR DESCRIPTION
Failed workflow: https://github.com/liquidaty/zsv/actions/runs/18736327189/job/53451080871

Error:

```
Run mislav/bump-homebrew-formula-action@v3
##[debug]GET https://codeload.github.com/liquidaty/zsv/tar.gz/refs/tags/1.0.1
file:///home/runner/work/_actions/mislav/bump-homebrew-formula-action/v3/lib/index.js:35273
                throw new Error(`HTTP ${res.statusCode}`);
                ^

Error: HTTP 404
    at ClientRequest.<anonymous> (file:///home/runner/work/_actions/mislav/bump-homebrew-formula-action/v3/lib/index.js:35273:23)
    at Object.onceWrapper (node:events:639:26)
    at ClientRequest.emit (node:events:524:28)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:702:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:118:17)
    at TLSSocket.socketOnData (node:_http_client:544:22)
    at TLSSocket.emit (node:events:524:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)

Node.js v20.19.5
##[debug]Node Action run completed with exit code 1
##[debug]Finishing: Update
```

Thanks to @liquidaty to identify this!
See: https://github.com/liquidaty/zsv/pull/434#issuecomment-3435420835

Here's the sequence where tarball is downloaded with `v` prefix in https://github.com/mislav/bump-homebrew-formula-action/tree/v3/:

https://github.com/mislav/bump-homebrew-formula-action/blob/daff4259e46a8d4f9f5f0f2cce12bbe9b460620b/src/main.ts#L105-L108

```typescript
  const version = tagName.replace(/^v(\d)/, '$1')
  const downloadUrl =
    getInput('download-url') ||
    tarballForRelease(ctx.repo.owner, ctx.repo.repo, tagName)
```

In `zsv` CI, we trim `v` prefix from tag in the start:

https://github.com/liquidaty/zsv/blob/19066982715c0c5128e3da625bc2f4b695b8baed/.github/workflows/ci.yml#L73

https://github.com/liquidaty/zsv/blob/19066982715c0c5128e3da625bc2f4b695b8baed/scripts/ci-set-tag-output-parameter.sh#L16

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>