### PR TITLE
fuzz: add dockerized fuzzer targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,6 +812,7 @@ jobs:
         emmake make test CONFIGFILE=config.emcc
 
   wasm-playground:
+    if: ${{ github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v') }}
     needs: [ci-wasm]
     runs-on: ubuntu-22.04-arm
     timeout-minutes: 15

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload crash artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: libfuzzer-findings
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ fuzz/.afl-*
 fuzz/zsvfuzz*
 crash*
 default.profraw
+fuzz/zsv-fuzzer

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -53,11 +53,6 @@ help:
 	@echo "  or if the raw test data changes. Otherwise, it is safely skipped."
 	@echo "  Based on raw corpus size, the corpus generation may take a while."
 	@echo ""
-	@echo "To check status for parallel fuzzing, run:"
-	@echo "  afl-whatsup $(FUZZOUT)"
-	@echo "or, for continuous updates, run with watch like this:"
-	@echo "  watch -c afl-whatsup $(FUZZOUT)"
-	@echo ""
 	@echo "To reproduce a specific crash, run:"
 	@echo "  $(FUZZBIN) < crash-file"
 	@echo "or, with test binary with stderr logs, run:"
@@ -68,6 +63,8 @@ help:
 	@echo "Requirements (run/run-parallel): afl-clang-fast, afl-fuzz"
 	@echo "Requirements (test-build/test-run): clang with ASan support"
 	@echo "PREFIX must point to the zsv repo root (default: ..)"
+	@echo ""
+	@echo "For dockerized fuzzing, run 'make help-dockerized-fuzzer' for usage details."
 
 ZSV_H = $(INCLUDE_DIR)/zsv.h
 ZSV_H_IN = $(INCLUDE_DIR)/zsv.h.in
@@ -135,7 +132,7 @@ watch-process-summary: validate-output
 	@watch -c afl-whatsup -s $(FUZZOUT)
 
 list-crashes: validate-output
-	find $(FUZZOUT) -type f -path "*/crashes/id:*"
+	@find $(FUZZOUT) -type f -path "*/crashes/id:*"
 
 # Smoke-test (no AFL++ needed)
 test-build: $(SOURCES)
@@ -158,7 +155,98 @@ clean:
 clean-all: clean
 	rm -rf $(CORPUS_DIR_GENERATED)
 
+# dockerized fuzzer targets
+
+help-dockerized-fuzzer:
+	@echo "Usage (run from inside the zsv repo fuzz/ directory):"
+	@echo "  make run-dockerized-fuzzer [ZSV_BRANCH=<branch>] [JOBS=N]  # clone/build/run dockerized fuzzer"
+	@echo "  make stop-dockerized-fuzzer                                # stop all fuzzing containers"
+	@echo "  make show-dockerized-fuzzer-logs                           # show logs for all containers"
+	@echo "  make watch-dockerized-fuzzer-logs                          # tail logs for all containers"
+	@echo "  make list-dockerized-fuzzer-crashes                        # list crash files from dockerized fuzzing"
+	@echo "  make clean-dockerized-fuzzer                               # stop containers and remove logs"
+	@echo "  make clean-all-dockerized-fuzzer [ZSV_BRANCH=<branch>]     # stop containers and remove fuzzer repo, logs, and image"
+	@echo ""
+	@echo "Notes:"
+	@echo "  Requires 'docker', 'docker compose' and 'yq' commands."
+	@echo "  ZSV_BRANCH is the git branch to fuzz (default: main)."
+	@echo "  JOBS is the number of parallel fuzzing jobs to run (default: 2)."
+
+DOCKERIZED_FUZZER_REPO_URL = https://github.com/matteoalba/fuzz-zsv
+DOCKERIZED_FUZZER_DIR = zsv-fuzzer
+DOCKERIZED_FUZZER_ENV_FILE = $(DOCKERIZED_FUZZER_DIR)/.env
+DOCKERIZED_FUZZER_COMPOSE_FILE = $(DOCKERIZED_FUZZER_DIR)/docker-compose.yml
+DOCKERIZED_FUZZER_LOGS_DIR = $(DOCKERIZED_FUZZER_DIR)/logs_local
+DOCKERIZED_FUZZER_CRASHES_DIR = $(DOCKERIZED_FUZZER_LOGS_DIR)/crashes
+ZSV_BRANCH = main
+DOCKERIZED_FUZZER_IMAGE = $(DOCKERIZED_FUZZER_DIR)
+DOCKERIZED_FUZZER_IMAGE_WITH_TAG = $(DOCKERIZED_FUZZER_IMAGE):$(ZSV_BRANCH)
+run-dockerized-fuzzer:
+	@echo "Running dockerized fuzzer '$(DOCKERIZED_FUZZER_IMAGE_WITH_TAG)' with $(JOBS) jobs..."
+	@if [ ! -d "$(DOCKERIZED_FUZZER_DIR)" ]; then \
+		git clone --depth=1 $(DOCKERIZED_FUZZER_REPO_URL) $(DOCKERIZED_FUZZER_DIR); \
+	fi
+
+	@echo "Updating $(DOCKERIZED_FUZZER_ENV_FILE)..."
+	@sed -i "s|^TARGET_VERSION=.*|TARGET_VERSION=$(ZSV_BRANCH)|" $(DOCKERIZED_FUZZER_ENV_FILE)
+	@sed -i "s|^FUZZER_JOBS=.*|FUZZER_JOBS=$(JOBS)|" $(DOCKERIZED_FUZZER_ENV_FILE)
+	@echo "=== $(DOCKERIZED_FUZZER_ENV_FILE) STARTS ==="
+	@cat "$(DOCKERIZED_FUZZER_ENV_FILE)"
+	@echo "==== $(DOCKERIZED_FUZZER_ENV_FILE) ENDS ===="
+
+	@echo "Updating $(DOCKERIZED_FUZZER_COMPOSE_FILE)..."
+	@yq '.services.fuzzer.image = "$(DOCKERIZED_FUZZER_IMAGE_WITH_TAG)"' -i $(DOCKERIZED_FUZZER_COMPOSE_FILE)
+	@yq 'del(.services.fuzzer.restart)' -i $(DOCKERIZED_FUZZER_COMPOSE_FILE)
+	@echo "=== $(DOCKERIZED_FUZZER_COMPOSE_FILE) STARTS ==="
+	@cat $(DOCKERIZED_FUZZER_COMPOSE_FILE)
+	@echo "==== $(DOCKERIZED_FUZZER_COMPOSE_FILE) ENDS ===="
+
+	# Ensure logs directory exists before starting containers to avoid potential issues with volume mounts
+	@mkdir -p $(DOCKERIZED_FUZZER_LOGS_DIR)
+
+	@echo "Building and running fuzzing containers for branch $(ZSV_BRANCH) with $(JOBS) jobs..."
+	@(cd $(DOCKERIZED_FUZZER_DIR) && \
+	docker compose build && \
+	docker compose up -d --wait --scale fuzzer=$(JOBS))
+	@echo "Dockerized fuzzer '$(DOCKERIZED_FUZZER_IMAGE_WITH_TAG)' started with $(JOBS) jobs."
+	@echo "Run 'make watch-dockerized-fuzzer-logs' to watch logs."
+
+stop-dockerized-fuzzer:
+	@echo "Stopping all fuzzing containers..."
+	@(cd $(DOCKERIZED_FUZZER_DIR) && docker compose down 2>/dev/null || true)
+
+show-dockerized-fuzzer-logs:
+	@echo "Showing logs for all fuzzing containers..."
+	@(cd $(DOCKERIZED_FUZZER_DIR) && docker compose logs)
+
+watch-dockerized-fuzzer-logs:
+	@echo "Watching logs for all fuzzing containers..."
+	@echo "Press Ctrl+C to stop watching logs."
+	@(cd $(DOCKERIZED_FUZZER_DIR) && docker compose logs -f)
+
+list-dockerized-fuzzer-crashes:
+	@echo "Listing crash files from dockerized fuzzing containers..."
+	@find $(DOCKERIZED_FUZZER_CRASHES_DIR) -type f -path '*/crash-*' 2>/dev/null
+
+clean-dockerized-fuzzer: stop-dockerized-fuzzer
+	rm -rf $(DOCKERIZED_FUZZER_LOGS_DIR)
+
+clean-all-dockerized-fuzzer: clean-dockerized-fuzzer
+	rm -rf $(DOCKERIZED_FUZZER_DIR)
+	docker rmi -f $(DOCKERIZED_FUZZER_IMAGE_WITH_TAG) 2>/dev/null
+	@if docker images --format '{{.Repository}}' $(DOCKERIZED_FUZZER_DIR) >/dev/null 2>&1; then \
+		echo ""; \
+		echo "Looks like the images for '$(DOCKERIZED_FUZZER_IMAGE)' still exist:"; \
+		docker images $(DOCKERIZED_FUZZER_IMAGE); \
+		echo ""; \
+		echo "Run 'make clean-all-dockerized-fuzzer ZSV_BRANCH=<YOUR-BRANCH-HERE>' to clean them up."; \
+		echo "Alternatively, remove them manually with 'docker rmi -f <IMAGE_ID>' if needed."; \
+	fi
+
 .PHONY: help build run run-parallel \
 		validate-output watch-process watch-process-summary \
 		list-crashes test-build test-run \
-		clean clean-all
+		clean clean-all \
+		run-dockerized-fuzzer stop-dockerized-fuzzer \
+		show-dockerized-fuzzer-logs watch-dockerized-fuzzer-logs \
+		list-dockerized-fuzzer-crashes clean-dockerized-fuzzer

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,39 @@
+# `libzsv` fuzzing
+
+This directory contains the fuzzing support for `libzsv`.
+
+## AFL/AFL++ fuzzing
+
+The AFL++ workflow uses a local build of `zsvfuzz`, a filtered/minimized seed
+corpus, and AFL++ itself.
+
+- Build and run a single AFL++ instance: `make run`
+- Run AFL++ in parallel: `make run-parallel JOBS=N`
+- Build an ASan/UBSan test binary: `make test-build`
+- Run the test binary against the raw corpus: `make test-run`
+
+For a complete list of AFL++-related commands, use: `make help`
+
+## `libFuzzer`-based fuzzing (Dockerized)
+
+A separate dockerized setup is provided for libFuzzer-based fuzzing.
+
+- Start the dockerized fuzzer: `make run-dockerized-fuzzer JOBS=N`
+- Stop the containers: `make stop-dockerized-fuzzer`
+- View logs: `make show-dockerized-fuzzer-logs`
+- Tail logs: `make watch-dockerized-fuzzer-logs`
+- List crashes: `make list-dockerized-fuzzer-crashes`
+
+For the full command list, use: `make help-dockerized-fuzzer`
+
+## Requirements
+
+- AFL++: `afl-clang-fast`, `afl-fuzz`, `afl-cmin`, `afl-tmin`
+- Clang with ASan/UBSan: `make test-build` | `make test-run`
+- Docker + Docker Compose + `yq`: dockerized `libFuzzer` workflow
+
+## Notes
+
+- The AFL++ corpus is generated automatically from `../data/test` when needed.
+- The dockerized setup clones <https://github.com/matteoalba/fuzz-zsv> repo as a
+  helper environment.


### PR DESCRIPTION
Related #612.

- Updated `fuzz/Makefile` to support dockerized fuzzer
- Added `fuzz/README.md` with a short intro

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>