### PR TITLE
ci: fix FreeBSD deprecation (cross-platform-actions/action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - name: Test and Build
+    - name: Set up FreeBSD
       uses: cross-platform-actions/action@v1.1.0
       env:
         PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
@@ -423,13 +423,15 @@ jobs:
       with:
         operating_system: freebsd
         version: '13.2'
-        environment_variables: 'PREFIX CC MAKE ARTIFACT_DIR'
+        environment_variables: PREFIX CC MAKE ARTIFACT_DIR
         shell: sh
-        run: |
-          ./scripts/ci-freebsd-setup.sh
-          export HOST=
-          RUN_TESTS=true SKIP_BUILD=true ./scripts/ci-build.sh
-          RUN_TESTS=false SKIP_BUILD=false CFLAGS='-DPREFIX=\"\"' ./scripts/ci-build.sh
+
+    - name: Build and Test
+      run: |
+        ./scripts/ci-freebsd-setup.sh
+        export HOST=
+        RUN_TESTS=true SKIP_BUILD=true ./scripts/ci-build.sh
+        RUN_TESTS=false SKIP_BUILD=false CFLAGS='-DPREFIX=\"\"' ./scripts/ci-build.sh
 
     - name: Prepare build artifacts for upload
       run: ./scripts/ci-prepare-artifacts-for-upload.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,22 +416,33 @@ jobs:
 
     - name: Set up FreeBSD
       uses: cross-platform-actions/action@v1.1.0
-      env:
-        PREFIX: ${{ env.AMD64_FREEBSD_GCC }}
-        CC: gcc13
-        MAKE: gmake
       with:
         operating_system: freebsd
         version: '13.2'
-        environment_variables: PREFIX CC MAKE ARTIFACT_DIR
+        environment_variables: TAG ARTIFACT_DIR
         shell: sh
 
-    - name: Build and Test
+    - name: Set up dependencies
       shell: cpa.sh {0}
       run: |
         ./scripts/ci-freebsd-setup.sh
+
+    - name: Test
+      shell: cpa.sh {0}
+      run: |
         export HOST=
+        export PREFIX=${{ env.AMD64_FREEBSD_GCC }}
+        export CC=gcc13
+        export MAKE=gmake
         RUN_TESTS=true SKIP_BUILD=true ./scripts/ci-build.sh
+
+    - name: Build
+      shell: cpa.sh {0}
+      run: |
+        export HOST=
+        export PREFIX=${{ env.AMD64_FREEBSD_GCC }}
+        export CC=gcc13
+        export MAKE=gmake
         RUN_TESTS=false SKIP_BUILD=false CFLAGS='-DPREFIX=\"\"' ./scripts/ci-build.sh
 
     - name: Prepare build artifacts for upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,7 @@ jobs:
         shell: sh
 
     - name: Build and Test
+      shell: cpa.sh {0}
       run: |
         ./scripts/ci-freebsd-setup.sh
         export HOST=


### PR DESCRIPTION
Fixes deprecation warning for https://github.com/cross-platform-actions/action:

> Input 'run' has been deprecated with message: The "run" parameter is deprecated. Use the custom shell (`shell: cpa.sh {0}`) on subsequent steps to run commands in the virtual machine instead.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>