### PR TITLE
[sheet] Fix building index issue on no data rows

### DIFF
--- a/app/sheet.c
+++ b/app/sheet.c
@@ -1094,7 +1094,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       if (err > 0)
         perror(filename_arg);
       else
-        fprintf(stderr, "%s: no data found", filename_arg); // to do: change this to a base-buff status msg
+        fprintf(stderr, "%s: no data found\n", filename_arg); // to do: change this to a base-buff status msg
 
       err = -1;
       goto zsvsheet_exit;

--- a/app/sheet/read-data.c
+++ b/app/sheet/read-data.c
@@ -254,14 +254,15 @@ static int read_data(struct zsvsheet_ui_buffer **uibufferp,   // a new zsvsheet_
   pthread_mutex_unlock(&uibuff->mutex);
 
   if (need_index) {
-    if (asprintf(&uibuff->status, "%s(building index) ", old_ui_status ? old_ui_status : "") == -1) {
-      rc = -1;
-      goto done;
-    }
-
     uibuff->buff_used_rows = rows_read;
     uibuff->dimensions.row_count = rows_read;
+
     if (original_row_num > 1 && rows_read > 0) {
+      if (asprintf(&uibuff->status, "%s(building index) ", old_ui_status ? old_ui_status : "") == -1) {
+        rc = -1;
+        goto done;
+      }
+
       opts.stream = NULL;
       get_data_index_async(uibuff, filename, &opts, custom_prop_handler, old_ui_status);
     }

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -802,11 +802,14 @@ test-sheet-cleanup:
 
 test-sheet-all: \
 	test-sheet-1 test-sheet-2 test-sheet-3 test-sheet-4 test-sheet-5 test-sheet-6 test-sheet-7 test-sheet-8 test-sheet-9 \
-	test-sheet-10 test-sheet-11 test-sheet-12 test-sheet-13 test-sheet-14 test-sheet-subcommand test-sheet-prop-cmd-opt \
+	test-sheet-10 test-sheet-11 test-sheet-12 test-sheet-13 test-sheet-14 test-sheet-15 test-sheet-16 \
+	test-sheet-subcommand \
+	test-sheet-prop-cmd-opt \
 	test-sheet-pivot-1 \
 	test-sheet-pivot-V \
 	test-sheet-sqlfilter-1 \
 	test-sheet-errors-1
+	@rm -f tmux-*.log zSE*
 	@(for SESSION in $^; do ! tmux -L "$$SESSION" kill-server 2>/dev/null || true; done && ${TEST_PASS} || ${TEST_FAIL})
 
 TMUX_TERM=xterm-256color
@@ -949,6 +952,14 @@ test-sheet-15: ${BUILD_DIR}/bin/zsv_sheet${EXE} ${TIMINGS_CSV}
 	tmux -L $@ send-keys -t $@ "G" && \
 	${EXPECT} $@ bottom && \
 	tmux -L $@ send-keys -t $@ -N 4096 "k" && \
+	${EXPECT} $@ && ${TEST_PASS} || ${TEST_FAIL})
+
+test-sheet-16: ${BUILD_DIR}/bin/zsv_sheet${EXE} ${TIMINGS_CSV}
+	@${TEST_INIT}
+	@echo 'set-option default-terminal "${TMUX_TERM}"' > ~/.tmux.conf
+	@(tmux -L $@ kill-server 2>/dev/null; rm -f ${TMP_DIR}/tmux-$$(id -u)/$@ 2>/dev/null; \
+	tmux -L $@ new-session -x 80 -y 6 -d -s $@ "${PREFIX} $< ${TEST_DATA_DIR}/test/header-only.csv" && \
+	${EXPECT} $@ indexed && \
 	${EXPECT} $@ && ${TEST_PASS} || ${TEST_FAIL})
 
 test-sheet-subcommand: \

--- a/app/test/expected/test-sheet-16-indexed.out
+++ b/app/test/expected/test-sheet-16-indexed.out
@@ -1,0 +1,6 @@
+Row #               Name                Address             Mobile
+
+
+
+
+? for help

--- a/app/test/expected/test-sheet-16.out
+++ b/app/test/expected/test-sheet-16.out
@@ -1,0 +1,6 @@
+Row #               Name                Address             Mobile
+
+
+
+
+? for help

--- a/data/test/header-only.csv
+++ b/data/test/header-only.csv
@@ -1,0 +1,1 @@
+Name,Address,Mobile


### PR DESCRIPTION
Fixes #470.

- Moved `(building index)` message where index is actually built
- Added test for header-only CSV i.e. `test-sheet-16`
- Added `test-sheet-15` missing from the execution list
- Updated sheet tests cleanup to remove `tmux*.log` and `zSE*` temp files on success

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>