### PR TITLE
[CI][FreeBSD] Install and use GCC 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,7 +444,7 @@ jobs:
       uses: cross-platform-actions/action@v0.32.0
       env:
         PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
-        CC: gcc
+        CC: gcc13
         MAKE: gmake
         RUN_TESTS: true
       with:

--- a/scripts/ci-freebsd-setup.sh
+++ b/scripts/ci-freebsd-setup.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sudo pkg install -y tree zip git autotools gmake lang/gcc tmux sqlite3 terminfo-db
+sudo pkg install -y tree zip git autotools gmake gcc13 tmux sqlite3 terminfo-db


### PR DESCRIPTION
Failing workflow run: https://github.com/liquidaty/zsv/actions/runs/21182181371/job/60980427067

Error:

```
In file included from external/sqlite3/sqlite3_csv_vtab-zsv.c:156,
                 from external/sqlite3/sqlite3_and_csv_vtab.c:2:
external/sqlite3/vtab_helper.c: In function 'csv_string_parameter':
external/sqlite3/vtab_helper.c:67:5: error: implicit declaration of function 'asprintf'; did you mean 'vsprintf'? [-Wimplicit-function-declaration]
   67 |     asprintf(errmsg, "unrecognized connection parameter: %s", zArg);
      |     ^~~~~~~~
      |     vsprintf
```

The default installed version using `lang/gcc` has been updated to GCC 14 which causes the above failure.
Pinned GCC version to 13 which was building fine earlier.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>