### PR TITLE
Fix i686 cross-compile build (configure + sheet + jq)

### DIFF
--- a/app/sheet/lexer.c
+++ b/app/sheet/lexer.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdbool.h>
 
 #if 0
 #define lexer_debug(FMT, ...) fprintf(stderr, "%s:%d: " FMT "\n", __func__, __LINE__, __VA_ARGS__)

--- a/configure
+++ b/configure
@@ -658,6 +658,40 @@ EOF
         fi
     fi
 
+    # 'sheet' renders multibyte (UTF-8) cells via the wide-character curses API
+    # (addnwstr/mvaddnwstr). A narrow curses library declares no such symbols, so
+    # a selected library is necessary but not sufficient: verify the chosen
+    # library actually links a wide-char call before enabling the feature.
+    # PDCurses is built/linked with PDC_WIDE (see app/sheet/curses.h), so it is
+    # treated as wide-capable without a probe; for the builtin PDCurses path the
+    # library does not exist yet (the Makefile bootstraps it), so a probe would
+    # spuriously fail. The ncurses/ncursesw probe compiles AND links (never runs
+    # the binary), so it is valid when cross-compiling.
+    HAVE_WIDE_CURSES=0
+    case "$NCLIB" in
+        pdcurses)
+            HAVE_WIDE_CURSES=1
+            ;;
+        ncursesw|ncurses)
+            printf "checking whether %s provides wide-character curses (addnwstr)... " "$NCLIB"
+            rm -f "$tmpc"
+            cat > "$tmpc" <<EOF
+#define _GNU_SOURCE
+#define _XOPEN_SOURCE_EXTENDED
+#include <wchar.h>
+#include "sheet/curses.h"
+int main(void) { wchar_t w[1] = {0}; addnwstr(w, 0); return 0; }
+EOF
+            # shellcheck disable=SC2086
+            if $CC $CPPFLAGS $CFLAGS_NCURSES -Iapp "$tmpc" $LDFLAGS $LDFLAGS_NCURSES -o "$tmpo" >/dev/null 2>&1 ; then
+                HAVE_WIDE_CURSES=1
+                printf "yes\n"
+            else
+                printf "no\n"
+            fi
+            ;;
+    esac
+
     ZSVSHEET_BUILD=1
     # A selected library (NCLIB) is what makes sheet buildable. For the builtin
     # PDCurses path LDFLAGS_NCURSES is intentionally empty (filled in by the
@@ -667,6 +701,13 @@ EOF
         echo "WARNING: could not find a curses library; cannot build 'sheet' feature"
         if [ "$TRY_SHEET" = "yes" ] ; then
             echo "Error: --enable-sheet requested but no curses library is available"
+            exit 1
+        fi
+    elif [ "$HAVE_WIDE_CURSES" != "1" ] ; then
+        ZSVSHEET_BUILD=0
+        echo "WARNING: curses library '$NCLIB' lacks wide-character support (addnwstr); cannot build 'sheet' feature. Install a wide-character curses (e.g. ncursesw) to enable it."
+        if [ "$TRY_SHEET" = "yes" ] ; then
+            echo "Error: --enable-sheet requested but the available curses library lacks wide-character support (addnwstr)"
             exit 1
         fi
     fi
@@ -842,7 +883,12 @@ if [ "$usetermcap" = "yes" ] || [ "$usetermcap" = "auto" ] ; then
             fi
 fi
 
-if [ "$JQ_PREFIX" = "" ] && [ "$PREFIX" != "" ] && [ -f "$PREFIX/include/jq.h" ] ; then
+# Auto-adopt the install PREFIX's jq only for a native build. When
+# cross-compiling we cannot validate the host prefix's libjq (and the -ljq probe
+# below is itself gated on CROSS_COMPILING=no, so the library would never get
+# onto the link line). Leaving JQ_PREFIX empty routes the cross build to the
+# vendored libjq, which app/Makefile cross-compiles via --host=$CONFIGURE_HOST.
+if [ "$JQ_PREFIX" = "" ] && [ "$PREFIX" != "" ] && [ -f "$PREFIX/include/jq.h" ] && [ "$CROSS_COMPILING" = "no" ] ; then
     JQ_PREFIX="$PREFIX"
 fi
 

--- a/i686_env
+++ b/i686_env
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+## Run this file to switch to i686 build env
+## Typical use would be to run this together with configure e.g.:
+##   ./i686_env configure
+##
+export THIS_CROSS_COMPILE_ENV="`dirname "$0"`/`basename "$0"`"
+
+## Build libressl out-of-tree, into a per-arch build-<triple> dir, so the
+## shared ~/install source tree's native (arm64) objects can't contaminate the
+## i686 link (the in-tree path links stale arch objects and fails on ocspcheck).
+export OUT_OF_TREE_BUILD=1
+
+export PREFIX=/opt/i686
+if ! [ -d $PREFIX ]; then ${SUDO} mkdir -p $PREFIX && ${SUDO} chown `whoami` $PREFIX ; fi
+
+if [ "$LDFLAGS" = "" ] ; then
+    export LDFLAGS=-L$PREFIX/lib
+fi
+if [ "$CPPFLAGS" = "" ]; then
+    export CPPFLAGS=-I$PREFIX/include
+fi
+
+export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig"
+export BIN_PREFIX=i686-nptl-linux-gnu
+export CONFIGURE_HOST=i686-nptl-linux-gnu
+export CONFIGURE_TARGET=i686-nptl-linux-gnu
+export CONFIGURE_BUILD=
+export CONFIGURE_ARCH=none
+
+## We build i686 binaries on a non-i686 host, so this is a cross-compile.
+## configure keys its behavior off CROSS_COMPILING (not the CONFIGURE_* vars):
+## with it set, ARCH defaults to "none" (so -march=native is not attempted,
+## which the cross gcc rejects) and the avx2/avx/sse2/NEON probes are skipped
+## (those compile-and-RUN a test binary, which can't execute on the host).
+export CROSS_COMPILING=yes
+export CC=$BIN_PREFIX-gcc
+export CXX=$BIN_PREFIX-g++
+export CPP=$BIN_PREFIX-cpp
+export RANLIB=$BIN_PREFIX-ranlib
+export PATH="$PREFIX/bin:$PATH"
+export AR=$BIN_PREFIX-ar
+export NM=$BIN_PREFIX-nm
+export LIBTOOL=$PREFIX/bin/libtool
+export C_INCLUDE_PATH=$PREFIX/include
+export WINDRES=$BIN_PREFIX-windres
+
+export CPLUS_INCLUDE_PATH=$C_INCLUDE_PATH
+
+export LIBRARY_PATH=$PREFIX/lib64:$PREFIX/lib:$LIBRARY_PATH
+
+export OTHER_LD_FLAGS=
+
+export CONFIGFILE=config.i686
+
+export SSL_DIR=$PREFIX/libressl
+
+if [ $# != 0 ]; then
+    exec "$@"
+fi
+


### PR DESCRIPTION
Update for i686 build (CROSS_COMPILING must be set to yes):

- configure: detect whether the selected curses library actually provides the wide-character API (addnwstr) via a link-only probe (cross-safe). 'sheet' is enabled only when wide-char curses is present, and skipped with a clear warning otherwise, instead of emitting a config that fails to compile.

- configure: do not auto-adopt the install PREFIX's jq when cross-compiling (the -ljq probe is already gated on CROSS_COMPILING=no, so the lib would never reach the link line). This routes the cross build to the vendored libjq, which app/Makefile cross-compiles via --host=$CONFIGURE_HOST.

- app/sheet/lexer.c: add #include <stdbool.h> for its use of 'true' under -std=gnu11 (surfaced once 'sheet' actually compiled).