### PR TITLE
compare: include unchanged rows by default; add --only-changed-rows

### DIFF
--- a/app/compare.c
+++ b/app/compare.c
@@ -512,6 +512,8 @@ zsv_compare_handle zsv_compare_new(void) {
 
   z->output_begin = zsv_compare_output_begin;
   z->output_end = zsv_compare_output_end;
+  /* Unchanged rows are included by default; --only-changed-rows clears this */
+  z->writer.include_unchanged_rows = 1;
   /* z->parse_opt left NULL: stock zsv has no custom options */
   return z;
 }
@@ -720,7 +722,8 @@ static int compare_usage(void) {
     NULL,
   };
   static const char *usage2[] = {
-    "  --include-unchanged-rows: (with --json-redline) emit matched rows",
+    "  --only-changed-rows: (with --json-redline) emit only rows that have a diff",
+    "                       (by default, unchanged/matched rows are also emitted)",
     "  --include-tolerated: (with --json-redline) emit tolerated diffs as arrays",
     "  --columns <spec>   : compare column ranges within a single file",
     "                       spec uses 'v' or 'vs' to separate ranges, '-' or ':'",
@@ -875,8 +878,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       const char *next_arg = zsv_next_arg(++arg_i, argc, argv, &err);
       if (next_arg)
         data->writer.output_path = next_arg;
-    } else if (!strcmp(arg, "--include-unchanged-rows")) {
-      data->writer.include_unchanged_rows = 1;
+    } else if (!strcmp(arg, "--only-changed-rows")) {
+      data->writer.include_unchanged_rows = 0;
     } else if (!strcmp(arg, "--include-tolerated")) {
       data->writer.include_tolerated = 1;
     } else if (!strcmp(arg, "--print-key-colname")) {

--- a/app/compare_internal.h
+++ b/app/compare_internal.h
@@ -144,7 +144,7 @@ struct zsv_compare_data {
     unsigned cell_ix;                         // only used for json + object output
     unsigned char compact : 1;                // whether to output compact JSON
     unsigned char object : 1;                 // whether to output JSON as objects
-    unsigned char include_unchanged_rows : 1; // --include-unchanged-rows
+    unsigned char include_unchanged_rows : 1; // default on; cleared by --only-changed-rows
     unsigned char include_tolerated : 1;      // --include-tolerated
     unsigned char redline_render : 1;         // --redline: render the redline JSON to a document
     unsigned char _ : 3;

--- a/app/test/expected/test-compare-redline.out1
+++ b/app/test/expected/test-compare-redline.out1
@@ -19,7 +19,7 @@
   "options": {
     "tolerance": null,
     "sort": false,
-    "include_unchanged_rows": false,
+    "include_unchanged_rows": true,
     "include_tolerated": false,
     "require_all_inputs": false
   },
@@ -102,5 +102,15 @@
     }
   },
   "rows": [
+    [
+      "1",
+      "Alice",
+      "100"
+    ],
+    [
+      "2",
+      "Bob",
+      "200"
+    ]
   ]
 }

--- a/app/test/expected/test-compare-redline.out10
+++ b/app/test/expected/test-compare-redline.out10
@@ -1,17 +1,16 @@
 {
   "schema": "zsv.compare",
   "version": "1",
-  "generated_at": "2023-11-14T22:13:20Z",
   "inputs": [
     {
-      "label": "jredline1a.csv",
-      "path": "compare/jredline1a.csv",
-      "row_count": 2
+      "label": "jredline5a.csv",
+      "path": "compare/jredline5a.csv",
+      "row_count": 3
     },
     {
-      "label": "jredline1b.csv",
-      "path": "compare/jredline1b.csv",
-      "row_count": 2
+      "label": "jredline5b.csv",
+      "path": "compare/jredline5b.csv",
+      "row_count": 3
     }
   ],
   "keys": [
@@ -20,7 +19,7 @@
   "options": {
     "tolerance": null,
     "sort": false,
-    "include_unchanged_rows": true,
+    "include_unchanged_rows": false,
     "include_tolerated": false,
     "require_all_inputs": false
   },
@@ -40,59 +39,43 @@
         0,
         1
       ]
-    },
-    {
-      "name": "val",
-      "is_key": false,
-      "in_inputs": [
-        0,
-        1
-      ]
     }
   ],
   "summary": {
     "rows": {
-      "in_all_inputs": 2,
+      "in_all_inputs": 3,
       "only_in_input_count": [
         0,
         0
       ],
-      "with_any_diff": 0
+      "with_any_diff": 1
     },
     "cells": {
       "compared": 6,
-      "matched": 6,
+      "matched": 5,
       "within_tolerance": 0,
-      "differing": 0
+      "differing": 1
     },
     "by_column": [
       {
         "name": "id",
-        "compared": 2,
-        "matched": 2,
+        "compared": 3,
+        "matched": 3,
         "within_tolerance": 0,
         "differing": 0
       },
       {
         "name": "name",
-        "compared": 2,
+        "compared": 3,
         "matched": 2,
         "within_tolerance": 0,
-        "differing": 0
-      },
-      {
-        "name": "val",
-        "compared": 2,
-        "matched": 2,
-        "within_tolerance": 0,
-        "differing": 0
+        "differing": 1
       }
     ],
     "schema": {
       "common": [
         "id",
-        "name",
-        "val"
+        "name"
       ],
       "only_in_input": [
         [
@@ -104,14 +87,11 @@
   },
   "rows": [
     [
-      "1",
-      "Alice",
-      "100"
-    ],
-    [
       "2",
-      "Bob",
-      "200"
+      [
+        "Bob",
+        "Robert"
+      ]
     ]
   ]
 }

--- a/app/test/expected/test-compare-redline.out2
+++ b/app/test/expected/test-compare-redline.out2
@@ -19,7 +19,7 @@
   "options": {
     "tolerance": 1,
     "sort": false,
-    "include_unchanged_rows": false,
+    "include_unchanged_rows": true,
     "include_tolerated": false,
     "require_all_inputs": false
   },
@@ -103,12 +103,22 @@
   },
   "rows": [
     [
+      "1",
+      "Alice",
+      "100.5"
+    ],
+    [
       "2",
       "Bob",
       [
         "200.0",
         "201.5"
       ]
+    ],
+    [
+      "3",
+      "Carol",
+      "300.0"
     ]
   ]
 }

--- a/app/test/expected/test-compare-redline.out3
+++ b/app/test/expected/test-compare-redline.out3
@@ -19,7 +19,7 @@
   "options": {
     "tolerance": null,
     "sort": false,
-    "include_unchanged_rows": false,
+    "include_unchanged_rows": true,
     "include_tolerated": false,
     "require_all_inputs": false
   },
@@ -101,5 +101,15 @@
     }
   },
   "rows": [
+    [
+      "1",
+      "Alice",
+      "X"
+    ],
+    [
+      "2",
+      "Bob",
+      "Y"
+    ]
   ]
 }

--- a/app/test/expected/test-compare-redline.out4
+++ b/app/test/expected/test-compare-redline.out4
@@ -19,7 +19,7 @@
   "options": {
     "tolerance": null,
     "sort": false,
-    "include_unchanged_rows": false,
+    "include_unchanged_rows": true,
     "include_tolerated": false,
     "require_all_inputs": false
   },
@@ -86,6 +86,10 @@
     }
   },
   "rows": [
+    [
+      "1",
+      "A"
+    ],
     {
       "data": [
         "2",
@@ -103,6 +107,10 @@
       "missing_in": [
         0
       ]
-    }
+    },
+    [
+      "4",
+      "D"
+    ]
   ]
 }

--- a/app/test/expected/test-compare-redline.out6
+++ b/app/test/expected/test-compare-redline.out6
@@ -19,7 +19,7 @@
   "options": {
     "tolerance": 1,
     "sort": false,
-    "include_unchanged_rows": false,
+    "include_unchanged_rows": true,
     "include_tolerated": true,
     "require_all_inputs": false
   },
@@ -117,6 +117,11 @@
         "200.0",
         "201.5"
       ]
+    ],
+    [
+      "3",
+      "Carol",
+      "300.0"
     ]
   ]
 }

--- a/app/test/expected/test-compare-redline.out7
+++ b/app/test/expected/test-compare-redline.out7
@@ -24,7 +24,7 @@
   "options": {
     "tolerance": null,
     "sort": false,
-    "include_unchanged_rows": false,
+    "include_unchanged_rows": true,
     "include_tolerated": false,
     "require_all_inputs": false
   },
@@ -96,6 +96,10 @@
     }
   },
   "rows": [
+    [
+      "1",
+      "A"
+    ],
     [
       "2",
       [

--- a/app/test/expected/test-compare-redline.out8
+++ b/app/test/expected/test-compare-redline.out8
@@ -24,7 +24,7 @@
   "options": {
     "tolerance": null,
     "sort": false,
-    "include_unchanged_rows": false,
+    "include_unchanged_rows": true,
     "include_tolerated": false,
     "require_all_inputs": false
   },
@@ -134,6 +134,10 @@
       "missing_in": [
         0
       ]
-    }
+    },
+    [
+      "5",
+      "E"
+    ]
   ]
 }

--- a/app/test/expected/test-compare-redline.out9
+++ b/app/test/expected/test-compare-redline.out9
@@ -19,7 +19,7 @@
   "options": {
     "tolerance": null,
     "sort": false,
-    "include_unchanged_rows": false,
+    "include_unchanged_rows": true,
     "include_tolerated": false,
     "require_all_inputs": true
   },
@@ -87,11 +87,19 @@
   },
   "rows": [
     [
+      "1",
+      "A"
+    ],
+    [
       "2",
       [
         "B",
         "X"
       ]
+    ],
+    [
+      "5",
+      "E"
     ]
   ]
 }

--- a/app/test/test-compare-redline.mk
+++ b/app/test/test-compare-redline.mk
@@ -6,16 +6,17 @@
 # Help-topic and --json-redline outputs are deterministic, so they are checked byte-for-byte
 # against goldens in expected/ (no jq/ajv: those tools are absent on the CI runners).
 
-# TC1: two identical inputs → empty rows[]
+# TC1: two identical inputs → all rows emitted (unchanged rows are included by default)
 # TC2: mix diff/tolerated (--tolerance 1.0)
 # TC3: schema mismatch (extra column in input 0)
 # TC4: missing rows on each side → object form
-# TC5: --include-unchanged-rows
+# TC5: unchanged rows are emitted by default (no flag needed)
 # TC6: --include-tolerated
 # TC7: three inputs → length-3 diff arrays
 # TC8: SOURCE_DATE_EPOCH yields a deterministic generated_at
 # TC9: --exit-code returns the number of differing cells in redline mode
 # TC10: --require-all-inputs drops rows missing from any input; options.require_all_inputs is recorded
+# TC11: --only-changed-rows suppresses unchanged rows (inverse of the new default)
 test-compare-redline: ${BUILD_DIR}/bin/zsv_compare${EXE}
 	@${TEST_INIT}
 	@(${PREFIX} $< --json-redline -k id compare/jredline1a.csv compare/jredline1b.csv ${REDIRECT1} ${TMP_DIR}/$@.out1raw && \
@@ -34,7 +35,7 @@ test-compare-redline: ${BUILD_DIR}/bin/zsv_compare${EXE}
 	sed '/"generated_at"/d' ${TMP_DIR}/$@.out4raw > ${TMP_DIR}/$@.out4 && \
 	${CMP} ${TMP_DIR}/$@.out4 expected/$@.out4 && ${TEST_PASS} || ${TEST_FAIL})
 
-	@(${PREFIX} $< --json-redline -k id --include-unchanged-rows compare/jredline5a.csv compare/jredline5b.csv ${REDIRECT1} ${TMP_DIR}/$@.out5raw && \
+	@(${PREFIX} $< --json-redline -k id compare/jredline5a.csv compare/jredline5b.csv ${REDIRECT1} ${TMP_DIR}/$@.out5raw && \
 	sed '/"generated_at"/d' ${TMP_DIR}/$@.out5raw > ${TMP_DIR}/$@.out5 && \
 	${CMP} ${TMP_DIR}/$@.out5 expected/$@.out5 && ${TEST_PASS} || ${TEST_FAIL})
 
@@ -59,6 +60,12 @@ test-compare-redline: ${BUILD_DIR}/bin/zsv_compare${EXE}
 	@(${PREFIX} $< --json-redline -k id --require-all-inputs compare/reqall_a.csv compare/reqall_b.csv ${REDIRECT1} ${TMP_DIR}/$@.out9raw && \
 	sed '/"generated_at"/d' ${TMP_DIR}/$@.out9raw > ${TMP_DIR}/$@.out9 && \
 	${CMP} ${TMP_DIR}/$@.out9 expected/$@.out9 && ${TEST_PASS} || ${TEST_FAIL})
+
+	@# TC11: --only-changed-rows suppresses unchanged rows (the inverse of the new default);
+	@# options.include_unchanged_rows is recorded as false and rows[] holds only the diffed row
+	@(${PREFIX} $< --json-redline -k id --only-changed-rows compare/jredline5a.csv compare/jredline5b.csv ${REDIRECT1} ${TMP_DIR}/$@.out10raw && \
+	sed '/"generated_at"/d' ${TMP_DIR}/$@.out10raw > ${TMP_DIR}/$@.out10 && \
+	${CMP} ${TMP_DIR}/$@.out10 expected/$@.out10 && ${TEST_PASS} || ${TEST_FAIL})
 
 # TC-A: missing_in indices are strictly ascending in 3-input case
 # TC-B: -a/--add combined with --json-redline errors with non-zero exit, exact stderr, empty stdout


### PR DESCRIPTION
Make the former --include-unchanged-rows behavior the default for `compare --json-redline`, remove that option, and add --only-changed-rows to opt into the inverse (emit only rows that have a diff).

The internal/output field include_unchanged_rows is retained (now defaults to true) so the published --json-redline JSON Schema is unchanged; it still truthfully reports whether unchanged rows are present in rows[].

Tests: TC5 now exercises the default (flag dropped); new TC11 covers --only-changed-rows; default-mode redline goldens regenerated to include the now-emitted unchanged rows.