### PR TITLE
help: make the command catalog a structured {name, synopsis} table

### DIFF
--- a/app/builtin/help.c
+++ b/app/builtin/help.c
@@ -22,8 +22,12 @@ static int main_help(int argc, const char *argv[]) {
   for (size_t i = 0; common_options[i]; i++)
     fprintf(f, "%s\n", common_options[i]);
   fprintf(f, "\n%s\n", commands_title);
-  for (size_t i = 0; commands[i]; i++)
-    fprintf(f, "%s\n", commands[i]);
+  for (size_t i = 0; commands[i].name || commands[i].synopsis; i++) {
+    if (!commands[i].name) /* section break: print synopsis as a sub-heading */
+      fprintf(f, "\n%s\n", commands[i].synopsis);
+    else
+      fprintf(f, "  %-9s: %s\n", commands[i].name, commands[i].synopsis);
+  }
 
 #ifndef __EMSCRIPTEN__
   char printed_init = 0;

--- a/app/builtin/help_usage.h
+++ b/app/builtin/help_usage.h
@@ -58,32 +58,43 @@ static const char *common_options[] = {
 };
 
 static const char *commands_title = "Commands that parse CSV or other tabular data:";
-static const char *commands[] = {
-  "  echo     : write tabular input to stdout with optional cell overwrites",
-  "  check    : check for anomalies (column counts, utf8 encoding etc)",
-  "  count    : print the number of rows",
-  "  select   : extract rows/columns by name or position and perform other basic and 'cleanup' operations",
-  "  desc     : describe each column",
-  "  sql      : run ad-hoc SQL on one or more CSV files",
-  "  pretty   : pretty print for console display",
-  "  serialize: convert into 3-column format (id, column name, cell value)",
-  "  flatten  : flatten a table consisting of N groups of data, each with 1 or",
-  "             more rows in the table, into a table of N rows",
-  "  2json    : convert CSV or sqlite3 db table to json",
-  "  2tsv     : convert to tab-delimited text",
-  "  stack    : stack tables vertically, aligning columns with common names",
-  "  paste    : horizontally paste two tables together: given inputs X, Y, ... of N rows",
-  "  compare  : compare two or more tables and output differences",
-  "  overwrite: save, modify or apply overwrites",
-  "",
-  "Other commands:",
-  "  2db      : convert json to sqlite3 db",
-  "  prop     : save parsing options associated with a file that are subsequently",
-  "             applied by default when processing that file",
-  "  rm       : remove a file and its related cache",
-  "  mv       : rename (move) a file and/or its related cache",
+
+/* Structured command catalog: the single source of truth for each
+ * command's name and one-line synopsis. help.c formats this into the
+ * display list shown by `zsv help`; downstream tools (e.g. the lq CLI)
+ * include this header and look up a command's synopsis by name, so the
+ * text lives in exactly one place rather than being duplicated. A NULL
+ * `name` marks a section break whose `synopsis`, if non-NULL, is printed
+ * as a sub-heading. The array is terminated by a {NULL, NULL} sentinel. */
+struct zsv_help_command {
+  const char *name;     /* command name; NULL marks a section break */
+  const char *synopsis; /* one-line description (or sub-heading text) */
+};
+static const struct zsv_help_command commands[] = {
+  {"echo", "write tabular input to stdout with optional cell overwrites"},
+  {"check", "check for anomalies (column counts, utf8 encoding etc)"},
+  {"count", "print the number of rows"},
+  {"select", "extract rows/columns by name or position and perform other basic and 'cleanup' operations"},
+  {"desc", "describe each column"},
+  {"sql", "run ad-hoc SQL on one or more CSV files"},
+  {"pretty", "pretty print for console display"},
+  {"serialize", "convert into 3-column format (id, column name, cell value)"},
+  {"flatten",
+   "flatten a table consisting of N groups of data, each with 1 or more rows in the table, into a table of N rows"},
+  {"2json", "convert CSV or sqlite3 db table to json"},
+  {"2tsv", "convert to tab-delimited text"},
+  {"stack", "stack tables vertically, aligning columns with common names"},
+  {"paste", "horizontally paste two tables together: given inputs X, Y, ... of N rows"},
+  {"compare", "compare two or more tables and output differences"},
+  {"overwrite", "save, modify or apply overwrites"},
+  {NULL, "Other commands:"},
+  {"2db", "convert json to sqlite3 db"},
+  {"prop",
+   "save parsing options associated with a file that are subsequently applied by default when processing that file"},
+  {"rm", "remove a file and its related cache"},
+  {"mv", "rename (move) a file and/or its related cache"},
 #ifdef USE_JQ
-  "  jq       : run a jq filter on json input",
+  {"jq", "run a jq filter on json input"},
 #endif
-  NULL,
+  {NULL, NULL},
 };

--- a/app/ext_example/test/expected/test-extension-3.out
+++ b/app/ext_example/test/expected/test-extension-3.out
@@ -46,8 +46,7 @@ Commands that parse CSV or other tabular data:
   sql      : run ad-hoc SQL on one or more CSV files
   pretty   : pretty print for console display
   serialize: convert into 3-column format (id, column name, cell value)
-  flatten  : flatten a table consisting of N groups of data, each with 1 or
-             more rows in the table, into a table of N rows
+  flatten  : flatten a table consisting of N groups of data, each with 1 or more rows in the table, into a table of N rows
   2json    : convert CSV or sqlite3 db table to json
   2tsv     : convert to tab-delimited text
   stack    : stack tables vertically, aligning columns with common names
@@ -57,8 +56,7 @@ Commands that parse CSV or other tabular data:
 
 Other commands:
   2db      : convert json to sqlite3 db
-  prop     : save parsing options associated with a file that are subsequently
-             applied by default when processing that file
+  prop     : save parsing options associated with a file that are subsequently applied by default when processing that file
   rm       : remove a file and its related cache
   mv       : rename (move) a file and/or its related cache
   jq       : run a jq filter on json input
@@ -115,8 +113,7 @@ Commands that parse CSV or other tabular data:
   sql      : run ad-hoc SQL on one or more CSV files
   pretty   : pretty print for console display
   serialize: convert into 3-column format (id, column name, cell value)
-  flatten  : flatten a table consisting of N groups of data, each with 1 or
-             more rows in the table, into a table of N rows
+  flatten  : flatten a table consisting of N groups of data, each with 1 or more rows in the table, into a table of N rows
   2json    : convert CSV or sqlite3 db table to json
   2tsv     : convert to tab-delimited text
   stack    : stack tables vertically, aligning columns with common names
@@ -126,8 +123,7 @@ Commands that parse CSV or other tabular data:
 
 Other commands:
   2db      : convert json to sqlite3 db
-  prop     : save parsing options associated with a file that are subsequently
-             applied by default when processing that file
+  prop     : save parsing options associated with a file that are subsequently applied by default when processing that file
   rm       : remove a file and its related cache
   mv       : rename (move) a file and/or its related cache
   jq       : run a jq filter on json input

--- a/app/ext_example/test/expected/test-extension-3.out.win
+++ b/app/ext_example/test/expected/test-extension-3.out.win
@@ -47,8 +47,7 @@ Commands that parse CSV or other tabular data:
   sql      : run ad-hoc SQL on one or more CSV files
   pretty   : pretty print for console display
   serialize: convert into 3-column format (id, column name, cell value)
-  flatten  : flatten a table consisting of N groups of data, each with 1 or
-             more rows in the table, into a table of N rows
+  flatten  : flatten a table consisting of N groups of data, each with 1 or more rows in the table, into a table of N rows
   2json    : convert CSV or sqlite3 db table to json
   2tsv     : convert to tab-delimited text
   stack    : stack tables vertically, aligning columns with common names
@@ -58,8 +57,7 @@ Commands that parse CSV or other tabular data:
 
 Other commands:
   2db      : convert json to sqlite3 db
-  prop     : save parsing options associated with a file that are subsequently
-             applied by default when processing that file
+  prop     : save parsing options associated with a file that are subsequently applied by default when processing that file
   rm       : remove a file and its related cache
   mv       : rename (move) a file and/or its related cache
   jq       : run a jq filter on json input
@@ -117,8 +115,7 @@ Commands that parse CSV or other tabular data:
   sql      : run ad-hoc SQL on one or more CSV files
   pretty   : pretty print for console display
   serialize: convert into 3-column format (id, column name, cell value)
-  flatten  : flatten a table consisting of N groups of data, each with 1 or
-             more rows in the table, into a table of N rows
+  flatten  : flatten a table consisting of N groups of data, each with 1 or more rows in the table, into a table of N rows
   2json    : convert CSV or sqlite3 db table to json
   2tsv     : convert to tab-delimited text
   stack    : stack tables vertically, aligning columns with common names
@@ -128,8 +125,7 @@ Commands that parse CSV or other tabular data:
 
 Other commands:
   2db      : convert json to sqlite3 db
-  prop     : save parsing options associated with a file that are subsequently
-             applied by default when processing that file
+  prop     : save parsing options associated with a file that are subsequently applied by default when processing that file
   rm       : remove a file and its related cache
   mv       : rename (move) a file and/or its related cache
   jq       : run a jq filter on json input


### PR DESCRIPTION
`commands[]` in builtin/help_usage.h was a display-formatted string array, which forced any downstream consumer (e.g. the lq CLI, which syncs this header) to either duplicate the synopsis text or parse the formatted lines. Replace it with a structured table:

  struct zsv_help_command { const char *name; const char *synopsis; };

so the name + one-line synopsis is the single source of truth and can be looked up by name. help.c now formats that table into the same display list (a NULL name marks the "Other commands:" section break). Output is unchanged except `flatten`/`prop` are emitted on a single line rather than hand-wrapped.