### PR TITLE
[compare][MinGW] Fix unstable sort issue breaking `--columns` option

### DIFF
--- a/app/compare.c
+++ b/app/compare.c
@@ -572,25 +572,37 @@ static enum zsv_compare_status zsv_compare_advance(struct zsv_compare_data *data
   return got ? zsv_compare_status_ok : zsv_compare_status_no_more_input;
 }
 
-static int zsv_compare_inputp_cmp(const void *inputpx, const void *inputpy) {
-  struct zsv_compare_input *const *xp = inputpx;
-  struct zsv_compare_input *const *yp = inputpy;
-  const struct zsv_compare_input *x = *xp;
-  const struct zsv_compare_input *y = *yp;
-
-  if (!x->row_loaded && !y->row_loaded)
-    return 0;
+static int zsv_compare_keys_only(const struct zsv_compare_input *x, const struct zsv_compare_input *y) {
+  if (x->row_loaded != y->row_loaded)
+    return x->row_loaded ? -1 : 1;
   if (!x->row_loaded)
-    return 1;
-  if (!y->row_loaded)
-    return -1;
+    return 0;
 
   int cmp = 0;
-  for (unsigned i = 0; !cmp && i < x->key_count && i < y->key_count; i++)
+  for (unsigned i = 0; !cmp && i < x->key_count && i < y->key_count; i++) {
     // for multibyte input, the input must be also sorted lexicographically
     // to avoid potential mismatches
     // see e.g. https://stackoverflow.com/questions/4611302/sorting-utf-8-strings
     cmp = zsv_strincmp(x->keys[i].value.str, x->keys[i].value.len, y->keys[i].value.str, y->keys[i].value.len);
+  }
+
+  if (cmp == 0 && x->key_count != y->key_count)
+    return (x->key_count < y->key_count) ? -1 : 1;
+
+  return cmp;
+}
+
+static int zsv_compare_inputp_cmp(const void *inputpx, const void *inputpy) {
+  const struct zsv_compare_input *x = *(const struct zsv_compare_input **)inputpx;
+  const struct zsv_compare_input *y = *(const struct zsv_compare_input **)inputpy;
+
+  const int cmp = zsv_compare_keys_only(x, y);
+  if (cmp == 0) {
+    if (x->index < y->index)
+      return -1;
+    if (x->index > y->index)
+      return 1;
+  }
   return cmp;
 }
 
@@ -602,7 +614,7 @@ static enum zsv_compare_status zsv_compare_next(struct zsv_compare_data *data) {
   data->row_count++;
   // sort the inputs by ID value first, and input position second
   // for as many inputs have the same smallest ID values, output them as a group
-  //   and set input->row_loaded to 0
+  // and set input->row_loaded to 0
   qsort(data->inputs_to_sort, data->input_count, sizeof(*data->inputs_to_sort), zsv_compare_inputp_cmp);
 
   // find the next subset of inputs with identical id values and process those inputs
@@ -612,7 +624,7 @@ static enum zsv_compare_status zsv_compare_next(struct zsv_compare_data *data) {
     struct zsv_compare_input *tmp = data->inputs_to_sort[tmp_i];
     if (!tmp->row_loaded)
       continue;
-    if (!zsv_compare_inputp_cmp(&min_input, &tmp)) { // keys are the same
+    if (!zsv_compare_keys_only(min_input, tmp)) { // keys are the same
       last = tmp_i;
       continue;
     }

--- a/app/compare.c
+++ b/app/compare.c
@@ -573,18 +573,19 @@ static enum zsv_compare_status zsv_compare_advance(struct zsv_compare_data *data
 }
 
 static int zsv_compare_keys_only(const struct zsv_compare_input *x, const struct zsv_compare_input *y) {
-  if (x->row_loaded != y->row_loaded)
-    return x->row_loaded ? -1 : 1;
-  if (!x->row_loaded)
+  if (!x->row_loaded && !y->row_loaded)
     return 0;
+  if (!x->row_loaded)
+    return 1;
+  if (!y->row_loaded)
+    return -1;
 
   int cmp = 0;
-  for (unsigned i = 0; !cmp && i < x->key_count && i < y->key_count; i++) {
+  for (unsigned i = 0; !cmp && i < x->key_count && i < y->key_count; i++)
     // for multibyte input, the input must be also sorted lexicographically
     // to avoid potential mismatches
     // see e.g. https://stackoverflow.com/questions/4611302/sorting-utf-8-strings
     cmp = zsv_strincmp(x->keys[i].value.str, x->keys[i].value.len, y->keys[i].value.str, y->keys[i].value.len);
-  }
 
   if (cmp == 0 && x->key_count != y->key_count)
     return (x->key_count < y->key_count) ? -1 : 1;


### PR DESCRIPTION
These tests under `test-compare` were failing locally for Win/MinGW (Ubuntu/wine | Windows/WSL2):

https://github.com/liquidaty/zsv/blob/612b444cbf58cfed133a16053a7ce44a0d3d6f1b/app/test/Makefile#L785-L795

Here's the side-by-side diff for **GCC and MinGW** output:

```
# GCC                                  # MinGW
Row #,Column,columns 1-3,columns 4-6    Row #,Column,columns 1-3,columns 4-6
1,New_A,,1						      |	1,Old_A,1,
1,New_B,,2						      |	1,Old_B,2,
1,New_C,,3						      |	1,Old_C,3,
2,New_A,,4							    2,New_A,,4
2,New_B,,5							    2,New_B,,5
2,New_C,,99							    2,New_C,,99
3,New_A,,7						      |	3,Old_A,7,
3,New_B,,88						      |	3,Old_B,8,
3,New_C,,9						      |	3,Old_C,9,
```

Investigated and tracked it down to stable vs unstable `qsort` on GCC vs MinGW.

- Fixed MinGW unstable sorting issue of `qsort` by adding tie-breaking logic based on `index` (unique identifier)
- Separated keys comparison to its own dedicated function `zsv_compare_keys_only` from `qsort` callback `zsv_compare_inputp_cmp` to be reused in `zsv_compare_next`

#### Environments

- **Linux**
  - Ubuntu 22.04 LTS (running exe in wine)
  - x86_64-w64-mingw32-gcc (GCC) 10-win32 20220113
- **Windows**
  - Windows 11 (WSL 2)
  - x86_64-w64-mingw32-gcc (GCC) 13-win32
- **CI**
  - Windows 2025 (WSL2)
  - x86_64-w64-mingw32-gcc (GCC) 10-win32 20220113
  - Failing workflow: https://github.com/liquidaty/zsv/actions/runs/24227234060/job/70730880723?pr=579

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>