### PR TITLE
sheet: add find-next-column to cycle matching headers

### DIFF
--- a/app/sheet.c
+++ b/app/sheet.c
@@ -607,43 +607,76 @@ static char zsvsheet_handle_find_next(struct zsvsheet_display_info *di, struct z
   return 0;
 }
 
-/* Find column handler: case-insensitive column header find */
-static zsvsheet_status zsvsheet_goto_column(struct zsvsheet_sheet_context *state) {
-  struct zsvsheet_display_info *di = &state->display_info;
-  struct zsvsheet_ui_buffer *current_ui_buffer = *(di->ui_buffers.current);
-  if (zsvsheet_buffer_data_filename(current_ui_buffer)) {
-    char prompt_buffer[256] = {0};
-    int prompt_footer_row = (int)(di->dimensions->rows - di->dimensions->footer_span);
-    get_subcommand("Find column", prompt_buffer, sizeof(prompt_buffer), prompt_footer_row, state->goto_column);
-    if (*prompt_buffer != '\0') {
-      free(state->goto_column);
-      state->goto_column = strdup(prompt_buffer);
-      if (state->goto_column) {
-        size_t len_lc = strlen(state->goto_column);
-        int err;
-        unsigned char *find_lc = zsv_strtolowercase_w_err((const unsigned char *)state->goto_column, &len_lc, &err);
-        if (find_lc && len_lc) {
-          zsvsheet_screen_buffer_t buffer = current_ui_buffer->buffer;
-          size_t colcount = zsvsheet_screen_buffer_cols(buffer);
-          size_t found = 0; // if found, will equal 1 + column index
-          for (size_t i = 0; !found && i < colcount; i++) {
-            const unsigned char *colname = zsvsheet_screen_buffer_cell_display(buffer, 0, i);
-            if (colname && *colname) {
-              size_t colname_len_lc = strlen((const char *)colname);
-              unsigned char *colname_lc = zsv_strtolowercase_w_err(colname, &colname_len_lc, &err);
-              if (colname_lc && colname_len_lc > 0 && memmem(colname_lc, colname_len_lc, find_lc, len_lc))
-                found = i + 1;
-              free(colname_lc);
-            }
-          }
-          free(find_lc);
-          if (found)
-            zsvsheet_move_hor_to(di, found - 1);
-        }
-      }
+/* Scan column headers for the first case-insensitive substring match of
+ * needle_lc (already lowercased, length needle_len). Scanning begins at column
+ * start_col and wraps around so every column is examined exactly once.
+ * Returns 1 + the matching column index, or 0 if no column matches. */
+static size_t zsvsheet_find_column_match(zsvsheet_screen_buffer_t buffer, size_t colcount,
+                                         const unsigned char *needle_lc, size_t needle_len, size_t start_col) {
+  for (size_t n = 0; n < colcount; n++) {
+    size_t i = (start_col + n) % colcount;
+    const unsigned char *colname = zsvsheet_screen_buffer_cell_display(buffer, 0, i);
+    if (colname && *colname) {
+      int err;
+      size_t colname_len_lc = strlen((const char *)colname);
+      unsigned char *colname_lc = zsv_strtolowercase_w_err(colname, &colname_len_lc, &err);
+      size_t found = 0; // if matched, will equal 1 + column index
+      if (colname_lc && colname_len_lc > 0 && memmem(colname_lc, colname_len_lc, needle_lc, needle_len))
+        found = i + 1;
+      free(colname_lc);
+      if (found)
+        return found;
     }
   }
   return 0;
+}
+
+/* Find column handler: case-insensitive column header find.
+ * If next is true, reuse the previously entered search term and continue from
+ * the column after the cursor (wrapping around); otherwise prompt for a new
+ * term and search from the first column. */
+static zsvsheet_status zsvsheet_goto_column(struct zsvsheet_sheet_context *state, bool next) {
+  struct zsvsheet_display_info *di = &state->display_info;
+  struct zsvsheet_ui_buffer *current_ui_buffer = *(di->ui_buffers.current);
+  if (!zsvsheet_buffer_data_filename(current_ui_buffer))
+    return zsvsheet_status_ok;
+
+  if (!next) {
+    char prompt_buffer[256] = {0};
+    int prompt_footer_row = (int)(di->dimensions->rows - di->dimensions->footer_span);
+    get_subcommand("Find column", prompt_buffer, sizeof(prompt_buffer), prompt_footer_row, state->goto_column);
+    if (*prompt_buffer == '\0')
+      return zsvsheet_status_ok;
+    free(state->goto_column);
+    state->goto_column = strdup(prompt_buffer);
+  }
+
+  if (!state->goto_column)
+    return zsvsheet_status_ok;
+
+  size_t len_lc = strlen(state->goto_column);
+  int err;
+  unsigned char *find_lc = zsv_strtolowercase_w_err((const unsigned char *)state->goto_column, &len_lc, &err);
+  if (find_lc && len_lc) {
+    zsvsheet_screen_buffer_t buffer = current_ui_buffer->buffer;
+    size_t colcount = zsvsheet_screen_buffer_cols(buffer);
+    if (colcount > 0) {
+      // For "next", start scanning just after the current column so repeated
+      // invocations cycle through all matches; otherwise start from column 0.
+      size_t start_col = 0;
+      if (next) {
+        size_t current_col = current_ui_buffer->buff_offset.col + current_ui_buffer->cursor_col;
+        start_col = (current_col + 1) % colcount;
+      }
+      size_t found = zsvsheet_find_column_match(buffer, colcount, find_lc, len_lc, start_col);
+      if (found)
+        zsvsheet_move_hor_to(di, found - 1);
+      else
+        zsvsheet_priv_set_status(di->dimensions, 1, "Column not found");
+    }
+  }
+  free(find_lc);
+  return zsvsheet_status_ok;
 }
 
 /* Find and find-next handler */
@@ -1015,7 +1048,9 @@ zsvsheet_status zsvsheet_builtin_proc_handler(struct zsvsheet_proc_context *ctx)
   case zsvsheet_builtin_proc_find_next:
     return zsvsheet_find(state, true);
   case zsvsheet_builtin_proc_goto_column:
-    return zsvsheet_goto_column(state);
+    return zsvsheet_goto_column(state, false);
+  case zsvsheet_builtin_proc_goto_column_next:
+    return zsvsheet_goto_column(state, true);
   }
 
   return zsvsheet_status_error;
@@ -1042,7 +1077,8 @@ struct builtin_proc_desc {
   { zsvsheet_builtin_proc_move_right,     "right",       "Move right one column",                                           zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_find,           "find",        "Set a search term and jump to the first result after the cursor", zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_find_next,      "next",        "Jump to the next search result",                                  zsvsheet_builtin_proc_handler },
-  { zsvsheet_builtin_proc_goto_column,    "gotocolumn",  "Go to column",                                                    zsvsheet_builtin_proc_handler },
+  { zsvsheet_builtin_proc_goto_column,    "gotocolumn",  "Find a column by name and jump to the first match",               zsvsheet_builtin_proc_handler },
+  { zsvsheet_builtin_proc_goto_column_next,"gotocolumnnext","Jump to the next column matching the find-column term",          zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_resize,         "resize",      "Resize the layout to fit new terminal dimensions",                zsvsheet_builtin_proc_handler },
   { zsvsheet_builtin_proc_open_file,      "open",        "Open another CSV file",                                           zsvsheet_open_file_handler    },
   { zsvsheet_builtin_proc_filter,         "filter",      "Filter by specified text",                                        zsvsheet_filter_handler       },

--- a/app/sheet/key-bindings.c
+++ b/app/sheet/key-bindings.c
@@ -168,6 +168,7 @@ struct zsvsheet_key_binding zsvsheet_vim_key_bindings[] = {
   { .ch = 'n',                 .proc_id = zsvsheet_builtin_proc_find_next,     },
 
   { .ch = '|',                 .proc_id = zsvsheet_builtin_proc_goto_column,   },
+  { .ch = '\\',                .proc_id = zsvsheet_builtin_proc_goto_column_next, },
 
   /* Open is a subcommand only in vim. Keeping the binding for now */
   { .ch = 'e',                 .proc_id = zsvsheet_builtin_proc_open_file,     },
@@ -259,6 +260,7 @@ struct zsvsheet_key_binding zsvsheet_emacs_key_bindings[] = {
   { .ch = 'f',                    .proc_id = zsvsheet_builtin_proc_filter,        },
   { .ch = 'F',                    .proc_id = zsvsheet_builtin_proc_filter_this,   },
   { .ch = '|',                    .proc_id = zsvsheet_builtin_proc_goto_column,   },
+  { .ch = '\\',                   .proc_id = zsvsheet_builtin_proc_goto_column_next, },
   { .ch = ZSVSHEET_CTRL('h'),     .proc_id = zsvsheet_builtin_proc_help,          },
   { .ch = '\n',                   .proc_id = zsvsheet_builtin_proc_newline,       },
   { .ch = '\r',                   .proc_id = zsvsheet_builtin_proc_newline,       },

--- a/app/sheet/procedure.h
+++ b/app/sheet/procedure.h
@@ -30,6 +30,7 @@ enum {
   zsvsheet_builtin_proc_find,
   zsvsheet_builtin_proc_find_next,
   zsvsheet_builtin_proc_goto_column,
+  zsvsheet_builtin_proc_goto_column_next,
   zsvsheet_builtin_proc_open_file,
   zsvsheet_builtin_proc_resize,
   zsvsheet_builtin_proc_prompt,

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -988,6 +988,7 @@ test-sheet-cleanup:
 test-sheet-all: \
 	test-sheet-1 test-sheet-2 test-sheet-3 test-sheet-4 test-sheet-5 test-sheet-6 test-sheet-7 test-sheet-8 test-sheet-9 \
 	test-sheet-10 test-sheet-11 test-sheet-12 test-sheet-13 test-sheet-14 test-sheet-15 test-sheet-16 test-sheet-17 \
+	test-sheet-18 \
 	test-sheet-subcommand \
 	test-sheet-prop-cmd-opt \
 	test-sheet-pivot-1 \
@@ -1159,6 +1160,22 @@ test-sheet-17: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv ${TIMINGS
 	tmux -L $@ send-keys -t $@ "0G" && \
 	${EXPECT} $@ 0g && \
 	tmux -L $@ send-keys -t $@ "1G" && \
+	${EXPECT} $@ && ${TEST_PASS} || ${TEST_FAIL})
+
+# Find column ("|") then find-next-column ("\") cycles through every header that
+# matches the search term. "it" matches City, AccentCity and Latitude; the footer
+# shows the selected cell value, confirming the cursor lands on each in turn.
+test-sheet-18: ${BUILD_DIR}/bin/zsv_sheet${EXE} worldcitiespop_mil.csv ${TIMINGS_CSV}
+	@${TEST_INIT}
+	@echo 'set-option default-terminal "${TMUX_TERM}"' > ~/.tmux.conf
+	@(tmux -L $@ kill-server 2>/dev/null; rm -f ${TMP_DIR}/tmux-$$(id -u)/$@ 2>/dev/null; \
+	tmux -L $@ new-session -x 80 -y 6 -d -s $@ "${PREFIX} $< worldcitiespop_mil.csv" && \
+	${EXPECT} $@ indexed && \
+	tmux -L $@ send-keys -t $@ "|" "it" ENTER && \
+	${EXPECT} $@ find-col && \
+	tmux -L $@ send-keys -t $@ "\\" && \
+	${EXPECT} $@ next-1 && \
+	tmux -L $@ send-keys -t $@ "\\" && \
 	${EXPECT} $@ && ${TEST_PASS} || ${TEST_FAIL})
 
 test-sheet-subcommand: \

--- a/app/test/expected/test-sheet-13.out
+++ b/app/test/expected/test-sheet-13.out
@@ -21,7 +21,8 @@ g g                       top                       Jump to the first row
 G                         bottom                    Jump to the last row (nG
 /                         find                      Set a search term and jum
 n                         next                      Jump to the next search r
-|                         gotocolumn                Go to column
+|                         gotocolumn                Find a column by name and
+\                         gotocolumnnext            Jump to the next column m
 e                         open                      Open another CSV file
 f                         filter                    Filter by specified text
 F                         filtercol                 Filter by specified text
@@ -35,6 +36,5 @@ V                         pivotexpr                 Group rows with group-by
                           errors                    Show errors (if any)
                           errors-clear              Clear any/all errors
                           compare                   Highlight differences bet
-
 
 <esc> to exit help Key(s)

--- a/app/test/expected/test-sheet-14-help.out
+++ b/app/test/expected/test-sheet-14-help.out
@@ -21,7 +21,8 @@ g g                       top                       Jump to the first row
 G                         bottom                    Jump to the last row (nG
 /                         find                      Set a search term and jum
 n                         next                      Jump to the next search r
-|                         gotocolumn                Go to column
+|                         gotocolumn                Find a column by name and
+\                         gotocolumnnext            Jump to the next column m
 e                         open                      Open another CSV file
 f                         filter                    Filter by specified text
 F                         filtercol                 Filter by specified text
@@ -35,6 +36,5 @@ V                         pivotexpr                 Group rows with group-by
                           errors                    Show errors (if any)
                           errors-clear              Clear any/all errors
                           compare                   Highlight differences bet
-
 
 <esc> to exit help Key(s)

--- a/app/test/expected/test-sheet-18-find-col.out
+++ b/app/test/expected/test-sheet-18-find-col.out
@@ -1,0 +1,6 @@
+Row #     Country   City      AccentCit Region    Populatio Latitude  Longitude
+1         ir        sarmaj-e  Sarmaj-e  13                  34.3578   47.5207
+2         ad        aixirival Aixirival 06                  42.466666 1.5
+3         mm        mokho-atw Mokho-atw 09                  18.033333 96.75
+4         id        selingon  Selingon  17                  -8.8374   116.4914
+? for help sarmaj-e hoseynkhani

--- a/app/test/expected/test-sheet-18-indexed.out
+++ b/app/test/expected/test-sheet-18-indexed.out
@@ -1,0 +1,6 @@
+Row #     Country   City      AccentCit Region    Populatio Latitude  Longitude
+1         ir        sarmaj-e  Sarmaj-e  13                  34.3578   47.5207
+2         ad        aixirival Aixirival 06                  42.466666 1.5
+3         mm        mokho-atw Mokho-atw 09                  18.033333 96.75
+4         id        selingon  Selingon  17                  -8.8374   116.4914
+? for help 1

--- a/app/test/expected/test-sheet-18-next-1.out
+++ b/app/test/expected/test-sheet-18-next-1.out
@@ -1,0 +1,6 @@
+Row #     Country   City      AccentCit Region    Populatio Latitude  Longitude
+1         ir        sarmaj-e  Sarmaj-e  13                  34.3578   47.5207
+2         ad        aixirival Aixirival 06                  42.466666 1.5
+3         mm        mokho-atw Mokho-atw 09                  18.033333 96.75
+4         id        selingon  Selingon  17                  -8.8374   116.4914
+? for help Sarmaj-e Hoseynkhani

--- a/app/test/expected/test-sheet-18.out
+++ b/app/test/expected/test-sheet-18.out
@@ -1,0 +1,6 @@
+Row #     Country   City      AccentCit Region    Populatio Latitude  Longitude
+1         ir        sarmaj-e  Sarmaj-e  13                  34.3578   47.5207
+2         ad        aixirival Aixirival 06                  42.466666 1.5
+3         mm        mokho-atw Mokho-atw 09                  18.033333 96.75
+4         id        selingon  Selingon  17                  -8.8374   116.4914
+? for help 34.3578

--- a/docs/sheet.md
+++ b/docs/sheet.md
@@ -115,7 +115,8 @@ Press `?` to see a list of commands:
 | G              | bottom     | Jump to the last row (nG for specific row e.g. 10G) |
 | /              | find       | Set a search term and jump to the …                 |
 | n              | next       | Jump to the next search result                      |
-| \|             | gotocolumn | Go to column                                        |
+| \|             | gotocolumn | Find a column by name and jump to the first match   |
+| \\             | gotocolumnnext | Jump to the next column matching the find-column term |
 | e              | open       | Open another CSV file                               |
 | f              | filter     | Filter by specified text                            |
 | F              | filtercol  | Filter by specified text only in c…                 |


### PR DESCRIPTION
#625

The "find column" command (|) jumps to the first header matching a search term. Add a find-next-column capability bound to backslash that reuses the prior term and continues from the column after the cursor, wrapping around so repeated invocations cycle through every match.

Refactor zsvsheet_goto_column to take a `next` flag (mirroring the cell-level find/find-next pattern) and extract the header scan into a DRY helper zsvsheet_find_column_match(). Add a "Column not found" status on no-match, register the new gotocolumnnext proc, bind backslash in both vim and emacs key tables, and document it.

Adds test-sheet-18 covering the find/find-next-column cycle; updates the help expected output (test-sheet-13/14) for the new binding.