### PR TITLE
Fix asprintf not declared issue

### DIFF
--- a/app/external/sqlite3/vtab_helper.c
+++ b/app/external/sqlite3/vtab_helper.c
@@ -2,6 +2,9 @@
  * Excerpted from https://sqlite.org/src/doc/tip/ext/misc/csv.c
  */
 
+#define _GNU_SOURCE
+#include <stdio.h>
+
 /* Skip leading whitespace.  Return a pointer to the first non-whitespace
 ** character, or to the zero terminator if the string has only whitespace */
 static const char *csv_skip_whitespace(const char *z) {


### PR DESCRIPTION
FreeBSD error:

```
In file included from external/sqlite3/sqlite3_csv_vtab-zsv.c:156,
                 from external/sqlite3/sqlite3_and_csv_vtab.c:2:
external/sqlite3/vtab_helper.c: In function 'csv_string_parameter':
external/sqlite3/vtab_helper.c:67:5: error: implicit declaration of function 'asprintf'; did you mean 'vsprintf'? [-Wimplicit-function-declaration]
   67 |     asprintf(errmsg, "unrecognized connection parameter: %s", zArg);
      |     ^~~~~~~~
      |     vsprintf
```

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>