### PR TITLE
[WSL][MinGW][sheet] Fix "Unexpected error!" issue

### DIFF
--- a/app/ext_example/Makefile
+++ b/app/ext_example/Makefile
@@ -26,8 +26,6 @@ ifeq ($(WIN),)
   endif
 endif
 
-IS_WSL=$(shell grep -qi microsoft /proc/version 2>/dev/null && echo 1 || echo 0)
-
 ifeq ($(WIN),0)
   EXE=
   EXT=
@@ -198,7 +196,7 @@ TMUX_TERM=xterm-256color
 test-sheet-extension-1: ${CLI} ${TARGET} ../test/worldcitiespop_mil.csv
 	@${TEST_INIT}
 	@rm -f ${TMP_DIR}/$@.out tmux-*.log
-	@tmux kill-session -t $@ || echo 'No tmux session to kill'
+	@tmux kill-session -t $@ 2>/dev/null || true
 	@echo 'set-option default-terminal "${TMUX_TERM}"' > ~/.tmux.conf
 	@${RUN_CLI} unregister my 2>/dev/null 1>/dev/null || true
 	@${RUN_CLI} register my 2>&1 | grep -v [.]${SO} || true
@@ -209,21 +207,17 @@ test-sheet-extension-1: ${CLI} ${TARGET} ../test/worldcitiespop_mil.csv
 
 test-sheet-extension-2: ${CLI} ${TARGET}
 	@${TEST_INIT}
-ifeq ($(IS_WSL),1)
-	@${TEST_SKIP}
-else
 	@rm -f ${TMP_DIR}/$@.out tmux-*.log
 	@tmux kill-session -t $@ 2>/dev/null || true
 	@echo 'set-option default-terminal "${TMUX_TERM}"' > ~/.tmux.conf
 	@${RUN_CLI} unregister my 2>/dev/null 1>/dev/null || true
 	@${RUN_CLI} register my 2>&1 | grep -v [.]${SO} || true
-	(ZSV_CONFIG_DIR=${TMP_DIR} tmux -v new-session -x 120 -y 5 -d -s $@ "$< sheet -d 3 ${TEST_DATA_DIR}/test/mixed-line-endings.csv" && \
+	@(ZSV_CONFIG_DIR=${TMP_DIR} tmux -v new-session -x 120 -y 5 -d -s $@ "$< sheet -d 3 ${TEST_DATA_DIR}/test/mixed-line-endings.csv" && \
 	${EXPECT} $@ indexed && \
 	tmux send-keys -t $@ "T" && \
 	${EXPECT} $@ transformed && \
 	tmux send-keys -t $@ "G" && \
 	${EXPECT} $@ && ${TEST_PASS} || ${TEST_FAIL})
-endif
 
 clean:
 	@rm -f ${TARGET} ${TARGET_SHEET} ${TMP_DIR}/test*.out

--- a/app/sheet/transformation.c
+++ b/app/sheet/transformation.c
@@ -73,7 +73,7 @@ enum zsv_status zsvsheet_transformation_new(struct zsvsheet_transformation_opts 
     goto free;
   trn->output_filename = temp_filename;
 
-  if (!(temp_f = fopen(temp_filename, "w+")))
+  if (!(temp_f = fopen(temp_filename, "wb+")))
     goto free;
   if (setvbuf(temp_f, NULL, _IONBF, 0))
     goto free;

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -45,8 +45,7 @@ BUILD_DIR=${THIS_LIB_BASE}/build/${BUILD_SUBDIR}/${CCBN}
 export TMP_DIR=${THIS_LIB_BASE}/tmp
 TEST_DATA_DIR=${THIS_LIB_BASE}/data
 
-IS_WSL=$(shell grep -qi microsoft /proc/version 2>/dev/null && echo 1 || echo 0)
-ifeq ($(IS_WSL),1)
+ifeq ($(WIN),1)
   TEST_DATA_DIR=./../../data
   TMP_DIR=./../../tmp
 endif
@@ -871,9 +870,6 @@ test-sheet-7: ${BUILD_DIR}/bin/zsv_sheet${EXE} ${TIMINGS_CSV}
 
 test-sheet-8: ${BUILD_DIR}/bin/zsv_sheet${EXE} ${TIMINGS_CSV}
 	@${TEST_INIT}
-ifeq ($(IS_WSL),1)
-	@${TEST_SKIP}
-else
 	@echo 'set-option default-terminal "${TMUX_TERM}"' > ~/.tmux.conf
 	@(tmux -L $@ kill-server 2>/dev/null; rm -f ${TMP_DIR}/tmux-$$(id -u)/$@ 2>/dev/null; \
 	tmux -L $@ new-session -x 160 -y 5 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
@@ -883,7 +879,6 @@ else
 	${EXPECT} $@ filtered && \
 	tmux -L $@ send-keys -t $@ "G" "C-u" "k" && \
 	${EXPECT} $@ && ${TEST_PASS} || ${TEST_FAIL})
-endif
 
 test-sheet-9: ${BUILD_DIR}/bin/zsv_sheet${EXE} ${TIMINGS_CSV}
 	@${TEST_INIT}
@@ -898,9 +893,6 @@ test-sheet-9: ${BUILD_DIR}/bin/zsv_sheet${EXE} ${TIMINGS_CSV}
 
 test-sheet-10: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.tsv ${TIMINGS_CSV}
 	@${TEST_INIT}
-ifeq ($(IS_WSL),1)
-	@${TEST_SKIP}
-else
 	@echo 'set-option default-terminal "${TMUX_TERM}"' > ~/.tmux.conf
 	@(tmux -L $@ kill-server 2>/dev/null; rm -f ${TMP_DIR}/tmux-$$(id -u)/$@ 2>/dev/null; \
 	tmux -L $@ new-session -x 80 -y 6 -d -s $@ "${PREFIX} $< -t worldcitiespop_mil.tsv" && \
@@ -909,7 +901,6 @@ else
 	${EXPECT} $@ filtered && \
 	tmux -L $@ send-keys -t $@ "G" && \
 	${EXPECT} $@ && ${TEST_PASS} || ${TEST_FAIL})
-endif
 
 test-sheet-11: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv ${TIMINGS_CSV}
 	@${TEST_INIT}

--- a/app/test/parallel/Makefile
+++ b/app/test/parallel/Makefile
@@ -14,8 +14,39 @@ COLOR_BLUE=\033[1;34m
 COLOR_PINK=\033[1;35m
 COLOR_YELLOW=\033[1;33m
 
-IS_WSL=$(shell grep -qi microsoft /proc/version 2>/dev/null && echo 1 || echo 0)
-ifeq ($(IS_WSL),1)
+CONFIGFILE ?= ../../../config.mk
+ifneq ($(QUIET),1)
+  $(info # Using config file ${CONFIGFILE})
+endif
+include ${CONFIGFILE}
+
+CONFIGFILEPATH=$(shell ls ${CONFIGFILE} >/dev/null 2>/dev/null && realpath ${CONFIGFILE})
+ifeq ($(CONFIGFILEPATH),)
+  $(error Config file ${CONFIGFILE} not found)
+endif
+
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(SELECT_EXE),)
+  $(error Missing SELECT_EXE)
+endif
+
+ifeq ($(COUNT_EXE),)
+  $(error Missing COUNT_EXE)
+endif
+
+$(info SELECT_EXE=$(SELECT_EXE))
+$(info COUNT_EXE=$(COUNT_EXE))
+endif
+
+WIN=
+ifeq ($(WIN),)
+  WIN=0
+  ifneq ($(findstring w64,$(CC)),) # e.g. mingw64
+    WIN=1
+  endif
+endif
+
+ifeq ($(WIN),1)
   TMP_DIR=./tmp
 else
   TMP_DIR=${THIS_MAKEFILE_DIR}/tmp
@@ -35,19 +66,6 @@ else
   PREFIX=
   SUFFIX=>${TMP_DIR}/$@.out
   CHECK=
-endif
-
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
-ifeq ($(SELECT_EXE),)
-  $(error Missing SELECT_EXE)
-endif
-
-ifeq ($(COUNT_EXE),)
-  $(error Missing COUNT_EXE)
-endif
-
-$(info SELECT_EXE=$(SELECT_EXE))
-$(info COUNT_EXE=$(COUNT_EXE))
 endif
 
 help:


### PR DESCRIPTION
Fixes #387.

Fixed binary file writing for Windows i.e. replaced `w+` with `wb+`.
Because according to [fopen](https://man7.org/linux/man-pages/man3/fopen.3.html) for `mode`:

```
       The mode string can also include the letter 'b' either as a last
       character or as a character between the characters in any of the
       two-character strings described above.  This is strictly for
       compatibility with ISO C and has no effect; the 'b' is ignored on
       all POSIX conforming systems, including Linux.  (Other systems may
       treat text files and binary files differently, and adding the 'b'
       may be a good idea if you do I/O to a binary file and expect that
       your program may be ported to non-UNIX environments.)
```

Updated tests accordingly and now all tests are passing successfully.
Removed `IS_WSL` and reused `WIN` instead for path updates.

WSL workflow run: https://github.com/liquidaty/zsv/actions/runs/24397316372

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>