### PR TITLE
[2db] Fix CodeQL issue (redundant null check due to previous dereference)

### DIFF
--- a/app/2db.c
+++ b/app/2db.c
@@ -219,11 +219,11 @@ static sqlite3_str *build_create_table_statement(sqlite3 *db, const char *tname,
     if (!err) {
       const char *collate = collates ? collates[i] : NULL;
       if (collate && *collate) {
-        if (collate && !(!strcmp("binary", collate) || !strcmp("rtrim", collate) || !strcmp("nocase", collate))) {
+        if (!(!strcmp("binary", collate) || !strcmp("rtrim", collate) || !strcmp("nocase", collate))) {
           fprintf(stderr, "Unrecognized collate: expected binary, rtrim or nocase, got %s", collate);
           err = 1;
         } else
-          sqlite3_str_appendf(pStr, " %s%s%s", datatype, collate ? " collate " : "", collate ? collate : "");
+          sqlite3_str_appendf(pStr, " %s collate %s", datatype, collate);
       }
     }
   }


### PR DESCRIPTION
Fixes these CodeQL issues:

- https://github.com/liquidaty/zsv/security/code-scanning/31
- https://github.com/liquidaty/zsv/security/code-scanning/32
- https://github.com/liquidaty/zsv/security/code-scanning/33

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>