### PR TITLE
sql: auto-disambiguate duplicate input columns by default (F7)

### DIFF
--- a/app/external/sqlite3/sqlite3_csv_vtab-zsv.c
+++ b/app/external/sqlite3/sqlite3_csv_vtab-zsv.c
@@ -174,90 +174,117 @@ static long zsv_csv_colname_find(char *const *seen, size_t n, const char *name) 
 
 /* Append the `"col" TEXT, ...` specifications for each header cell to pStr.
 ** When `dedupe` is nonzero, duplicate column names are made unique by appending
-** _2, _3, ... (e.g. a,b,a -> a,b,a_2) so input with repeated headers is loadable;
-** if `warn` is also nonzero, each rename is noted on stderr (renames are never
-** silent). Callers that drive a curses UI (sheet) pass warn=0 to keep stderr clean.
+** _2, _3, ... so input with repeated headers is loadable: the first occurrence of
+** a name keeps it and later occurrences are renamed. A synthesized name is probed
+** against every user-supplied name and every name already assigned, so it never
+** displaces an explicit column (a,a,a_2 -> a,a_3,a_2). If `warn` is nonzero, one
+** summary line naming up to 5 renames is printed to stderr (never silent, but
+** collapsed to a single line); callers driving a curses UI (sheet) pass warn=0.
 ** When `dedupe` is zero, the first duplicate name is reported via *dup_errmsg
 ** (allocated with asprintf, naming the column and its 1-based positions) so the
 ** caller can fail with an actionable message instead of SQLite's generic one.
 ** Returns 0 on success, 1 if a duplicate was reported, -1 on out-of-memory. */
 static int zsv_csv_append_column_defs(sqlite3_str *pStr, zsv_parser parser, int dedupe, int warn, char **dup_errmsg) {
   size_t ncols = zsv_cell_count(parser);
-  char **seen = NULL;
+  char **base = NULL;  // user-supplied name (trimmed, or blank placeholder) per column
+  char **final = NULL; // unique name assigned to each column (may alias base[i])
+  sqlite3_str *summary = NULL;
+  unsigned nrenamed = 0;
   int rc = 0;
   if(ncols) {
-    seen = sqlite3_malloc64((sqlite3_int64)(sizeof(*seen) * ncols));
-    if(!seen)
-      return -1;
-    memset(seen, 0, sizeof(*seen) * ncols);
+    base = sqlite3_malloc64((sqlite3_int64)(sizeof(*base) * ncols));
+    final = sqlite3_malloc64((sqlite3_int64)(sizeof(*final) * ncols));
+    if(!base || !final) {
+      rc = -1;
+      goto done;
+    }
+    memset(base, 0, sizeof(*base) * ncols);
+    memset(final, 0, sizeof(*final) * ncols);
   }
+
+  // phase 1: capture every column's user-supplied name; blanks keep their placeholder
   for(size_t i = 0; i < ncols; i++) {
     struct zsv_cell cell = zsv_get_cell(parser, i);
     size_t len = cell.len;
     unsigned char *utf8_value = (unsigned char *)zsv_strtrim(cell.str, &len);
-
-    // base (NUL-terminated) column name; blanks keep their existing placeholder
-    char *base;
     if(!len) {
       if(blank_column_name_count++)
-        base = sqlite3_mprintf("%s_%u", BLANK_COLUMN_NAME_PREFIX, blank_column_name_count - 1);
+        base[i] = sqlite3_mprintf("%s_%u", BLANK_COLUMN_NAME_PREFIX, blank_column_name_count - 1);
       else
-        base = sqlite3_mprintf("%s", BLANK_COLUMN_NAME_PREFIX);
+        base[i] = sqlite3_mprintf("%s", BLANK_COLUMN_NAME_PREFIX);
     } else
-      base = sqlite3_mprintf("%.*s", (int)len, utf8_value);
-    if(!base) {
+      base[i] = sqlite3_mprintf("%.*s", (int)len, utf8_value);
+    if(!base[i]) {
       rc = -1;
-      break;
+      goto done;
     }
+  }
 
-    char *name = base;     // points at base, or at a freshly-allocated suffixed name
-    char *suffixed = NULL;
-    if(dedupe) {
-      for(unsigned n = 2; zsv_csv_colname_find(seen, i, name) >= 0; n++) {
-        sqlite3_free(suffixed);
-        suffixed = sqlite3_mprintf("%s_%u", base, n);
-        if(!suffixed) {
-          rc = -1;
-          break;
-        }
-        name = suffixed;
-      }
-      if(rc) {
-        sqlite3_free(suffixed);
-        sqlite3_free(base);
-        break;
-      }
-      if(warn && name != base) // a rename happened; never silent
-        fprintf(stderr, "renamed duplicate column \"%s\" \xe2\x86\x92 \"%s\"\n", base, name);
-    } else {
-      long prior = zsv_csv_colname_find(seen, i, name);
+  // phase 2: assign a unique name to each column and emit its column def
+  for(size_t i = 0; i < ncols; i++) {
+    if(!dedupe) {
+      long prior = zsv_csv_colname_find(base, i, base[i]);
       if(prior >= 0) {
-        if(asprintf(dup_errmsg,
-                    "duplicate column name \"%s\" at columns %d and %d"
-                    "; pass --rename-duplicate-columns to auto-disambiguate",
-                    name, (int)(prior + 1), (int)(i + 1)) < 0)
+        if(asprintf(dup_errmsg, "duplicate column name \"%s\" at columns %d and %d", base[i], (int)(prior + 1),
+                    (int)(i + 1)) < 0)
           *dup_errmsg = NULL;
         rc = *dup_errmsg ? 1 : -1;
-        sqlite3_free(base);
-        break;
+        goto done;
+      }
+      final[i] = base[i]; // no dedupe: name is already unique (borrows base[i])
+    } else if(zsv_csv_colname_find(base, i, base[i]) < 0) {
+      final[i] = base[i]; // first occurrence keeps its name (borrows base[i])
+    } else {
+      // duplicate: bump _k past every user-supplied name and every name already assigned,
+      // so disambiguation never collides with, or displaces, an explicit column
+      char *cand = NULL;
+      for(unsigned k = 2;; k++) {
+        sqlite3_free(cand);
+        cand = sqlite3_mprintf("%s_%u", base[i], k);
+        if(!cand) {
+          rc = -1;
+          goto done;
+        }
+        if(zsv_csv_colname_find(base, ncols, cand) < 0 && zsv_csv_colname_find(final, i, cand) < 0)
+          break;
+      }
+      final[i] = cand;
+      if(warn) {
+        if(!summary && !(summary = sqlite3_str_new(0))) {
+          rc = -1;
+          goto done;
+        }
+        if(nrenamed < 5)
+          sqlite3_str_appendf(summary, "%s%s\xe2\x86\x92%s", nrenamed ? ", " : "", base[i], final[i]);
+        nrenamed++;
       }
     }
-    seen[i] = sqlite3_mprintf("%s", name);
-    if(!seen[i]) {
-      sqlite3_free(suffixed);
-      sqlite3_free(base);
-      rc = -1;
-      break;
-    }
-    sqlite3_str_appendf(pStr, "%s\"%w\" TEXT", i > 0 ? "," : "", name);
-    sqlite3_free(suffixed);
+    sqlite3_str_appendf(pStr, "%s\"%w\" TEXT", i > 0 ? "," : "", final[i]);
+  }
+
+  if(warn && nrenamed) {
+    if(nrenamed > 5)
+      sqlite3_str_appendf(summary, ", +%u more", nrenamed - 5);
+    fprintf(stderr,
+            "note: auto-renamed %u duplicate input column(s): %s"
+            "  (pass --error-on-duplicate-columns to treat as an error)\n",
+            nrenamed, sqlite3_str_value(summary));
+  }
+
+done:
+  if(final) {
+    for(size_t i = 0; i < ncols; i++)
+      if(final[i] && final[i] != base[i]) // only synthesized names are owned separately
+        sqlite3_free(final[i]);
+    sqlite3_free(final);
+  }
+  if(base) {
+    for(size_t i = 0; i < ncols; i++)
+      sqlite3_free(base[i]);
     sqlite3_free(base);
   }
-  if(seen) {
-    for(size_t i = 0; i < ncols; i++)
-      sqlite3_free(seen[i]);
-    sqlite3_free(seen);
-  }
+  if(summary)
+    sqlite3_free(sqlite3_str_finish(summary));
   return rc;
 }
 

--- a/app/sql.c
+++ b/app/sql.c
@@ -59,8 +59,11 @@ const char *zsv_sql_usage_msg[] = {
   "  -C,--max-cols <n>     : change the maximum allowable columns. must be > 0 and < 2000",
   "  -o <filename>         : filename to save output to",
   "  --memory              : use in-memory instead of temporary db (see https://www.sqlite.org/inmemorydb.html)",
-  "  --rename-duplicate-columns : auto-rename duplicate input column names (a, a_2, a_3, ...)",
-  "                          so input with repeated headers loads instead of erroring",
+  "  --error-on-duplicate-columns : fail (non-zero exit) if the input has duplicate column names,",
+  "                          instead of auto-disambiguating them (a, a_2, a_3, ...). Column-name",
+  "                          comparison is case-insensitive",
+  "  --rename-duplicate-columns : (default; retained for back-compat) auto-rename duplicate input",
+  "                          column names to a, a_2, a_3, ... A one-line summary is printed to stderr",
   NULL,
 };
 
@@ -77,8 +80,9 @@ struct zsv_sql_data {
   char *join_indexes; // will hold contents of join_indexes arg, prefixed and suffixed with a comma
   struct string_list *join_column_names;
   unsigned char in_memory : 1;
-  unsigned char rename_dup_cols : 1;
-  unsigned char _ : 6;
+  unsigned char rename_dup_cols : 1;   // back-compat alias for the default (auto-disambiguate); a no-op
+  unsigned char error_on_dup_cols : 1; // opt-out: error on duplicate input columns instead of renaming
+  unsigned char _ : 5;
 };
 
 static void zsv_sql_finalize(struct zsv_sql_data *data) {
@@ -197,6 +201,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         data.in_memory = 1;
       else if (!strcmp(arg, "--rename-duplicate-columns"))
         data.rename_dup_cols = 1;
+      else if (!strcmp(arg, "--error-on-duplicate-columns"))
+        data.error_on_dup_cols = 1;
       else if (!strcmp(arg, "-b"))
         writer_opts.with_bom = 1;
       else if (*arg != '-') {
@@ -227,6 +233,11 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         err = 1;
         fprintf(stderr, "Unrecognized option: %s\n", arg);
       }
+    }
+
+    if (!err && data.rename_dup_cols && data.error_on_dup_cols) {
+      fprintf(stderr, "--rename-duplicate-columns and --error-on-duplicate-columns are mutually exclusive\n");
+      err = 1;
     }
 
     if (!data.in || !data.input_filename) {
@@ -288,10 +299,11 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       unsigned char cw_buff[1024];
       zsv_writer_set_temp_buff(cw, cw_buff, sizeof(cw_buff));
 
+      int dedupe = !data.error_on_dup_cols; // auto-disambiguate by default; --error-on-duplicate-columns opts out
       struct zsv_sqlite3_dbopts dbopts = {
         .in_memory = data.in_memory,
-        .dedupe_cols = data.rename_dup_cols,
-        .warn_dupe_rename = data.rename_dup_cols, // non-interactive: note renames on stderr
+        .dedupe_cols = dedupe,
+        .warn_dupe_rename = dedupe, // non-interactive: emit one-line rename summary on stderr
       };
       struct zsv_sqlite3_db *zdb = zsv_sqlite3_db_new(&dbopts);
       if (zdb && zdb->rc == SQLITE_OK) {

--- a/app/sql_internal.c
+++ b/app/sql_internal.c
@@ -29,6 +29,7 @@ void zsv_sqlite3_db_delete(struct zsv_sqlite3_db *zdb) {
     }
     if (zdb->db)
       sqlite3_close(zdb->db);
+    free(zdb->err_msg); // strdup'd in zsv_sqlite3_db_new / create_virtual_csv_table
     free(zdb);
   }
 }

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -807,7 +807,9 @@ test-serialize : test-%: ${BUILD_DIR}/bin/zsv_%${EXE} test-serialize-quoted test
 	@(${PREFIX} $< -p < ${TEST_DATA_DIR}/test/$*.csv ${REDIRECT1} ${TMP_DIR}/$@-2.out && \
 	${CMP} ${TMP_DIR}/$@-2.out expected/$@-2.out && ${TEST_PASS} || ${TEST_FAIL})
 
-test-sql: test-sql2 test-sql3 test-sql4 test-sql5 test-sql-dupcol test-sql-dupcol-rename test-sql-dupcol-msg
+test-sql: test-sql2 test-sql3 test-sql4 test-sql5 test-sql-dupcol test-sql-dupcol-rename test-sql-dupcol-msg \
+          test-sql-dupcol-default test-sql-dupcol-3x test-sql-dupcol-collide test-sql-dupcol-caseins \
+          test-sql-dupcol-nodup
 test-sql2: ${BUILD_DIR}/bin/zsv_sql${EXE}
 	@${TEST_INIT}
 	@echo ${ARGS-sql} > ${TMP_DIR}/$@.sql
@@ -830,41 +832,85 @@ test-sql5: ${BUILD_DIR}/bin/zsv_sql${EXE} # test blank rows
 	@(${PREFIX} $< ${TMP_DIR}/1.csv 'select * from data' ${REDIRECT1} ${TMP_DIR}/$@.out)
 	@${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || ${TEST_FAIL}
 
-# Regression for the duplicate-column-name abort: input whose header has the same
-# name twice makes SQLite reject the CREATE TABLE. zsv sql must report the error and
-# exit *gracefully* (normal nonzero code), not die by signal (SIGABRT -> 128+6=134),
-# which is what the pre-fix double-free in zsv_sqlite3_add_csv() caused. We assert the
-# exit code is a graceful failure (nonzero and < 128) rather than a signal death, so
-# the test stays valid regardless of the exact error message wording.
+# Regression for the duplicate-column-name abort under the opt-out flag: input whose
+# header has the same name twice makes SQLite reject the CREATE TABLE. With
+# --error-on-duplicate-columns, zsv sql must report the error and exit *gracefully*
+# (normal nonzero code), not die by signal (SIGABRT -> 128+6=134), which is what the
+# pre-fix double-free in zsv_sqlite3_add_csv() caused. We assert the exit code is a
+# graceful failure (nonzero and < 128) rather than a signal death.
 test-sql-dupcol: ${BUILD_DIR}/bin/zsv_sql${EXE}
 	@${TEST_INIT}
 	@printf 'a,b,a\n1,2,3\n' > ${TMP_DIR}/$@.csv
-	@${PREFIX} $< ${TMP_DIR}/$@.csv 'select 1 from data limit 1' > ${TMP_DIR}/$@.out 2>&1; \
+	@${PREFIX} $< --error-on-duplicate-columns ${TMP_DIR}/$@.csv 'select 1 from data limit 1' > ${TMP_DIR}/$@.out 2>&1; \
 	  rc=$$?; \
 	  printf '  exit=%s\n' "$$rc"; \
 	  [ "$$rc" -ne 0 ] && [ "$$rc" -lt 128 ] && ${TEST_PASS} || ${TEST_FAIL}
 
-# --rename-duplicate-columns makes repeated header names unique (a,b,a -> a,b,a_2)
-# so input with duplicate columns loads successfully instead of erroring. The renamed
-# data goes to stdout; each rename is also noted on stderr (renames are never silent).
+# Back-compat: --rename-duplicate-columns still makes repeated header names unique
+# (a,b,a -> a,b,a_2). The renamed data goes to stdout; the rename is noted on stderr
+# as a single summary line containing the token 'auto-renamed' (never silent). (F7 G7)
 test-sql-dupcol-rename: ${BUILD_DIR}/bin/zsv_sql${EXE}
 	@${TEST_INIT}
 	@printf 'a,b,a\n1,2,3\n' > ${TMP_DIR}/$@.csv
 	@${PREFIX} $< --rename-duplicate-columns ${TMP_DIR}/$@.csv 'select * from data' > ${TMP_DIR}/$@.out 2> ${TMP_DIR}/$@.err
-	@${CMP} ${TMP_DIR}/$@.out expected/$@.out \
-	  && grep -q 'renamed duplicate column "a"' ${TMP_DIR}/$@.err && ${TEST_PASS} || ${TEST_FAIL}
+	@n=$$(grep -c -i 'auto-renamed' ${TMP_DIR}/$@.err); ${CMP} ${TMP_DIR}/$@.out expected/$@.out \
+	  && [ "$$n" = "1" ] && ${TEST_PASS} || ${TEST_FAIL}
 
-# Without the flag, a duplicate header is detected at parse time and reported with
-# a single actionable message naming the column, its 1-based positions, and the flag
-# to fix it (rather than SQLite's generic "bad schema"), while still exiting gracefully.
+# Opt-out: with --error-on-duplicate-columns a duplicate header is detected at parse
+# time and reported with a single actionable message naming the column and its 1-based
+# positions (rather than SQLite's generic "bad schema"), while exiting gracefully. (F7 G5)
 test-sql-dupcol-msg: ${BUILD_DIR}/bin/zsv_sql${EXE}
 	@${TEST_INIT}
 	@printf 'a,b,a\n1,2,3\n' > ${TMP_DIR}/$@.csv
-	@${PREFIX} $< ${TMP_DIR}/$@.csv 'select * from data' > ${TMP_DIR}/$@.out 2>&1; \
+	@${PREFIX} $< --error-on-duplicate-columns ${TMP_DIR}/$@.csv 'select * from data' > ${TMP_DIR}/$@.out 2>&1; \
 	  rc=$$?; \
 	  printf '  exit=%s\n' "$$rc"; \
-	  grep -q 'duplicate column name "a" at columns 1 and 3; pass --rename-duplicate-columns' ${TMP_DIR}/$@.out \
+	  grep -q 'duplicate column name "a" at columns 1 and 3' ${TMP_DIR}/$@.out \
 	    && [ "$$rc" -ne 0 ] && [ "$$rc" -lt 128 ] && ${TEST_PASS} || ${TEST_FAIL}
+
+# F7 G1/G2: duplicate input columns are auto-disambiguated by DEFAULT (no flag) ->
+# exit 0, header BV_NUM,name,amount,BV_NUM_2, and exactly ONE 'auto-renamed' stderr line.
+test-sql-dupcol-default: ${BUILD_DIR}/bin/zsv_sql${EXE}
+	@${TEST_INIT}
+	@printf 'BV_NUM,name,amount,BV_NUM\n1,a,10,100\n' > ${TMP_DIR}/$@.csv
+	@${PREFIX} $< ${TMP_DIR}/$@.csv 'select * from data' > ${TMP_DIR}/$@.out 2> ${TMP_DIR}/$@.err; \
+	  rc=$$?; h=$$(sed -n '1p' ${TMP_DIR}/$@.out); n=$$(grep -c -i 'auto-renamed' ${TMP_DIR}/$@.err); \
+	  [ "$$rc" = "0" ] && [ "$$h" = "BV_NUM,name,amount,BV_NUM_2" ] && [ "$$n" = "1" ] && ${TEST_PASS} || ${TEST_FAIL}
+
+# F7 G3/G4: three 'a' columns -> a,a_2,a_3,b, and the two renames COLLAPSE to one line.
+test-sql-dupcol-3x: ${BUILD_DIR}/bin/zsv_sql${EXE}
+	@${TEST_INIT}
+	@printf 'a,a,a,b\n1,2,3,4\n' > ${TMP_DIR}/$@.csv
+	@${PREFIX} $< ${TMP_DIR}/$@.csv 'select * from data' > ${TMP_DIR}/$@.out 2> ${TMP_DIR}/$@.err; \
+	  rc=$$?; h=$$(sed -n '1p' ${TMP_DIR}/$@.out); n=$$(grep -c -i 'auto-renamed' ${TMP_DIR}/$@.err); \
+	  [ "$$rc" = "0" ] && [ "$$h" = "a,a_2,a_3,b" ] && [ "$$n" = "1" ] && ${TEST_PASS} || ${TEST_FAIL}
+
+# F7 G8 + decision D1 (collision-stability): a,a,a_2 -> a,a_3,a_2. The synthesized name
+# skips past the user's explicit a_2 (left intact); all three output headers are unique.
+test-sql-dupcol-collide: ${BUILD_DIR}/bin/zsv_sql${EXE}
+	@${TEST_INIT}
+	@printf 'a,a,a_2\n1,2,3\n' > ${TMP_DIR}/$@.csv
+	@${PREFIX} $< ${TMP_DIR}/$@.csv 'select * from data' > ${TMP_DIR}/$@.out 2> ${TMP_DIR}/$@.err; \
+	  rc=$$?; h=$$(sed -n '1p' ${TMP_DIR}/$@.out); \
+	  uq=$$(printf '%s' "$$h" | tr ',' '\n' | sort -u | grep -c .); \
+	  [ "$$rc" = "0" ] && [ "$$h" = "a,a_3,a_2" ] && [ "$$uq" = "3" ] && ${TEST_PASS} || ${TEST_FAIL}
+
+# F7 G9: case-insensitive duplicate (BV_NUM/bv_num) is auto-fixed -> exit 0, 2 columns.
+test-sql-dupcol-caseins: ${BUILD_DIR}/bin/zsv_sql${EXE}
+	@${TEST_INIT}
+	@printf 'BV_NUM,bv_num\n1,2\n' > ${TMP_DIR}/$@.csv
+	@${PREFIX} $< ${TMP_DIR}/$@.csv 'select * from data' > ${TMP_DIR}/$@.out 2> ${TMP_DIR}/$@.err; \
+	  rc=$$?; h=$$(sed -n '1p' ${TMP_DIR}/$@.out); \
+	  tot=$$(printf '%s' "$$h" | tr ',' '\n' | grep -c .); \
+	  [ "$$rc" = "0" ] && [ "$$tot" = "2" ] && ${TEST_PASS} || ${TEST_FAIL}
+
+# F7 G6 (guard, no false positive): a file with no duplicates exits 0 with NO summary line.
+test-sql-dupcol-nodup: ${BUILD_DIR}/bin/zsv_sql${EXE}
+	@${TEST_INIT}
+	@printf 'a,b,c\n1,2,3\n' > ${TMP_DIR}/$@.csv
+	@${PREFIX} $< ${TMP_DIR}/$@.csv 'select * from data' > ${TMP_DIR}/$@.out 2> ${TMP_DIR}/$@.err; \
+	  rc=$$?; n=$$(grep -c -i 'auto-renamed' ${TMP_DIR}/$@.err); \
+	  [ "$$rc" = "0" ] && [ "$$n" = "0" ] && ${TEST_PASS} || ${TEST_FAIL}
 
 ${BUILD_DIR}/bin/zsv_%${EXE}:
 	${MAKE} -C .. $@ CONFIGFILE=${CONFIGFILEPATH} DEBUG=${DEBUG}


### PR DESCRIPTION
`zsv sql` no longer hard-errors on duplicate input column names. It renames later occurrences (a, a_2, a_3, ...) and proceeds, matching how blank-named columns are already handled. A new --error-on-duplicate-columns opts back into the strict (exit-1) behavior; --rename-duplicate-columns becomes a back-compat no-op alias, mutually exclusive with the opt-out.

- zsv_csv_append_column_defs: two-phase rewrite. Reserve all user-supplied names first, keep the first occurrence of each, and bump a synthesized name past every reserved and already-assigned name (case-insensitive) so it never displaces an explicit column (a,a,a_2 -> a,a_3,a_2). The per-column rename log is replaced by one stderr summary line (<=5 mappings, then "+N more").
- sql.c: default flip, new flag, mutual-exclusion guard, updated -h text.
- sql_internal.c: free zdb->err_msg in zsv_sqlite3_db_delete (pre-existing leak on the error path the opt-out now exercises).
- test/Makefile: repoint the 3 existing dupcol tests to the new default and add G1-G9 acceptance targets.

Verified: full `make clean test` (329 pass, 0 fail) incl. --disable-toon; 0 leaks and clean ASan+UBSan across all rename/error/join/cleanup paths.