### PR TITLE
[overwrite list] Fix NULL pointer dereference (UB)

### DIFF
--- a/app/overwrite.c
+++ b/app/overwrite.c
@@ -275,6 +275,10 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   struct zsv_overwrite *data = zsv_overwrite_writer_new(&args, &ctx_opts);
   free(overwrites_fn);
 
+  if (!data) {
+    return zsv_status_error;
+  }
+
   if (!err && data) {
     if (data->mode == zsvsheet_mode_list)
       err = show_all_overwrites(data, data->writer);

--- a/app/utils/overwrite_writer.c
+++ b/app/utils/overwrite_writer.c
@@ -93,7 +93,7 @@ struct zsv_overwrite *zsv_overwrite_writer_new(struct zsv_overwrite_args *args, 
   enum zsv_status err = zsv_status_ok;
   if (data->mode == zsvsheet_mode_list) {
     if ((err = (zsv_overwrite_open(data->ctx)))) // use open when it's read-only
-      fprintf(stderr, "Failed to initialize database\n");
+      fprintf(stderr, "Failed to open database\n");
   } else {
     if ((err = zsv_overwrite_writer_init(data))) // use init when writing to db
       fprintf(stderr, "Failed to initialize database\n");
@@ -103,9 +103,6 @@ struct zsv_overwrite *zsv_overwrite_writer_new(struct zsv_overwrite_args *args, 
 }
 
 void zsv_overwrite_writer_delete(struct zsv_overwrite *data) {
-  if (!data)
-    return;
-
   if (data->writer)
     zsv_writer_delete(data->writer);
   if (data->ctx)


### PR DESCRIPTION
While looking into #496, I ran into this NULL deference issue i.e. **Segmentation fault (core dumped)**.

Related code snippet:

https://github.com/liquidaty/zsv/blob/8c509431a5f8d8b6b890bfda6d5f30c1708a799f/app/overwrite.c#L275-L292

`data` assigned from `zsv_overwrite_writer_new` can be NULL. (line # 275)
Currently, in case of an error, it goes straight to `zsv_overwrite_writer_delete`. (line # 292)
`zsv_overwrite_writer_delete` doesn't have a non-NULL check in it hence the segfault.
Fixed it by checking and exiting early on NULL with error status.

## Test

### Before

```shell
$ zsv overwrite dummy2.csv list
unable to open database file: .zsv/data/dummy2.csv/overwrite.sqlite3
Failed to initalize database
Segmentation fault (core dumped)

$ echo $?
139
```

### After

```shell
$ zsv overwrite dummy2.csv list
unable to open database file: .zsv/data/dummy2.csv/overwrite.sqlite3
Failed to open database

$ echo $?
5
```

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>