### PR TITLE
app: derive help/usage program name at runtime; generalize compare cu…

### DIFF
--- a/app/2db.c
+++ b/app/2db.c
@@ -646,9 +646,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
   opts.verbose = zsv_get_default_opts().verbose;
 
   const char *usage[] = {
-    APPNAME ": convert JSON to SQLite3 DB",
+    ZSV_USAGE_PROG " " APPNAME ": convert JSON to SQLite3 DB",
     "",
-    "Usage: " APPNAME " -o <output path> [-t <table name>] [input.json]\n",
+    "Usage: " ZSV_USAGE_PROG " " APPNAME " -o <output path> [-t <table name>] [input.json]\n",
     "",
     "Options:",
     "  -h,--help            : show usage",
@@ -678,8 +678,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
 
   for (int i = 1; !err && i < argc; i++) {
     if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
-      for (int j = 0; usage[j]; j++)
-        fprintf(stdout, "%s\n", usage[j]);
+      zsv_print_usage(usage);
       goto exit_2db;
     } else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
       if (++i >= argc)

--- a/app/2json.c
+++ b/app/2json.c
@@ -231,9 +231,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   data.headers_next = &data.headers;
 
   const char *usage[] = {
-    APPNAME ": streaming CSV to JSON converter, or SQLite3 DB to JSON converter",
+    ZSV_USAGE_PROG " " APPNAME ": streaming CSV to JSON converter, or SQLite3 DB to JSON converter",
     "",
-    "Usage: " APPNAME " [options] [file.csv]",
+    "Usage: " ZSV_USAGE_PROG " " APPNAME " [options] [file.csv]",
     "",
     "Options:",
     "  -h,--help                     : show usage",
@@ -257,8 +257,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
   for (int i = 1; !err && !done && i < argc; i++) {
     if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
-      for (int j = 0; usage[j]; j++)
-        fprintf(stdout, "%s\n", usage[j]);
+      zsv_print_usage(usage);
       done = 1;
     } else if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
       if (++i >= argc)

--- a/app/2tsv.c
+++ b/app/2tsv.c
@@ -140,12 +140,12 @@ static void zsv_2tsv_row(void *ctx) {
 
 int zsv_2tsv_usage(int rc) {
   static const char *zsv_2tsv_usage_msg[] = {
-    APPNAME ": convert CSV to TSV (tab-delimited text) suitable for simple-delimiter",
+    ZSV_USAGE_PROG " " APPNAME ": convert CSV to TSV (tab-delimited text) suitable for simple-delimiter",
     "          text processing. By default, embedded tabs or multilines will be escaped",
     "          to \\t, \\n or \\r, respectively",
     "",
-    "Usage: " APPNAME " [filename] [options]",
-    "  e.g. " APPNAME " < file.csv > file.tsv",
+    "Usage: " ZSV_USAGE_PROG " " APPNAME " [filename] [options]",
+    "  e.g. " ZSV_USAGE_PROG " " APPNAME " < file.csv > file.tsv",
     "",
     "Options:",
     "  -o <file>         : save output to <file>",
@@ -153,8 +153,7 @@ int zsv_2tsv_usage(int rc) {
     NULL,
   };
 
-  for (size_t i = 0; zsv_2tsv_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_2tsv_usage_msg[i]);
+  zsv_print_usage(zsv_2tsv_usage_msg);
 
   return rc;
 }

--- a/app/Makefile
+++ b/app/Makefile
@@ -194,7 +194,7 @@ endif
 THIS_LIB_BASE:=$(shell cd .. && pwd)
 INCLUDE_DIR:=${THIS_LIB_BASE}/include
 BUILD_DIR:=${THIS_LIB_BASE}/build/${BUILD_SUBDIR}/${CCBN}
-UTILS1=writer file err signal mem clock arg dl string dirs prop cache jq os index chunk
+UTILS1=writer file err signal mem clock arg dl string dirs prop cache jq os index chunk appname
 
 ZSV_EXTRAS ?=
 
@@ -239,7 +239,8 @@ ifeq ($(NO_MEMMEM),1)
   UTIL_A_OBJ_WIN=memmem
 endif
 
-ZSV=$(BINDIR)/zsv${EXE}
+PROG_NAME ?= zsv
+ZSV=$(BINDIR)/$(PROG_NAME)${EXE}
 
 SOURCES=echo paste check count count-pull select select-pull 2tsv 2json serialize flatten pretty stack desc sql 2db compare prop rm mv jq
 ifeq ($(ZSV_EXTRAS),1)

--- a/app/builtin/help.c
+++ b/app/builtin/help.c
@@ -16,8 +16,7 @@ static int main_help(int argc, const char *argv[]) {
 
 #include "help_usage.h"
 
-  for (size_t i = 0; usage[i]; i++)
-    fprintf(f, "%s\n", usage[i]);
+  zsv_fprint_usage(f, usage);
   fprintf(f, "\n%s\n", common_options_title);
   for (size_t i = 0; common_options[i]; i++)
     fprintf(f, "%s\n", common_options[i]);

--- a/app/builtin/help_usage.h
+++ b/app/builtin/help_usage.h
@@ -1,10 +1,10 @@
 static const char *usage[] = {
-  "zsv: streaming csv processor",
+  ZSV_USAGE_PROG ": streaming csv processor",
   "",
   "Usage:",
-  "  zsv version: display version info (and if applicable, extension info)",
+  "  " ZSV_USAGE_PROG " version: display version info (and if applicable, extension info)",
 #ifndef __EMSCRIPTEN__
-  "  zsv (un)register [<extension_id>]    : (un)register an extension",
+  "  " ZSV_USAGE_PROG " (un)register [<extension_id>]    : (un)register an extension",
   "      Registration info is saved in zsv.ini located in a directory determined as:",
   "        ZSV_CONFIG_DIR environment variable value, if set",
 #if defined(_WIN32)
@@ -14,13 +14,13 @@ static const char *usage[] = {
   "        otherwise, " PREFIX "/etc",
 #endif
 #endif
-  "  zsv help [<command>]",
-  "  zsv <command> <options> <arguments>  : run a command on data (see below for details)",
+  "  " ZSV_USAGE_PROG " help [<command>]",
+  "  " ZSV_USAGE_PROG " <command> <options> <arguments>  : run a command on data (see below for details)",
 #ifndef __EMSCRIPTEN__
-  "  zsv <id>-<cmd> <options> <arguments> : invoke command 'cmd' of extension 'id'",
-  "  zsv license [<extension_id>]",
+  "  " ZSV_USAGE_PROG " <id>-<cmd> <options> <arguments> : invoke command 'cmd' of extension 'id'",
+  "  " ZSV_USAGE_PROG " license [<extension_id>]",
 #endif
-  "  zsv thirdparty                       : view third-party licenses & acknowledgements",
+  "  " ZSV_USAGE_PROG " thirdparty                       : view third-party licenses & acknowledgements",
   NULL,
 };
 static const char *common_options_title = "Options common to all commands except `prop`, `rm` and `jq`:";

--- a/app/builtin/version.c
+++ b/app/builtin/version.c
@@ -13,7 +13,7 @@ static int main_version(int argc, const char *argv[]) {
       verbose = 1;
   }
 
-  printf("zsv version %s (lib %s)\n", VERSION, zsv_lib_version());
+  printf("%s version %s (lib %s)\n", zsv_prog_name(), VERSION, zsv_lib_version());
 
   if (verbose) {
     printf("\nBuild configuration:\n");

--- a/app/check.c
+++ b/app/check.c
@@ -86,9 +86,9 @@ static void zsv_check_header(void *ctx) {
 
 static int zsv_check_usage(void) {
   const char *zsv_check_usage_msg[] = {
-    USAGE_APPNAME ": check input for anomalies",
+    ZSV_USAGE_PROG " " USAGE_APPNAME ": check input for anomalies",
     "",
-    "Usage: " APPNAME " <filename>",
+    "Usage: " ZSV_USAGE_PROG " " APPNAME " <filename>",
     "",
     "Options:",
     "  -o,--output <path> : output to specified file path",
@@ -99,8 +99,7 @@ static int zsv_check_usage(void) {
     "If no check options are provided, all checks are run",
     NULL,
   };
-  for (size_t i = 0; zsv_check_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_check_usage_msg[i]);
+  zsv_print_usage(zsv_check_usage_msg);
   return 1;
 }
 

--- a/app/cli.c
+++ b/app/cli.c
@@ -20,6 +20,7 @@
 #endif
 #include <zsv.h>
 #include <zsv/ext.h>
+#include <zsv/utils/appname.h>
 #include "cli_internal.h"
 #include "cli_const.h"
 #include "cli_export.h"
@@ -559,6 +560,8 @@ static const char *extension_cmd_from_arg(const char *arg) {
 
 ZSV_CLI_EXPORT
 int ZSV_CLI_MAIN(int argc, const char *argv[]) {
+  const char *prog = getenv("ZSV_PROG_NAME");
+  zsv_set_prog_name(prog && *prog ? prog : argv[0]);
   const char **alt_argv = NULL;
   struct builtin_cmd *builtin = find_builtin(argc > 1 ? argv[1] : "help");
   if (builtin) {

--- a/app/compare.c
+++ b/app/compare.c
@@ -509,6 +509,10 @@ zsv_compare_handle zsv_compare_new(void) {
   z->get_column_name = zsv_compare_get_unsorted_cell;
   z->get_column_count = zsv_compare_get_unsorted_colcount;
   z->input_init = input_init_unsorted;
+
+  z->output_begin = zsv_compare_output_begin;
+  z->output_end = zsv_compare_output_end;
+  /* z->parse_opt left NULL: stock zsv has no custom options */
   return z;
 }
 
@@ -540,6 +544,8 @@ static void zsv_compare_data_free(struct zsv_compare_data *data) {
       jsonwriter_delete(data->writer.handle.jsw);
   } else
     zsv_writer_delete(data->writer.handle.csv);
+  if (data->writer.tmp) /* --redline scratch (closed here on every path) */
+    fclose(data->writer.tmp);
 
   for (unsigned i = 0; i < data->input_count; i++)
     zsv_compare_input_free(&data->inputs[i]);
@@ -687,9 +693,10 @@ static enum zsv_compare_status zsv_compare_next(struct zsv_compare_data *data) {
 /* Help topics for `zsv help compare <topic>` (see compare_help.c). */
 #include "compare_help.c"
 
+const char **zsv_compare_extra_usage = NULL;
 static int compare_usage(void) {
   static const char *usage[] = {
-    "Usage: compare [options] <file.csv>...",
+    "Usage: " ZSV_USAGE_PROG " " APPNAME " [options] <file.csv>...",
     "",
     "Options:",
     "  -h,--help          : show usage",
@@ -709,7 +716,10 @@ static int compare_usage(void) {
     "  --json-compact     : output as compact JSON",
     "  --json-object      : output as an array of objects",
     "  --json-redline     : output self-contained redline JSON",
-    "                       (see `zsv help compare json-redline` for schema)",
+    "                       (see `" ZSV_USAGE_PROG " help " APPNAME " json-redline` for schema)",
+    NULL,
+  };
+  static const char *usage2[] = {
     "  --include-unchanged-rows: (with --json-redline) emit matched rows",
     "  --include-tolerated: (with --json-redline) emit tolerated diffs as arrays",
     "  --columns <spec>   : compare column ranges within a single file",
@@ -749,8 +759,10 @@ static int compare_usage(void) {
     NULL,
   };
 
-  for (size_t i = 0; usage[i]; i++)
-    printf("%s\n", usage[i]);
+  zsv_print_usage(usage);
+  if (zsv_compare_extra_usage != NULL)
+    zsv_print_usage(zsv_compare_extra_usage);
+  zsv_print_usage(usage2);
 
   static const char *topics[] = {
     "",
@@ -758,25 +770,28 @@ static int compare_usage(void) {
     "  json-redline       : --json-redline output format (schema, narrative)",
     "  json-redline-schema: --json-redline output format (JSON Schema, Draft 2020-12)",
     "",
-    "  Usage: zsv help compare <topic>",
+    "  Usage: " ZSV_USAGE_PROG " help " APPNAME " <topic>",
     NULL,
   };
-  for (size_t i = 0; topics[i]; i++)
-    printf("%s\n", topics[i]);
+  zsv_print_usage(topics);
 
   return 0;
 }
 
-// TO DO: consolidate w sql.c, move common code to utils/db.c
+/* Customization hook: invoked once on the freshly-created handle so a host can
+ * override the output_begin/output_end/parse_opt members (e.g. to add --redline
+ * rendering). No-op in stock zsv. */
+#ifndef ZSV_COMPARE_CUSTOMIZE
+#define ZSV_COMPARE_CUSTOMIZE(data) ((void)(data))
+#endif
+
 int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *opts,
                                struct zsv_prop_handler *custom_prop_handler) {
-  // See sql.c re passing options to sqlite3 when sorting is used
   if (argc < 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
     compare_usage();
     return argc < 2 ? 1 : 0;
   }
 
-  /* Change C: --help-topic <name> prints a topic and exits */
   for (int i = 1; i < argc - 1; i++) {
     if (!strcmp(argv[i], "--help-topic"))
       return zsv_compare_print_help_topic(argv[i + 1]);
@@ -792,11 +807,13 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     free(input_filenames);
     return zsv_compare_status_memory;
   }
+  ZSV_COMPARE_CUSTOMIZE(data);
 
   int err = 0;
   const char *column_ranges_spec = NULL;
   // initialization starts here. to do: make this a separate function
   unsigned input_count = 0;
+  int saw_json = 0, saw_json_redline = 0;
   struct zsv_compare_key **next_key = &data->keys;
   struct zsv_compare_added_column **added_column_next = &data->added_columns;
   for (int arg_i = 1; data->status == zsv_compare_status_ok && !err && arg_i < argc; arg_i++) {
@@ -842,14 +859,22 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       data->return_count = 1;
     } else if (!strcmp(arg, "--json")) {
       data->writer.type = ZSV_COMPARE_OUTPUT_TYPE_JSON;
+      saw_json = 1;
     } else if (!strcmp(arg, "--json-object")) {
       data->writer.type = ZSV_COMPARE_OUTPUT_TYPE_JSON;
       data->writer.object = 1;
+      saw_json = 1;
     } else if (!strcmp(arg, "--json-compact")) {
       data->writer.type = ZSV_COMPARE_OUTPUT_TYPE_JSON;
       data->writer.compact = 1;
+      saw_json = 1;
     } else if (!strcmp(arg, "--json-redline")) {
       data->writer.type = ZSV_COMPARE_OUTPUT_TYPE_JSON_REDLINE;
+      saw_json_redline = 1;
+    } else if (!strcmp(arg, "-o") || !strcmp(arg, "--output")) {
+      const char *next_arg = zsv_next_arg(++arg_i, argc, argv, &err);
+      if (next_arg)
+        data->writer.output_path = next_arg;
     } else if (!strcmp(arg, "--include-unchanged-rows")) {
       data->writer.include_unchanged_rows = 1;
     } else if (!strcmp(arg, "--include-tolerated")) {
@@ -858,14 +883,31 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       data->print_key_col_names = 1;
     } else if (!strcmp(arg, "--require-all-inputs") || !strcmp(arg, "--intersect")) {
       data->require_all_inputs = 1;
+    } else if (data->parse_opt && data->parse_opt(data, arg, &arg_i, argc, argv, &err)) {
+      ; /* option consumed by a host-provided custom handler (e.g. --redline) */
     } else
       input_filenames[input_count++] = arg;
   }
 
-  /* Change B: -a/--add is incompatible with --json-redline */
   if (!err && data->added_colcount > 0 && data->writer.type == ZSV_COMPARE_OUTPUT_TYPE_JSON_REDLINE) {
     fprintf(stderr, "Error: -a/--add cannot be combined with --json-redline."
                     " All input columns are already emitted under --json-redline.\n");
+    err = 1;
+  }
+
+  /* A host-provided --redline (writer.redline_render) fuses `compare
+   * --json-redline` with document rendering; it owns the output format, so it is
+   * mutually exclusive with the other JSON output flags and requires an -o
+   * destination. redline_render is always 0 in stock zsv, so these checks are
+   * no-ops there. */
+  if (!err && data->writer.redline_render && (saw_json || saw_json_redline)) {
+    fprintf(stderr, "Error: --redline cannot be combined with --json, --json-object,"
+                    " --json-compact, or --json-redline.\n");
+    err = 1;
+  }
+  if (!err && data->writer.redline_render && !data->writer.output_path) {
+    fprintf(stderr, "Error: --redline requires -o <file> (format inferred from the"
+                    " .html or .xlsx extension).\n");
     err = 1;
   }
 
@@ -1050,7 +1092,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     char started = 0;
     if (data->status == zsv_compare_status_ok) {
       started = 1;
-      zsv_compare_output_begin(data);
+      data->output_begin(data);
 
       // match output colnames to added columns
       for (struct zsv_compare_added_column *ac = data->added_columns; ac; ac = ac->next) {
@@ -1115,7 +1157,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     while (data->status == zsv_compare_status_ok && zsv_compare_next(data) == zsv_compare_status_ok)
       ;
     if (started)
-      zsv_compare_output_end(data);
+      data->output_end(data);
   }
 
   err = data->status == zsv_compare_status_ok ? 0 : 1;

--- a/app/compare.h
+++ b/app/compare.h
@@ -20,4 +20,6 @@ void zsv_compare_set_input_parser(zsv_compare_handle cmp, zsv_parser p, unsigned
 void zsv_compare_delete(zsv_compare_handle);
 void zsv_compare_set_comparison(zsv_compare_handle, zsv_compare_cell_func, void *);
 
+extern const char **zsv_compare_extra_usage; // set this to a NULL-terminated text array to insert additional help text
+
 #endif

--- a/app/compare_help.c
+++ b/app/compare_help.c
@@ -11,7 +11,7 @@
  * and its narrative). #included directly into compare.c as a single translation unit.
  */
 
-static void zsv_compare_print_help_topic_narrative(void) {
+void zsv_compare_print_help_topic_narrative(FILE *out) {
   static const char *text[] = {"zsv compare --json-redline schema (version " ZSV_COMPARE_REDLINE_VERSION ")",
                                "==========================================================",
                                "",
@@ -52,145 +52,148 @@ static void zsv_compare_print_help_topic_narrative(void) {
                                "  zsv help compare json-redline-schema  (JSON Schema Draft 2020-12)",
                                NULL};
   for (size_t i = 0; text[i]; i++)
-    printf("%s\n", text[i]);
+    fprintf(out, "%s\n", text[i]);
 }
 
-static void zsv_compare_print_help_topic_json_schema(void) {
-  printf("{\n");
-  printf("  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n");
-  printf("  \"$id\": \"zsv.compare.json-redline.v%s\",\n", ZSV_COMPARE_REDLINE_VERSION);
-  printf("  \"title\": \"zsv compare --json-redline output (v%s)\",\n", ZSV_COMPARE_REDLINE_VERSION);
-  printf("  \"type\": \"object\",\n");
-  printf(
+void zsv_compare_print_help_topic_json_schema(FILE *out) {
+  fprintf(out, "{\n");
+  fprintf(out, "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n");
+  fprintf(out, "  \"$id\": \"zsv.compare.json-redline.v%s\",\n", ZSV_COMPARE_REDLINE_VERSION);
+  fprintf(out, "  \"title\": \"zsv compare --json-redline output (v%s)\",\n", ZSV_COMPARE_REDLINE_VERSION);
+  fprintf(out, "  \"type\": \"object\",\n");
+  fprintf(
+    out,
     "  \"required\": "
     "[\"schema\",\"version\",\"generated_at\",\"inputs\",\"keys\",\"options\",\"columns\",\"summary\",\"rows\"],\n");
-  printf("  \"properties\": {\n");
-  printf("    \"schema\": {\"const\": \"zsv.compare\"},\n");
-  printf("    \"version\": {\"const\": \"%s\"},\n", ZSV_COMPARE_REDLINE_VERSION);
-  printf("    \"generated_at\": {\"type\": \"string\"},\n");
-  printf("    \"inputs\": {\n");
-  printf("      \"type\": \"array\",\n");
-  printf("      \"items\": {\n");
-  printf("        \"type\": \"object\",\n");
-  printf("        \"required\": [\"label\",\"path\",\"row_count\"],\n");
-  printf("        \"properties\": {\n");
-  printf("          \"label\": {\"type\": \"string\"},\n");
-  printf("          \"path\": {\"type\": \"string\"},\n");
-  printf("          \"row_count\": {\"type\": \"integer\", \"minimum\": 0}\n");
-  printf("        }\n");
-  printf("      }\n");
-  printf("    },\n");
-  printf("    \"keys\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}},\n");
-  printf("    \"options\": {\n");
-  printf("      \"type\": \"object\",\n");
-  printf("      \"required\": [\"tolerance\",\"sort\",\"include_unchanged_rows\",\"include_tolerated\"],\n");
-  printf("      \"properties\": {\n");
-  printf("        \"tolerance\": {\"oneOf\": [{\"type\": \"number\"},{\"type\": \"null\"}]},\n");
-  printf("        \"sort\": {\"type\": \"boolean\"},\n");
-  printf("        \"include_unchanged_rows\": {\"type\": \"boolean\"},\n");
-  printf("        \"include_tolerated\": {\"type\": \"boolean\"},\n");
-  printf("        \"require_all_inputs\": {\"type\": \"boolean\"}\n");
-  printf("      }\n");
-  printf("    },\n");
-  printf("    \"columns\": {\n");
-  printf("      \"type\": \"array\",\n");
-  printf("      \"items\": {\n");
-  printf("        \"type\": \"object\",\n");
-  printf("        \"required\": [\"name\",\"is_key\",\"in_inputs\"],\n");
-  printf("        \"properties\": {\n");
-  printf("          \"name\": {\"type\": \"string\"},\n");
-  printf("          \"is_key\": {\"type\": \"boolean\"},\n");
-  printf("          \"in_inputs\": {\"type\": \"array\", \"items\": {\"type\": \"integer\", \"minimum\": 0}}\n");
-  printf("        }\n");
-  printf("      }\n");
-  printf("    },\n");
-  printf("    \"summary\": {\n");
-  printf("      \"type\": \"object\",\n");
-  printf("      \"required\": [\"rows\",\"cells\",\"by_column\",\"schema\"],\n");
-  printf("      \"properties\": {\n");
-  printf("        \"rows\": {\n");
-  printf("          \"type\": \"object\",\n");
-  printf("          \"required\": [\"in_all_inputs\",\"only_in_input_count\",\"with_any_diff\"],\n");
-  printf("          \"properties\": {\n");
-  printf("            \"in_all_inputs\": {\"type\": \"integer\", \"minimum\": 0},\n");
-  printf("            \"only_in_input_count\": {\"type\": \"array\", \"items\": {\"type\": \"integer\", \"minimum\": "
-         "0}},\n");
-  printf("            \"with_any_diff\": {\"type\": \"integer\", \"minimum\": 0}\n");
-  printf("          }\n");
-  printf("        },\n");
-  printf("        \"cells\": {\n");
-  printf("          \"type\": \"object\",\n");
-  printf("          \"required\": [\"compared\",\"matched\",\"within_tolerance\",\"differing\"],\n");
-  printf("          \"properties\": {\n");
-  printf("            \"compared\": {\"type\": \"integer\", \"minimum\": 0},\n");
-  printf("            \"matched\": {\"type\": \"integer\", \"minimum\": 0},\n");
-  printf("            \"within_tolerance\": {\"type\": \"integer\", \"minimum\": 0},\n");
-  printf("            \"differing\": {\"type\": \"integer\", \"minimum\": 0}\n");
-  printf("          }\n");
-  printf("        },\n");
-  printf("        \"by_column\": {\n");
-  printf("          \"type\": \"array\",\n");
-  printf("          \"items\": {\n");
-  printf("            \"type\": \"object\",\n");
-  printf("            \"required\": [\"name\",\"compared\",\"matched\",\"within_tolerance\",\"differing\"],\n");
-  printf("            \"properties\": {\n");
-  printf("              \"name\": {\"type\": \"string\"},\n");
-  printf("              \"compared\": {\"type\": \"integer\", \"minimum\": 0},\n");
-  printf("              \"matched\": {\"type\": \"integer\", \"minimum\": 0},\n");
-  printf("              \"within_tolerance\": {\"type\": \"integer\", \"minimum\": 0},\n");
-  printf("              \"differing\": {\"type\": \"integer\", \"minimum\": 0}\n");
-  printf("            }\n");
-  printf("          }\n");
-  printf("        },\n");
-  printf("        \"schema\": {\n");
-  printf("          \"type\": \"object\",\n");
-  printf("          \"required\": [\"common\",\"only_in_input\"],\n");
-  printf("          \"properties\": {\n");
-  printf("            \"common\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}},\n");
-  printf("            \"only_in_input\": {\"type\": \"array\", \"items\": {\"type\": \"array\", \"items\": {\"type\": "
-         "\"string\"}}}\n");
-  printf("          }\n");
-  printf("        }\n");
-  printf("      }\n");
-  printf("    },\n");
-  printf("    \"rows\": {\n");
-  printf("      \"type\": \"array\",\n");
-  printf("      \"items\": {\n");
-  printf("        \"oneOf\": [\n");
-  printf("          {\n");
-  printf("            \"type\": \"array\",\n");
-  printf("            \"items\": {\n");
-  printf("              \"oneOf\": [\n");
-  printf("                {\"type\": [\"string\",\"null\"]},\n");
-  printf("                {\"type\": \"array\", \"items\": {\"type\": [\"string\",\"null\"]}}\n");
-  printf("              ]\n");
-  printf("            }\n");
-  printf("          },\n");
-  printf("          {\n");
-  printf("            \"type\": \"object\",\n");
-  printf("            \"required\": [\"data\",\"missing_in\"],\n");
-  printf("            \"properties\": {\n");
-  printf("              \"data\": {\n");
-  printf("                \"type\": \"array\",\n");
-  printf("                \"items\": {\n");
-  printf("                  \"oneOf\": [\n");
-  printf("                    {\"type\": [\"string\",\"null\"]},\n");
-  printf("                    {\"type\": \"array\", \"items\": {\"type\": [\"string\",\"null\"]}}\n");
-  printf("                  ]\n");
-  printf("                }\n");
-  printf("              },\n");
-  printf("              \"missing_in\": {\n");
-  printf("                \"type\": \"array\",\n");
-  printf("                \"items\": {\"type\": \"integer\", \"minimum\": 0},\n");
-  printf("                \"description\": \"indices in ascending order\"\n");
-  printf("              }\n");
-  printf("            }\n");
-  printf("          }\n");
-  printf("        ]\n");
-  printf("      }\n");
-  printf("    }\n");
-  printf("  }\n");
-  printf("}\n");
+  fprintf(out, "  \"properties\": {\n");
+  fprintf(out, "    \"schema\": {\"const\": \"zsv.compare\"},\n");
+  fprintf(out, "    \"version\": {\"const\": \"%s\"},\n", ZSV_COMPARE_REDLINE_VERSION);
+  fprintf(out, "    \"generated_at\": {\"type\": \"string\"},\n");
+  fprintf(out, "    \"inputs\": {\n");
+  fprintf(out, "      \"type\": \"array\",\n");
+  fprintf(out, "      \"items\": {\n");
+  fprintf(out, "        \"type\": \"object\",\n");
+  fprintf(out, "        \"required\": [\"label\",\"path\",\"row_count\"],\n");
+  fprintf(out, "        \"properties\": {\n");
+  fprintf(out, "          \"label\": {\"type\": \"string\"},\n");
+  fprintf(out, "          \"path\": {\"type\": \"string\"},\n");
+  fprintf(out, "          \"row_count\": {\"type\": \"integer\", \"minimum\": 0}\n");
+  fprintf(out, "        }\n");
+  fprintf(out, "      }\n");
+  fprintf(out, "    },\n");
+  fprintf(out, "    \"keys\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}},\n");
+  fprintf(out, "    \"options\": {\n");
+  fprintf(out, "      \"type\": \"object\",\n");
+  fprintf(out, "      \"required\": [\"tolerance\",\"sort\",\"include_unchanged_rows\",\"include_tolerated\"],\n");
+  fprintf(out, "      \"properties\": {\n");
+  fprintf(out, "        \"tolerance\": {\"oneOf\": [{\"type\": \"number\"},{\"type\": \"null\"}]},\n");
+  fprintf(out, "        \"sort\": {\"type\": \"boolean\"},\n");
+  fprintf(out, "        \"include_unchanged_rows\": {\"type\": \"boolean\"},\n");
+  fprintf(out, "        \"include_tolerated\": {\"type\": \"boolean\"},\n");
+  fprintf(out, "        \"require_all_inputs\": {\"type\": \"boolean\"}\n");
+  fprintf(out, "      }\n");
+  fprintf(out, "    },\n");
+  fprintf(out, "    \"columns\": {\n");
+  fprintf(out, "      \"type\": \"array\",\n");
+  fprintf(out, "      \"items\": {\n");
+  fprintf(out, "        \"type\": \"object\",\n");
+  fprintf(out, "        \"required\": [\"name\",\"is_key\",\"in_inputs\"],\n");
+  fprintf(out, "        \"properties\": {\n");
+  fprintf(out, "          \"name\": {\"type\": \"string\"},\n");
+  fprintf(out, "          \"is_key\": {\"type\": \"boolean\"},\n");
+  fprintf(out, "          \"in_inputs\": {\"type\": \"array\", \"items\": {\"type\": \"integer\", \"minimum\": 0}}\n");
+  fprintf(out, "        }\n");
+  fprintf(out, "      }\n");
+  fprintf(out, "    },\n");
+  fprintf(out, "    \"summary\": {\n");
+  fprintf(out, "      \"type\": \"object\",\n");
+  fprintf(out, "      \"required\": [\"rows\",\"cells\",\"by_column\",\"schema\"],\n");
+  fprintf(out, "      \"properties\": {\n");
+  fprintf(out, "        \"rows\": {\n");
+  fprintf(out, "          \"type\": \"object\",\n");
+  fprintf(out, "          \"required\": [\"in_all_inputs\",\"only_in_input_count\",\"with_any_diff\"],\n");
+  fprintf(out, "          \"properties\": {\n");
+  fprintf(out, "            \"in_all_inputs\": {\"type\": \"integer\", \"minimum\": 0},\n");
+  fprintf(out,
+          "            \"only_in_input_count\": {\"type\": \"array\", \"items\": {\"type\": \"integer\", \"minimum\": "
+          "0}},\n");
+  fprintf(out, "            \"with_any_diff\": {\"type\": \"integer\", \"minimum\": 0}\n");
+  fprintf(out, "          }\n");
+  fprintf(out, "        },\n");
+  fprintf(out, "        \"cells\": {\n");
+  fprintf(out, "          \"type\": \"object\",\n");
+  fprintf(out, "          \"required\": [\"compared\",\"matched\",\"within_tolerance\",\"differing\"],\n");
+  fprintf(out, "          \"properties\": {\n");
+  fprintf(out, "            \"compared\": {\"type\": \"integer\", \"minimum\": 0},\n");
+  fprintf(out, "            \"matched\": {\"type\": \"integer\", \"minimum\": 0},\n");
+  fprintf(out, "            \"within_tolerance\": {\"type\": \"integer\", \"minimum\": 0},\n");
+  fprintf(out, "            \"differing\": {\"type\": \"integer\", \"minimum\": 0}\n");
+  fprintf(out, "          }\n");
+  fprintf(out, "        },\n");
+  fprintf(out, "        \"by_column\": {\n");
+  fprintf(out, "          \"type\": \"array\",\n");
+  fprintf(out, "          \"items\": {\n");
+  fprintf(out, "            \"type\": \"object\",\n");
+  fprintf(out, "            \"required\": [\"name\",\"compared\",\"matched\",\"within_tolerance\",\"differing\"],\n");
+  fprintf(out, "            \"properties\": {\n");
+  fprintf(out, "              \"name\": {\"type\": \"string\"},\n");
+  fprintf(out, "              \"compared\": {\"type\": \"integer\", \"minimum\": 0},\n");
+  fprintf(out, "              \"matched\": {\"type\": \"integer\", \"minimum\": 0},\n");
+  fprintf(out, "              \"within_tolerance\": {\"type\": \"integer\", \"minimum\": 0},\n");
+  fprintf(out, "              \"differing\": {\"type\": \"integer\", \"minimum\": 0}\n");
+  fprintf(out, "            }\n");
+  fprintf(out, "          }\n");
+  fprintf(out, "        },\n");
+  fprintf(out, "        \"schema\": {\n");
+  fprintf(out, "          \"type\": \"object\",\n");
+  fprintf(out, "          \"required\": [\"common\",\"only_in_input\"],\n");
+  fprintf(out, "          \"properties\": {\n");
+  fprintf(out, "            \"common\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}},\n");
+  fprintf(out,
+          "            \"only_in_input\": {\"type\": \"array\", \"items\": {\"type\": \"array\", \"items\": {\"type\": "
+          "\"string\"}}}\n");
+  fprintf(out, "          }\n");
+  fprintf(out, "        }\n");
+  fprintf(out, "      }\n");
+  fprintf(out, "    },\n");
+  fprintf(out, "    \"rows\": {\n");
+  fprintf(out, "      \"type\": \"array\",\n");
+  fprintf(out, "      \"items\": {\n");
+  fprintf(out, "        \"oneOf\": [\n");
+  fprintf(out, "          {\n");
+  fprintf(out, "            \"type\": \"array\",\n");
+  fprintf(out, "            \"items\": {\n");
+  fprintf(out, "              \"oneOf\": [\n");
+  fprintf(out, "                {\"type\": [\"string\",\"null\"]},\n");
+  fprintf(out, "                {\"type\": \"array\", \"items\": {\"type\": [\"string\",\"null\"]}}\n");
+  fprintf(out, "              ]\n");
+  fprintf(out, "            }\n");
+  fprintf(out, "          },\n");
+  fprintf(out, "          {\n");
+  fprintf(out, "            \"type\": \"object\",\n");
+  fprintf(out, "            \"required\": [\"data\",\"missing_in\"],\n");
+  fprintf(out, "            \"properties\": {\n");
+  fprintf(out, "              \"data\": {\n");
+  fprintf(out, "                \"type\": \"array\",\n");
+  fprintf(out, "                \"items\": {\n");
+  fprintf(out, "                  \"oneOf\": [\n");
+  fprintf(out, "                    {\"type\": [\"string\",\"null\"]},\n");
+  fprintf(out, "                    {\"type\": \"array\", \"items\": {\"type\": [\"string\",\"null\"]}}\n");
+  fprintf(out, "                  ]\n");
+  fprintf(out, "                }\n");
+  fprintf(out, "              },\n");
+  fprintf(out, "              \"missing_in\": {\n");
+  fprintf(out, "                \"type\": \"array\",\n");
+  fprintf(out, "                \"items\": {\"type\": \"integer\", \"minimum\": 0},\n");
+  fprintf(out, "                \"description\": \"indices in ascending order\"\n");
+  fprintf(out, "              }\n");
+  fprintf(out, "            }\n");
+  fprintf(out, "          }\n");
+  fprintf(out, "        ]\n");
+  fprintf(out, "      }\n");
+  fprintf(out, "    }\n");
+  fprintf(out, "  }\n");
+  fprintf(out, "}\n");
 }
 
 static int zsv_compare_print_help_topic(const char *name) {
@@ -198,12 +201,12 @@ static int zsv_compare_print_help_topic(const char *name) {
      silent aliases (undocumented): compare-json-redline, json-redline-json, compare-json-redline-schema
   */
   if (!strcmp(name, "json-redline") || !strcmp(name, "compare-json-redline")) {
-    zsv_compare_print_help_topic_narrative();
+    zsv_compare_print_help_topic_narrative(stdout);
     return 0;
   }
   if (!strcmp(name, "json-redline-schema") || !strcmp(name, "json-redline-json") ||
       !strcmp(name, "compare-json-redline-schema")) {
-    zsv_compare_print_help_topic_json_schema();
+    zsv_compare_print_help_topic_json_schema(stdout);
     return 0;
   }
   fprintf(stderr, "Unknown help topic: %s\n", name);

--- a/app/compare_internal.h
+++ b/app/compare_internal.h
@@ -1,6 +1,7 @@
 #ifndef ZSV_COMPARE_PRIVATE_H
 #define ZSV_COMPARE_PRIVATE_H
 
+#include <stdio.h>
 #include <sglib.h>
 #include <sqlite3.h>
 
@@ -106,6 +107,20 @@ struct zsv_compare_data {
   enum zsv_compare_status (*input_init)(struct zsv_compare_data *data, struct zsv_compare_input *input,
                                         struct zsv_opts *opts, struct zsv_prop_handler *custom_prop_handler);
 
+  /* Output lifecycle hooks. zsv_compare_new() initializes these to the stock
+   * implementations; a host (e.g. a custom CLI) may override them to customize
+   * output, such as buffering the redline JSON and rendering it to a document. */
+  void (*output_begin)(struct zsv_compare_data *data);
+  void (*output_end)(struct zsv_compare_data *data);
+
+  /* Custom option handler for command-line args the stock parser does not
+   * recognize. NULL in stock zsv. A host may set it (e.g. to handle --redline).
+   * Should consume one option starting at argv[*arg_ip], advancing *arg_ip past
+   * any consumed value, set *errp nonzero on error, and return 1 if the option
+   * was recognized (0 otherwise, in which case arg is treated as an input). */
+  int (*parse_opt)(struct zsv_compare_data *data, const char *arg, int *arg_ip, int argc, const char *argv[],
+                   int *errp);
+
   sqlite3 *sort_db; // used when --sort option was specified
 
   struct {
@@ -131,7 +146,11 @@ struct zsv_compare_data {
     unsigned char object : 1;                 // whether to output JSON as objects
     unsigned char include_unchanged_rows : 1; // --include-unchanged-rows
     unsigned char include_tolerated : 1;      // --include-tolerated
-    unsigned char _ : 4;
+    unsigned char redline_render : 1;         // --redline: render the redline JSON to a document
+    unsigned char _ : 3;
+
+    const char *output_path; // -o <file>: destination for the --redline rendered document
+    FILE *tmp;               // temp file holding the redline JSON while --redline renders it
   } writer;
 
   struct zsv_compare_redline *redline; // allocated only for --json-redline mode

--- a/app/compare_redline.h
+++ b/app/compare_redline.h
@@ -1,7 +1,15 @@
 #ifndef ZSV_COMPARE_REDLINE_H
 #define ZSV_COMPARE_REDLINE_H
 
+#include <stdio.h>
 #include <stdlib.h>
+
+/* Print the `--json-redline` schema documentation to `out`: a narrative
+ * reference and a JSON Schema (Draft 2020-12). Defined in compare_help.c. These
+ * are the single source of truth for the redline schema docs, reused both by
+ * `zsv help compare <topic>` */
+void zsv_compare_print_help_topic_narrative(FILE *out);
+void zsv_compare_print_help_topic_json_schema(FILE *out);
 
 struct zsv_compare_redline_cell {
   unsigned char is_diff;      /* 1=diff array emitted, 0=scalar */

--- a/app/count-pull.c
+++ b/app/count-pull.c
@@ -14,12 +14,13 @@
 #include "zsv_command.h"
 
 static int count_usage(void) {
-  static const char *usage = "Usage: count [options]\n"
-                             "\n"
-                             "Options:\n"
-                             "  -h,--help              : show usage\n"
-                             "  -i,--input <filename>  : use specified file input\n";
-  printf("%s\n", usage);
+  printf("Usage: %s " APPNAME " [options]\n"
+         "\n"
+         "Options:\n"
+         "  -h,--help              : show usage\n"
+         "  -i,--input <filename>  : use specified file input\n"
+         "\n",
+         zsv_prog_name());
   return 0;
 }
 

--- a/app/count.c
+++ b/app/count.c
@@ -278,7 +278,7 @@ static void header_handler(void *ctx) {
 
 static int count_usage(void) {
   static const char *usage[] = {
-    "Usage: count [options]",
+    "Usage: " ZSV_USAGE_PROG " " APPNAME " [options]",
     "",
     "Options:",
     "  -h,--help             : show usage",
@@ -290,9 +290,7 @@ static int count_usage(void) {
 #endif
     NULL,
   };
-  for (size_t i = 0; usage[i]; i++) {
-    printf("%s\n", usage[i]);
-  }
+  zsv_print_usage(usage);
   return 0;
 }
 

--- a/app/desc.c
+++ b/app/desc.c
@@ -419,9 +419,9 @@ static void zsv_desc_row(void *ctx) {
 }
 
 const char *zsv_desc_usage_msg[] = {
-  APPNAME ": get column-level information about a table's content",
+  ZSV_USAGE_PROG " " APPNAME ": get column-level information about a table's content",
   "",
-  "Usage: " APPNAME " [options] <filename>",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [options] <filename>",
   "",
   "Options:",
   "  -b,--with-bom            : output with BOM",
@@ -434,8 +434,7 @@ const char *zsv_desc_usage_msg[] = {
 };
 
 static int zsv_desc_usage(void) {
-  for (size_t i = 0; zsv_desc_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_desc_usage_msg[i]);
+  zsv_print_usage(zsv_desc_usage_msg);
   return 0;
 }
 

--- a/app/echo.c
+++ b/app/echo.c
@@ -113,12 +113,12 @@ static void zsv_echo_row_start_at(void *ctx) {
 
 const char *zsv_echo_usage_msg[] = {
 #ifdef ZSV_EXTRAS
-  APPNAME ": write tabular input to stdout with optional cell overwrites",
+  ZSV_USAGE_PROG " " APPNAME ": write tabular input to stdout with optional cell overwrites",
 #else
-  APPNAME ": write tabular input to stdout",
+  ZSV_USAGE_PROG " " APPNAME ": write tabular input to stdout",
 #endif
   "",
-  "Usage: " APPNAME " [options] <filename>",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [options] <filename>",
   "",
   "Options:",
   "  -b                     : output with BOM",
@@ -144,8 +144,7 @@ const char *zsv_echo_usage_msg[] = {
 };
 
 static int zsv_echo_usage(void) {
-  for (size_t i = 0; zsv_echo_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_echo_usage_msg[i]);
+  zsv_print_usage(zsv_echo_usage_msg);
   return 1;
 }
 

--- a/app/ext_example/Makefile
+++ b/app/ext_example/Makefile
@@ -124,7 +124,9 @@ endif
 
 CLI=${BUILD_DIR}/bin/cli${EXE}
 
-RUN_CLI=ZSV_CONFIG_DIR=${TMP_DIR} ${CLI}
+# Pin the program name so help/usage output matches the expected fixtures
+# regardless of the build-dir binary name (basename(argv[0]) would otherwise be "cli").
+RUN_CLI=ZSV_CONFIG_DIR=${TMP_DIR} ZSV_PROG_NAME=zsv ${CLI}
 
 ${BUILD_DIR}/bin/cli:
 	${MAKE} -C .. build-cli CONFIGFILE=${CONFIGFILEPATH} DEBUG=${DEBUG}

--- a/app/flatten.c
+++ b/app/flatten.c
@@ -597,11 +597,11 @@ static void flatten_row2(void *hook) {
 }
 
 const char *flatten_usage_msg[] = {
-  APPNAME ": flatten a table",
+  ZSV_USAGE_PROG " " APPNAME ": flatten a table",
   "          based on a single-column key, assuming that rows to flatten always",
   "          appear in contiguous lines",
   "",
-  "Usage: " APPNAME " [<filename>] [<options>] -- [aggregate_output_spec ...]",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [<filename>] [<options>] -- [aggregate_output_spec ...]",
   "",
   "Each aggregate output specification consists of the column name or index, followed",
   // "either (i) a single-column aggregation or (future: (ii) the \"*\" placeholder (in conjunction with -a)).",
@@ -653,8 +653,7 @@ B,90,B,you,zzz
 */
 
 static void flatten_usage(void) {
-  for (size_t i = 0; flatten_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", flatten_usage_msg[i]);
+  zsv_print_usage(flatten_usage_msg);
 }
 
 void flatten_agg_cols_delete(struct flatten_agg_col **p) {

--- a/app/jq.c
+++ b/app/jq.c
@@ -16,7 +16,7 @@
  */
 int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
   if (argc < 2 || !strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")) {
-    printf("Usage: " APPNAME " <filter> filename [-o,--output filename] [--csv]\n");
+    printf("Usage: %s " APPNAME " <filter> filename [-o,--output filename] [--csv]\n", zsv_prog_name());
     return 0;
   }
 

--- a/app/mv.c
+++ b/app/mv.c
@@ -29,9 +29,9 @@
 #include <zsv/utils/os.h>
 
 const char *zsv_mv_usage_msg[] = {
-  APPNAME ": move a file and its related cache",
+  ZSV_USAGE_PROG " " APPNAME ": move a file and its related cache",
   "",
-  "Usage: " APPNAME " [options] <source> <destination>",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [options] <source> <destination>",
   "",
   "Options:",
   "  -v,--verbose         : verbose output",
@@ -40,8 +40,7 @@ const char *zsv_mv_usage_msg[] = {
 };
 
 static int zsv_mv_usage(FILE *target) {
-  for (size_t j = 0; zsv_mv_usage_msg[j]; j++)
-    fprintf(target, "%s\n", zsv_mv_usage_msg[j]);
+  zsv_fprint_usage(target, zsv_mv_usage_msg);
   return target == stdout ? 0 : 1;
 }
 

--- a/app/noop.c
+++ b/app/noop.c
@@ -9,6 +9,7 @@
 #include <zsv/utils/writer.h>
 #include <zsv/utils/signal.h>
 #include <zsv/utils/arg.h>
+#include <zsv/utils/appname.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -51,7 +52,7 @@ int main(int argc, const char *argv[]) {
 
   for (int i = 1; i < argc; i++) {
     if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h")) {
-      fprintf(stdout, "Usage: noop [filename]\n");
+      fprintf(stdout, "Usage: %s noop [filename]\n", zsv_prog_name());
       fprintf(stdout, "  Reads CSV input and does nothing. For performance testing\n\n");
       return 0;
     } else if (!f) {

--- a/app/overwrite.c
+++ b/app/overwrite.c
@@ -26,10 +26,10 @@
 #include "zsv_command.h"
 
 const char *zsv_overwrite_usage_msg[] = {
-  APPNAME " - Manage overwrites associated with a CSV file",
+  ZSV_USAGE_PROG " " APPNAME " - Manage overwrites associated with a CSV file",
   "",
   "Usage:",
-  "  " APPNAME " <file> <command> [arguments] [options]",
+  "  " ZSV_USAGE_PROG " " APPNAME " <file> <command> [arguments] [options]",
   "",
   "Commands (where <cell> can be <row>-<col> or an Excel-style address):",
   "  list                   : Display all saved overwrite entries",
@@ -75,8 +75,7 @@ const char *zsv_overwrite_usage_msg[] = {
   NULL};
 
 static int zsv_overwrite_usage(void) {
-  for (size_t i = 0; zsv_overwrite_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_overwrite_usage_msg[i]);
+  zsv_print_usage(zsv_overwrite_usage_msg);
   return 1;
 }
 

--- a/app/paste.c
+++ b/app/paste.c
@@ -16,7 +16,7 @@
 
 static int zsv_paste_usage(void) {
   static const char *usage[] = {
-    "Usage: paste <filename> [<filename> ...]",
+    "Usage: " ZSV_USAGE_PROG " " APPNAME " <filename> [<filename> ...]",
     "",
     "Horizontally paste two tables together: given inputs X, Y, ... of N rows",
     "outputs 1...N rows, where each row i contains:",
@@ -28,8 +28,7 @@ static int zsv_paste_usage(void) {
     "  -h,--help : show usage",
     NULL,
   };
-  for (size_t i = 0; usage[i]; i++)
-    printf("%s\n", usage[i]);
+  zsv_print_usage(usage);
   return 0;
 }
 

--- a/app/pretty.c
+++ b/app/pretty.c
@@ -493,9 +493,9 @@ static void zsv_pretty_row(void *ctx) {
 }
 
 const char *zsv_pretty_usage_msg[] = {
-  APPNAME ": print one or more tables of data in fixed-width format",
+  ZSV_USAGE_PROG " " APPNAME ": print one or more tables of data in fixed-width format",
   "",
-  "Usage: " APPNAME " [options] <filename>",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [options] <filename>",
   "",
   "Options:",
   "  -o,--output <filename>     : save output the the specified file",
@@ -511,8 +511,7 @@ const char *zsv_pretty_usage_msg[] = {
 };
 
 static void zsv_pretty_usage(void) {
-  for (size_t i = 0; zsv_pretty_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_pretty_usage_msg[i]);
+  zsv_print_usage(zsv_pretty_usage_msg);
 }
 
 static void zsv_pretty_flush(struct zsv_pretty_data *data) {

--- a/app/prop.c
+++ b/app/prop.c
@@ -30,10 +30,10 @@
 #include <zsv/utils/string.h>
 
 const char *zsv_property_usage_msg[] = {
-  APPNAME ": view or save parsing options associated with a file",
+  ZSV_USAGE_PROG " " APPNAME ": view or save parsing options associated with a file",
   "          saved options will be applied by default when processing that file",
   "",
-  "Usage: " APPNAME " <filepath> [options]",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " <filepath> [options]",
   "       where filepath is the path to the input CSV file, or",
   "       when using --auto, input CSV file or - for stdin",
   "       when using --clean, directory to clean from (use '.' for current directory)",
@@ -71,8 +71,7 @@ const char *zsv_property_usage_msg[] = {
 };
 
 static int zsv_property_usage(FILE *target) {
-  for (size_t j = 0; zsv_property_usage_msg[j]; j++)
-    fprintf(target, "%s\n", zsv_property_usage_msg[j]);
+  zsv_fprint_usage(target, zsv_property_usage_msg);
   return target == stdout ? 0 : 1;
 }
 

--- a/app/rm.c
+++ b/app/rm.c
@@ -25,9 +25,9 @@
  * TO DO: add --orphaned option to remove all orphaned caches
  */
 const char *zsv_rm_usage_msg[] = {
-  APPNAME ": remove a file and its related cache",
+  ZSV_USAGE_PROG " " APPNAME ": remove a file and its related cache",
   "",
-  "Usage: " APPNAME " [options] <filepath>",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [options] <filepath>",
   "",
   "Options:",
   "  -v,--verbose   : verbose output",
@@ -40,8 +40,7 @@ const char *zsv_rm_usage_msg[] = {
 };
 
 static int zsv_rm_usage(FILE *target) {
-  for (size_t j = 0; zsv_rm_usage_msg[j]; j++)
-    fprintf(target, "%s\n", zsv_rm_usage_msg[j]);
+  zsv_fprint_usage(target, zsv_rm_usage_msg);
   return target == stdout ? 0 : 1;
 }
 

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -525,13 +525,13 @@ static void zsv_select_header_row(struct zsv_select_data *data, zsv_parser p) {
 #define ZSV_SELECT_MAX_COLS_DEFAULT_S "1024"
 
 const char *zsv_select_usage_msg[] = {
-  APPNAME ": extracts and outputs specified columns",
+  ZSV_USAGE_PROG " " APPNAME ": extracts and outputs specified columns",
   "",
-  "Usage: " APPNAME " [filename] [options] [-- col_specifier [... col_specifier]]",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [filename] [options] [-- col_specifier [... col_specifier]]",
   "       where col_specifier is a column name or, if the -n option is used,",
   "       a column index (starting at 1) or index range in the form of n-m",
-  "       e.g. " APPNAME " -n file.csv -- 1 4-6 50 10",
-  "            " APPNAME " file.csv -- first_col fiftieth_column \"Tenth Column\"",
+  "       e.g. " ZSV_USAGE_PROG " " APPNAME " -n file.csv -- 1 4-6 50 10",
+  "            " ZSV_USAGE_PROG " " APPNAME " file.csv -- first_col fiftieth_column \"Tenth Column\"",
   "",
   "Note: Outputs the columns specified after '--' separator, or all columns if omitted.",
   "",
@@ -582,8 +582,7 @@ const char *zsv_select_usage_msg[] = {
 };
 
 static void zsv_select_usage(void) {
-  for (size_t i = 0; zsv_select_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_select_usage_msg[i]);
+  zsv_print_usage(zsv_select_usage_msg);
 }
 
 static void zsv_select_cleanup(struct zsv_select_data *data) {

--- a/app/select/usage.c
+++ b/app/select/usage.c
@@ -1,11 +1,11 @@
 const char *zsv_select_usage_msg[] = {
-  APPNAME ": extracts and outputs specified columns",
+  ZSV_USAGE_PROG " " APPNAME ": extracts and outputs specified columns",
   "",
-  "Usage: " APPNAME " [filename] [options] [-- col_specifier [... col_specifier]]",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [filename] [options] [-- col_specifier [... col_specifier]]",
   "       where col_specifier is a column name or, if the -n option is used,",
   "       a column index (starting at 1) or index range in the form of n-m",
-  "       e.g. " APPNAME " -n file.csv -- 1 4-6 50 10",
-  "            " APPNAME " file.csv -- first_col fiftieth_column \"Tenth Column\"",
+  "       e.g. " ZSV_USAGE_PROG " " APPNAME " -n file.csv -- 1 4-6 50 10",
+  "            " ZSV_USAGE_PROG " " APPNAME " file.csv -- first_col fiftieth_column \"Tenth Column\"",
   "",
   "Note: Outputs the columns specified after '--' separator, or all columns if omitted.",
   "",
@@ -67,6 +67,5 @@ const char *zsv_select_usage_msg[] = {
 };
 
 static void zsv_select_usage(void) {
-  for (size_t i = 0; zsv_select_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_select_usage_msg[i]);
+  zsv_print_usage(zsv_select_usage_msg);
 }

--- a/app/serialize.c
+++ b/app/serialize.c
@@ -208,9 +208,9 @@ static void serialize_row(void *hook) {
 }
 
 const char *serialize_usage_msg[] = {
-  APPNAME ": serialize a CSV file into row/column/value triplets",
+  ZSV_USAGE_PROG " " APPNAME ": serialize a CSV file into row/column/value triplets",
   "",
-  "Usage: " APPNAME " [<filename>]",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [<filename>]",
   "",
   "Options:",
   "  -b                     : output with BOM",
@@ -227,8 +227,7 @@ const char *serialize_usage_msg[] = {
 };
 
 static int serialize_usage(void) {
-  for (size_t i = 0; serialize_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", serialize_usage_msg[i]);
+  zsv_print_usage(serialize_usage_msg);
   return 1;
 }
 

--- a/app/sql.c
+++ b/app/sql.c
@@ -33,17 +33,18 @@ struct string_list {
 #endif
 
 const char *zsv_sql_usage_msg[] = {
-  APPNAME ": run ad hoc sql on a CSV file",
+  ZSV_USAGE_PROG " " APPNAME ": run ad hoc sql on a CSV file",
   "          or join multiple CSV files on one or more common column(s)",
   "",
 #ifdef NO_STDIN
-  "Usage: " APPNAME " <filename> [filename ...] <sql | @file.sql>",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " <filename> [filename ...] <sql | @file.sql>",
 #else
-  "Usage: " APPNAME " [filename, or - for stdin] [filename ...] <sql | @file.sql | --join-indexes <N,...>>",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME
+  " [filename, or - for stdin] [filename ...] <sql | @file.sql | --join-indexes <N,...>>",
 #endif
-  "  e.g. " APPNAME " file.csv \"select * from data\"",
-  "  e.g. " APPNAME " file1.csv file2.csv \"select * from data inner join data2\"",
-  "  e.g. " APPNAME " file1.csv file2.csv --join-indexes 1,2",
+  "  e.g. " ZSV_USAGE_PROG " " APPNAME " file.csv \"select * from data\"",
+  "  e.g. " ZSV_USAGE_PROG " " APPNAME " file1.csv file2.csv \"select * from data inner join data2\"",
+  "  e.g. " ZSV_USAGE_PROG " " APPNAME " file1.csv file2.csv --join-indexes 1,2",
   "",
   "Loads your CSV file into a table named 'data', then runs your sql, which must start with 'select '.",
   "If multiple files are specified, tables will be named data, data2, data3, ...",
@@ -64,8 +65,7 @@ const char *zsv_sql_usage_msg[] = {
 };
 
 static int zsv_sql_usage(FILE *f) {
-  for (size_t i = 0; zsv_sql_usage_msg[i]; i++)
-    fprintf(f, "%s\n", zsv_sql_usage_msg[i]);
+  zsv_fprint_usage(f, zsv_sql_usage_msg);
   return f == stderr ? 1 : 0;
 }
 

--- a/app/stack.c
+++ b/app/stack.c
@@ -18,9 +18,9 @@
 #include <zsv/utils/string.h>
 
 const char *zsv_stack_usage_msg[] = {
-  APPNAME ": stack one or more csv files vertically, aligning columns with the same name",
+  ZSV_USAGE_PROG " " APPNAME ": stack one or more csv files vertically, aligning columns with the same name",
   "",
-  "Usage: " APPNAME " [options] filename [filename...]",
+  "Usage: " ZSV_USAGE_PROG " " APPNAME " [options] filename [filename...]",
   "",
   "Options:",
   "  -o <filename>      : output file",
@@ -33,8 +33,7 @@ const char *zsv_stack_usage_msg[] = {
 };
 
 static int zsv_stack_usage(void) {
-  for (size_t i = 0; zsv_stack_usage_msg[i]; i++)
-    fprintf(stdout, "%s\n", zsv_stack_usage_msg[i]);
+  zsv_print_usage(zsv_stack_usage_msg);
   return 0;
 }
 

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -427,9 +427,11 @@ test-cli: ${CLI}
 	@${TEST_INIT}
 	@[ "${CLI}" = "" ] && echo 1>&2 'test-cli: missing CLI env var' && exit 1 || exit 0
 	@${PREFIX} $< help select 2>&1 > ${TMP_DIR}/$@.out
-	@[ "`head -1 ${TMP_DIR}/$@.out | tr -d '\r\n'`" = "select: extracts and outputs specified columns" ] && [ $$(( `cat ${TMP_DIR}/$@.out | wc -l` )) = "${HELP_SELECT_LINES}" ] && ${TEST_PASS} || ${TEST_FAIL}
+# help/usage now prefixes the command with the host program name (e.g. `zsv select`,
+# or whatever argv[0]/$$ZSV_PROG_NAME resolves to), so match the text as a suffix.
+	@head -1 ${TMP_DIR}/$@.out | tr -d '\r\n' | grep -qE 'select: extracts and outputs specified columns$$' && [ $$(( `cat ${TMP_DIR}/$@.out | wc -l` )) = "${HELP_SELECT_LINES}" ] && ${TEST_PASS} || ${TEST_FAIL}
 	@${PREFIX} $< help count 2>&1 > ${TMP_DIR}/$@.out
-	@[ "`head -1 ${TMP_DIR}/$@.out | tr -d '\r\n'`" = "Usage: count [options]" ] && [ $$(( `cat ${TMP_DIR}/$@.out | wc -l` )) = "${HELP_COUNT_LINES}" ] && ${TEST_PASS} || ${TEST_FAIL}
+	@head -1 ${TMP_DIR}/$@.out | tr -d '\r\n' | grep -qE 'Usage: .*count \[options\]$$' && [ $$(( `cat ${TMP_DIR}/$@.out | wc -l` )) = "${HELP_COUNT_LINES}" ] && ${TEST_PASS} || ${TEST_FAIL}
 
 test-1-count test-1-count-pull: test-1-% : ${BUILD_DIR}/bin/zsv_%${EXE} worldcitiespop_mil.csv
 	@${TEST_INIT}

--- a/app/utils/appname.c
+++ b/app/utils/appname.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Liquidaty and the zsv/lib contributors
+ * All rights reserved
+ *
+ * This file is part of zsv/lib, distributed under the license defined at
+ * https://opensource.org/licenses/MIT
+ */
+
+#include <stdio.h>
+#include <zsv/utils/appname.h>
+#include <zsv/utils/file.h> /* zsv_dir_len_basename */
+
+static char prog_name[128] = ZSV_DEFAULT_PROG_NAME;
+
+void zsv_set_prog_name(const char *host) {
+  if (host && *host) {
+    const char *base = host;
+    zsv_dir_len_basename(host, &base); /* portable: splits on '/' and '\\' */
+    snprintf(prog_name, sizeof(prog_name), "%s", base);
+  }
+}
+
+const char *zsv_prog_name(void) {
+  return prog_name;
+}
+
+void zsv_fprint_usage(FILE *f, const char *const *lines) {
+  for (; *lines; lines++) {
+    for (const char *p = *lines; *p; p++) {
+      if (*p == ZSV_USAGE_PROG[0])
+        fputs(prog_name, f);
+      else
+        putc(*p, f);
+    }
+    putc('\n', f);
+  }
+}
+
+void zsv_print_usage(const char *const *lines) {
+  zsv_fprint_usage(stdout, lines);
+}

--- a/app/zsv_command.h
+++ b/app/zsv_command.h
@@ -14,6 +14,7 @@
 #include <zsv/utils/compiler.h>
 #include <zsv/utils/signal.h>
 #include <zsv/utils/memmem.h>
+#include <zsv/utils/appname.h>
 
 #include "zsv_main.h"
 

--- a/include/zsv/utils/appname.h
+++ b/include/zsv/utils/appname.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 Liquidaty and the zsv/lib contributors
+ * All rights reserved
+ *
+ * This file is part of zsv/lib, distributed under the license defined at
+ * https://opensource.org/licenses/MIT
+ */
+
+#ifndef ZSV_UTILS_APPNAME_H
+#define ZSV_UTILS_APPNAME_H
+
+#include <stdio.h> /* FILE */
+
+/*
+ * The zsv commands can be bundled into the `zsv` CLI, built standalone, or
+ * embedded into a third-party app. Their help/usage text must therefore refer
+ * to the host program by its *runtime* name (e.g. "zsv" or "xxx"), not a name
+ * fixed at compile time.
+ *
+ * Usage strings embed the ZSV_USAGE_PROG placeholder wherever the host program
+ * name belongs; zsv_print_usage() substitutes the runtime name when printing.
+ * The subcommand portion ("compare", "count", ...) is supplied separately via
+ * the APPNAME macro (see zsv_command.h), so a single token suffices here.
+ */
+
+/* Compile-time fallback; an embedder may override with
+ *   -DZSV_DEFAULT_PROG_NAME='"xxx"' */
+#ifndef ZSV_DEFAULT_PROG_NAME
+#define ZSV_DEFAULT_PROG_NAME "zsv"
+#endif
+
+/* Placeholder for the host program name within usage[] string literals.
+ * Uses a control character that never appears in legitimate help text. */
+#define ZSV_USAGE_PROG "\x01"
+
+/* Set the host program name once at startup, from argv[0] (the basename is
+ * extracted) or an explicit override. host may be NULL or empty, in which case
+ * the current value (default ZSV_DEFAULT_PROG_NAME) is retained. */
+void zsv_set_prog_name(const char *host);
+
+/* The host program name, e.g. "zsv" or "xxx". Never NULL. */
+const char *zsv_prog_name(void);
+
+/* Print a NULL-terminated array of usage lines to the given stream, substituting
+ * ZSV_USAGE_PROG with zsv_prog_name() and appending a newline to each line. */
+void zsv_fprint_usage(FILE *f, const char *const *lines);
+
+/* Convenience wrapper for zsv_fprint_usage(stdout, lines). */
+void zsv_print_usage(const char *const *lines);
+
+#endif


### PR DESCRIPTION
…stomization

Help/usage text referred to commands as "zsv <command>" via hardcoded literals and the compile-time APPNAME, so a host that bundles these commands under a different name (XXX) printed the wrong program name.

Introduce a runtime program-name facility (utils/appname): a ZSV_USAGE_PROG token embedded in usage[] arrays, substituted by zsv_print_usage / zsv_fprint_usage with the host name. The name is resolved from $ZSV_PROG_NAME, else basename(argv[0]) (set once in the CLI dispatcher and the standalone main), so renaming the multi-call binary to "xxx" makes all help read "xxx <command>" with no other changes. Defaults to "zsv" (overridable via -DZSV_DEFAULT_PROG_NAME).

Sweep every command's usage/help (incl. the top-level `zsv help` and `version`) to use the token + helper.

compare: replace the LQ_HAVE_JSON2REDLINE #ifdefs with generic seams so a host can inject --redline rendering without editing this file: output_begin/ output_end/parse_opt function pointers on the handle, a ZSV_COMPARE_CUSTOMIZE hook, ZSV_COMPARE_USAGE_* text macros, and FILE*-based help-topic printers shared as the single source of truth for the redline schema docs.