### PR TITLE
sheet: fix extra column in filter f/F output

### DIFF
--- a/app/sheet/read-data.c
+++ b/app/sheet/read-data.c
@@ -182,6 +182,10 @@ static int read_data(struct zsvsheet_ui_buffer **uibufferp,   // a new zsvsheet_
         zsvsheet_opts->hide_row_nums = 1;
         if (uibuff)
           uibuff->has_row_num = 1;
+        if (buffer && !buffer->opts.no_rownum_column) {
+          buffer->cols = col_count;
+          buffer->opts.no_rownum_column = 1;
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #577.

<img width="1832" height="953" alt="zsv-sheet-filter-f-F-extra-column-fix" src="https://github.com/user-attachments/assets/5cad54df-3580-4a9c-8445-aa20e607b08c" />

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>
