### PR TITLE
compare: make --toon emit array of objects (like --json-object)

### DIFF
--- a/app/compare.c
+++ b/app/compare.c
@@ -862,7 +862,7 @@ static int compare_usage(void) {
     "  --json-compact     : output as compact JSON",
     "  --json-object      : output as an array of objects",
 #ifndef ZSV_NO_TOON
-    "  --toon             : output as TOON (https://github.com/toon-format/spec)",
+    "  --toon             : output as TOON, an array of objects (https://github.com/toon-format/spec)",
     "  --redline          : output a self-contained redline document (JSON by default,",
     "                       or TOON with --toon or when the AI_AGENT env var is non-blank)",
 #else
@@ -1030,6 +1030,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 #ifndef ZSV_NO_TOON
     } else if (!strcmp(arg, "--toon")) {
       data->writer.type = ZSV_COMPARE_OUTPUT_TYPE_JSON;
+      data->writer.object = 1; // --toon == --json-object rendered as TOON
       data->writer.toon = 1;
       saw_toon = 1;
 #endif

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -62,6 +62,8 @@ endif
 # 2toon exists only when TOON features are enabled (configure --disable-toon omits it)
 ifneq ($(ZSV_NO_TOON),1)
   SOURCES+=2toon
+  # test-compare's --toon equivalence check pipes through 2toon (empty under --disable-toon)
+  COMPARE_TOON_DEP=${BUILD_DIR}/bin/zsv_2toon${EXE}
 endif
 TARGETS=$(addprefix ${BUILD_DIR}/bin/zsv_,$(addsuffix ${EXE},${SOURCES}))
 
@@ -1117,7 +1119,7 @@ test-compare-tolerance: ${BUILD_DIR}/bin/zsv_compare${EXE}
 	@(${PREFIX} $< --tolerance 0.00001 ../../data/compare/tolerance1.csv ../../data/compare/tolerance2.csv ${REDIRECT1} ${TMP_DIR}/$@.out4 && \
 	${CMP} ${TMP_DIR}/$@.out4 expected/$@.out4 && ${TEST_PASS} || ${TEST_FAIL})
 
-test-compare: test-%: ${BUILD_DIR}/bin/zsv_%${EXE}
+test-compare: test-%: ${BUILD_DIR}/bin/zsv_%${EXE} ${COMPARE_TOON_DEP}
 	@${TEST_INIT}
 	@(${PREFIX} $< compare/t1.csv compare/t2.csv compare/t3.csv ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || ${TEST_FAIL})
@@ -1195,9 +1197,14 @@ test-compare: test-%: ${BUILD_DIR}/bin/zsv_%${EXE}
 	@($< --columns bad compare/colrange1.csv >/dev/null 2>&1 && ${TEST_FAIL} || ${TEST_PASS})
 
 ifneq ($(ZSV_NO_TOON),1)
-	@# --toon: TOON output (same comparison as --json out6, rendered as TOON)
+	@# --toon: TOON output (same comparison as --json-object out7, rendered as TOON)
 	@(${PREFIX} $< compare/t1.csv compare/t2.csv compare/t3.csv --toon ${REDIRECT1} ${TMP_DIR}/$@.toon && \
 	${CMP} ${TMP_DIR}/$@.toon expected/$@.toon && ${TEST_PASS} || ${TEST_FAIL})
+
+	@# --toon is equivalent to --json-object piped through `2toon --from-json`
+	@(${PREFIX} $< compare/t1.csv compare/t2.csv compare/t3.csv --json-object | \
+	${PREFIX} ${BUILD_DIR}/bin/zsv_2toon${EXE} --from-json ${REDIRECT1} ${TMP_DIR}/$@.toon-equiv && \
+	${CMP} ${TMP_DIR}/$@.toon-equiv expected/$@.toon && ${TEST_PASS} || ${TEST_FAIL})
 
 	@# get_default_output_format() does NOT affect the (non-redline) comparison output: with
 	@# AI_AGENT set and no format flag, output stays the default CSV (byte-identical to out).

--- a/app/test/expected/test-compare.toon
+++ b/app/test/expected/test-compare.toon
@@ -1,5 +1,4 @@
-[4]:
-  - [5]: Row #,Column,compare/t1.csv,compare/t2.csv,compare/t3.csv
-  - [5]: 1,B,X1,B1,X1
-  - [5]: 2,B,B2,B2,BB
-  - [5]: 2,C,X2,C2,C2
+[3]{"Row #",Column,"compare/t1.csv","compare/t2.csv","compare/t3.csv"}:
+  1,B,X1,B1,X1
+  2,B,B2,B2,BB
+  2,C,X2,C2,C2

--- a/docs/compare.md
+++ b/docs/compare.md
@@ -334,7 +334,7 @@ Options:
   --json             : output as JSON
   --json-compact     : output as compact JSON
   --json-object      : output as an array of objects
-  --toon             : output as TOON (https://github.com/toon-format/spec)
+  --toon             : output as TOON, an array of objects (https://github.com/toon-format/spec)
   --redline          : output a self-contained redline document (JSON by default,
                        or TOON with --toon or when the AI_AGENT environment default
                        is TOON; --json-redline is a legacy alias)


### PR DESCRIPTION
`zsv compare --toon` (without --redline) now produces output equivalent to `zsv compare --json-object | zsv 2toon --from-json`, instead of the previous array-of-arrays form that matched plain `--json`.

The fix enables object mode (writer.object = 1) in the --toon handler, mirroring --json-object; the existing cw_*->toonwriter_* dispatch already supports it, so no new code paths or struct changes are needed. Redline output is unaffected because --redline forces its own output type and every path reading writer.object early-returns for it.

Tests: regenerated the golden TOON file and added an assertion that --toon is byte-identical to `--json-object | 2toon --from-json`. Full `make clean test` passes with TOON enabled and with --disable-toon.