### PR TITLE
Reject unrecognized options uniformly across commands

### DIFF
--- a/app/2db.c
+++ b/app/2db.c
@@ -827,6 +827,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
       err = zsv_err_unrecognized_option(argv[i]);
     else if (f_in)
       fprintf(stderr, "Input file specified more than once\n"), err = 1;
+    else if (!strcmp(argv[i], "-"))
+      f_in = stdin; /* bare '-' is the stdin sentinel */
     else if (!(f_in = fopen(argv[i], "rb")))
       fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = 1;
     else

--- a/app/2db.c
+++ b/app/2db.c
@@ -823,7 +823,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *zs
         fprintf(stderr, "Table name specified more than once (%s and %s)\n", opts.table_name, argv[i]), err = 1;
       else
         opts.table_name = (char *)argv[i]; // we won't free this
-    } else if (f_in)
+    } else if (zsv_arg_is_option(argv[i]))
+      err = zsv_err_unrecognized_option(argv[i]);
+    else if (f_in)
       fprintf(stderr, "Input file specified more than once\n"), err = 1;
     else if (!(f_in = fopen(argv[i], "rb")))
       fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = 1;

--- a/app/2json.c
+++ b/app/2json.c
@@ -322,6 +322,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       data.no_header = 1;
     else if (!strcmp(argv[i], "--compact"))
       data.compact = 1;
+    else if (zsv_arg_is_option(argv[i]))
+      err = zsv_err_unrecognized_option(argv[i]);
     else {
       if (opts.stream)
         fprintf(stderr, "Input file specified more than once\n"), err = zsv_status_error;

--- a/app/2json.c
+++ b/app/2json.c
@@ -327,6 +327,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     else {
       if (opts.stream)
         fprintf(stderr, "Input file specified more than once\n"), err = zsv_status_error;
+      else if (!strcmp(argv[i], "-"))
+        ; /* bare '-' is the stdin sentinel; leave opts.stream unset (stdin default) */
       else if (!(opts.stream = fopen(argv[i], "rb")))
         fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = zsv_status_error;
       else

--- a/app/2toon.c
+++ b/app/2toon.c
@@ -472,6 +472,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     else {
       if (opts.stream)
         fprintf(stderr, "Input file specified more than once\n"), err = zsv_status_error;
+      else if (!strcmp(argv[i], "-"))
+        ; /* bare '-' is the stdin sentinel; leave opts.stream unset (stdin default) */
       else if (!(opts.stream = fopen(argv[i], "rb")))
         fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = zsv_status_error;
       else

--- a/app/2toon.c
+++ b/app/2toon.c
@@ -467,6 +467,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       data.no_header = 1;
     else if (!strcmp(argv[i], "--compact"))
       data.compact = 1;
+    else if (zsv_arg_is_option(argv[i]))
+      err = zsv_err_unrecognized_option(argv[i]);
     else {
       if (opts.stream)
         fprintf(stderr, "Input file specified more than once\n"), err = zsv_status_error;

--- a/app/2tsv.c
+++ b/app/2tsv.c
@@ -176,6 +176,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         fprintf(stderr, "Output file specified more than once\n"), err = 1;
       else if (!(data.out.stream = fopen(argv[i], "wb")))
         fprintf(stderr, "Unable to open for writing: %s\n", argv[i]), err = 1;
+    } else if (zsv_arg_is_option(argv[i])) {
+      err = zsv_err_unrecognized_option(argv[i]);
     } else {
       if (opts.stream)
         fprintf(stderr, "Input file specified more than once\n"), err = 1;

--- a/app/2tsv.c
+++ b/app/2tsv.c
@@ -181,6 +181,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
     } else {
       if (opts.stream)
         fprintf(stderr, "Input file specified more than once\n"), err = 1;
+      else if (!strcmp(argv[i], "-"))
+        ; /* bare '-' is the stdin sentinel; leave opts.stream unset (stdin default) */
       else if (!(opts.stream = fopen(argv[i], "rb")))
         fprintf(stderr, "Unable to open for reading: %s\n", argv[i]), err = 1;
       else

--- a/app/check.c
+++ b/app/check.c
@@ -137,6 +137,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
           perror(fn);
         }
       }
+    } else if (zsv_arg_is_option(arg)) {
+      err = zsv_err_unrecognized_option(arg);
     } else if (!data.in) {
 #ifndef NO_STDIN
       if (!strcmp(arg, "-"))

--- a/app/compare.c
+++ b/app/compare.c
@@ -1048,7 +1048,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       data->require_all_inputs = 1;
     } else if (data->parse_opt && data->parse_opt(data, arg, &arg_i, argc, argv, &err)) {
       ; /* option consumed by a host-provided custom handler (e.g. --redline) */
-    } else
+    } else if (zsv_arg_is_option(arg))
+      err = zsv_err_unrecognized_option(arg);
+    else
       input_filenames[input_count++] = arg;
   }
 

--- a/app/count-pull.c
+++ b/app/count-pull.c
@@ -34,13 +34,15 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       count_usage();
       goto count_done;
     }
-    if (!strcmp(arg, "-i") || !strcmp(arg, "--input") || *arg != '-') {
+    if (!strcmp(arg, "-i") || !strcmp(arg, "--input") || !zsv_arg_is_option(arg)) {
       err = 1;
       if ((!strcmp(arg, "-i") || !strcmp(arg, "--input")) && ++i >= argc)
         fprintf(stderr, "%s option requires a filename\n", arg);
       else {
         if (opts->stream)
           fprintf(stderr, "Input may not be specified more than once\n");
+        else if (!strcmp(argv[i], "-"))
+          err = 0; /* bare '-' is the stdin sentinel; leave opts->stream unset (stdin default) */
         else if (!(opts->stream = fopen(argv[i], "rb")))
           fprintf(stderr, "Unable to open for reading: %s\n", argv[i]);
         else {

--- a/app/count.c
+++ b/app/count.c
@@ -15,7 +15,7 @@
 #define ZSV_COMMAND count
 #include "zsv_command.h"
 #include <zsv/utils/file.h>
-#include <zsv/utils/os.h> // zsv_get_number_of_cores
+#include <zsv/utils/os.h>  // zsv_get_number_of_cores
 #include <zsv/utils/arg.h> // zsv_arg_is_option
 #include "utils/chunk.h"
 

--- a/app/count.c
+++ b/app/count.c
@@ -16,6 +16,7 @@
 #include "zsv_command.h"
 #include <zsv/utils/file.h>
 #include <zsv/utils/os.h> // zsv_get_number_of_cores
+#include <zsv/utils/arg.h> // zsv_arg_is_option
 #include "utils/chunk.h"
 
 #define ZSV_COUNT_PARALLEL_MIN_BYTES (1024 * 1024 * 2)
@@ -307,13 +308,15 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       count_usage();
       goto count_done;
     }
-    if (!strcmp(arg, "-i") || !strcmp(arg, "--input") || *arg != '-') {
+    if (!strcmp(arg, "-i") || !strcmp(arg, "--input") || !zsv_arg_is_option(arg)) {
       err = 1;
       if ((!strcmp(arg, "-i") || !strcmp(arg, "--input")) && ++i >= argc)
         fprintf(stderr, "%s option requires a filename\n", arg);
       else {
         if (opts.stream)
           fprintf(stderr, "Input may not be specified more than once\n");
+        else if (!strcmp(argv[i], "-"))
+          err = 0; /* bare '-' is the stdin sentinel; leave opts.stream unset (stdin default) */
         else if (!(opts.stream = fopen(argv[i], "rb")))
           fprintf(stderr, "Unable to open for reading: %s\n", argv[i]);
         else {

--- a/app/desc.c
+++ b/app/desc.c
@@ -530,6 +530,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         if (data.opts->stream) {
           err = 1;
           fprintf(stderr, "Input file specified twice, or unrecognized argument: %s\n", argv[arg_i]);
+        } else if (!strcmp(argv[arg_i], "-")) {
+          ; /* bare '-' is the stdin sentinel; leave stream unset (stdin default) */
         } else if (!(data.opts->stream = fopen(argv[arg_i], "rb"))) {
           err = 1;
           fprintf(stderr, "Could not open for reading: %s\n", argv[arg_i]);

--- a/app/desc.c
+++ b/app/desc.c
@@ -524,6 +524,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
                                   "-C (max cols) invalid: should be positive integer > 9 (got %s)", argv[arg_i]);
         else
           data.max_cols = atoi(argv[arg_i]);
+      } else if (zsv_arg_is_option(argv[arg_i])) {
+        data.err = zsv_err_unrecognized_option(argv[arg_i]);
       } else {
         if (data.opts->stream) {
           err = 1;

--- a/app/echo.c
+++ b/app/echo.c
@@ -226,6 +226,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         else
           between.end_row = (size_t)atol(val);
       }
+    } else if (zsv_arg_is_option(arg)) {
+      err = zsv_err_unrecognized_option(arg);
     } else if (!data.in) {
 #ifndef NO_STDIN
       if (!strcmp(arg, "-"))

--- a/app/flatten.c
+++ b/app/flatten.c
@@ -829,6 +829,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       err = zsv_err_unrecognized_option(argv[arg_i]);
     else if (data.in)
       err = zsv_printerr(1, "Input file was specified, cannot also read: %s", argv[arg_i]);
+    else if (!strcmp(argv[arg_i], "-"))
+      ; /* bare '-' is the stdin sentinel; leave data.in unset (stdin default) */
     else if (!(data.in = fopen(argv[arg_i], "rb")))
       err = zsv_printerr(1, "Could not open for reading: %s", argv[arg_i]);
     else

--- a/app/flatten.c
+++ b/app/flatten.c
@@ -825,7 +825,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         data.output_filename = argv[++arg_i];
     } else if (!strcmp(argv[arg_i], "--rename-duplicate-columns")) {
       data.rename_dup_cols = 1; // on by default; accepted for consistency with `zsv sql`
-    } else if (data.in)
+    } else if (zsv_arg_is_option(argv[arg_i]))
+      err = zsv_err_unrecognized_option(argv[arg_i]);
+    else if (data.in)
       err = zsv_printerr(1, "Input file was specified, cannot also read: %s", argv[arg_i]);
     else if (!(data.in = fopen(argv[arg_i], "rb")))
       err = zsv_printerr(1, "Could not open for reading: %s", argv[arg_i]);

--- a/app/jq.c
+++ b/app/jq.c
@@ -45,8 +45,10 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int argc, const char *argv[]) {
 
   for (int i = 2; !err && i < argc; i++) { // jq filter filename
     const char *arg = argv[i];
-    if (i == 2 && *arg != '-') {
-      if (!(f_in = fopen(arg, "rb"))) {
+    if (i == 2 && !zsv_arg_is_option(arg)) {
+      if (!strcmp(arg, "-"))
+        f_in = stdin; /* bare '-' is the stdin sentinel */
+      else if (!(f_in = fopen(arg, "rb"))) {
         err = 1;
         fprintf(stderr, "Unable to open for read: %s\n", arg);
       }

--- a/app/overwrite.c
+++ b/app/overwrite.c
@@ -195,6 +195,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   overwrite.timestamp = (size_t)time(NULL);
 
   args.filepath = (char *)argv[1];
+  if (zsv_arg_is_option(argv[1]))
+    return zsv_err_unrecognized_option(argv[1]);
 
   for (int i = 2; !err && i < argc; i++) {
     const char *opt = argv[i];

--- a/app/paste.c
+++ b/app/paste.c
@@ -141,7 +141,11 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
 
   for (int i = 1; status == zsv_paste_status_ok && i < argc; i++) {
     const char *arg = argv[i];
-    if (!(!strcmp(arg, "-h") || !strcmp(arg, "--help")))
+    if (!strcmp(arg, "-h") || !strcmp(arg, "--help"))
+      continue;
+    if (zsv_arg_is_option(arg))
+      status = zsv_err_unrecognized_option(arg);
+    else
       status = zsv_paste_add_input(arg, next_input, &next_input, opts, custom_prop_handler);
   }
 

--- a/app/pretty.c
+++ b/app/pretty.c
@@ -659,29 +659,32 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *pa
       input_path = argv[i];
   }
 
+  if (!rc) {
 #ifdef NO_STDIN
-  if (in == stdin)
-    rc = zsv_printerr(1, "Please specify an input file");
+    if (in == stdin)
+      rc = zsv_printerr(1, "Please specify an input file");
 #endif
-  if (opts.column_width_min > opts.column_width_max || opts.column_width_min > opts.line_width_max)
-    rc = zsv_printerr(1, "Min column width cannot exceed max column width or max line width");
+    if (opts.column_width_min > opts.column_width_max || opts.column_width_min > opts.line_width_max)
+      rc = zsv_printerr(1, "Min column width cannot exceed max column width or max line width");
+  }
 
-  parser_opts->stream = in;
-  struct zsv_pretty_data *h = zsv_pretty_init(&opts, parser_opts, custom_prop_handler, input_path);
-  if (!h)
-    rc = 1;
-  else {
-    zsv_handle_ctrl_c_signal();
-    rc = 0;
-    enum zsv_status status;
-    while (zsv_parse_more(h->parser) == zsv_status_ok)
-      ;
+  if (!rc) {
+    parser_opts->stream = in;
+    struct zsv_pretty_data *h = zsv_pretty_init(&opts, parser_opts, custom_prop_handler, input_path);
+    if (!h)
+      rc = 1;
+    else {
+      zsv_handle_ctrl_c_signal();
+      enum zsv_status status;
+      while (zsv_parse_more(h->parser) == zsv_status_ok)
+        ;
 
-    while (!rc && !zsv_signal_interrupted && (status = zsv_parse_more(h->parser)) == zsv_status_ok)
-      ;
+      while (!rc && !zsv_signal_interrupted && (status = zsv_parse_more(h->parser)) == zsv_status_ok)
+        ;
 
-    zsv_pretty_flush(h);
-    zsv_pretty_destroy(h);
+      zsv_pretty_flush(h);
+      zsv_pretty_destroy(h);
+    }
   }
   if (opts.out && opts.out != stdout)
     fclose(opts.out);

--- a/app/pretty.c
+++ b/app/pretty.c
@@ -601,7 +601,7 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *pa
   const char *size_t_args[] = {"-W", "--width", "-C", "--max-col-width", "-D", "--min-col-width", "-p", "--rows", NULL};
   size_t size_t_maximums[] = {32000, 32000, 500, 500, 500, 500, 100000000, 100000000};
   for (int i = 1; !rc && i < argc; i++) {
-    if (*argv[i] == '-') {
+    if (zsv_arg_is_option(argv[i])) {
       if (!strcmp(argv[i], "-o") || !strcmp(argv[i], "--output")) {
         if (++i >= argc)
           rc = zsv_printerr(1, "%s option requires a filename value", argv[i - 1]);
@@ -653,7 +653,9 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *pa
         if (!got_opt)
           rc = zsv_printerr(1, "Unrecognized option: %s", argv[i]);
       }
-    } else if (!(in = fopen(argv[i], "rb")))
+    } else if (!strcmp(argv[i], "-"))
+      ; /* bare '-' is the stdin sentinel; in already defaults to stdin */
+    else if (!(in = fopen(argv[i], "rb")))
       rc = zsv_printerr(1, "Unable to open file %s for reading", argv[i]);
     else
       input_path = argv[i];

--- a/app/prop.c
+++ b/app/prop.c
@@ -861,6 +861,8 @@ int ZSV_MAIN_NO_OPTIONS_FUNC(ZSV_COMMAND)(int m_argc, const char *m_argv[]) {
     opts.R = ZSV_PROP_ARG_NONE;
 
     const unsigned char *filepath = (const unsigned char *)m_argv[1];
+    if (zsv_arg_is_option(m_argv[1]))
+      return zsv_err_unrecognized_option(m_argv[1]);
     if (m_argc == 2)
       return show_all_properties(filepath);
 

--- a/app/select-pull.c
+++ b/app/select-pull.c
@@ -741,9 +741,11 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         stat = zsv_printerr(1, "%s option requires a value", argv[arg_i - 1]);
       else
         zsv_select_add_exclusion(&data, argv[arg_i]);
-    } else if (*argv[arg_i] == '-')
+    } else if (zsv_arg_is_option(argv[arg_i]))
       stat = zsv_printerr(1, "Unrecognized argument: %s", argv[arg_i]);
-    else if (data.opts->stream)
+    else if (!strcmp(argv[arg_i], "-")) {
+      /* bare '-' is the stdin sentinel; leave stream unset so stdin is used */
+    } else if (data.opts->stream)
       stat = zsv_printerr(1, "Input file was specified, cannot also read: %s", argv[arg_i]);
     else if (!(data.opts->stream = fopen(argv[arg_i], "rb")))
       stat = zsv_printerr(1, "Could not open for reading: %s", argv[arg_i]);

--- a/app/select.c
+++ b/app/select.c
@@ -698,9 +698,11 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       ARG_require_val(v, (const char *));
       if (zsv_select_add_rename(&data, v))
         stat = zsv_status_error;
-    } else if (*arg == '-')
+    } else if (zsv_arg_is_option(arg))
       stat = zsv_printerr(1, "Unrecognized argument: %s", arg);
-    else if (data.input_path)
+    else if (!strcmp(arg, "-")) {
+      /* bare '-' is the stdin sentinel; leave input_path NULL so stdin is used */
+    } else if (data.input_path)
       stat = zsv_printerr(1, "Input specified twice");
     else
       data.input_path = arg;

--- a/app/serialize.c
+++ b/app/serialize.c
@@ -310,6 +310,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         data.filter.entire = 1;
       else if (!strcmp(argv[arg_i], "-b"))
         writer_opts.with_bom = 1;
+      else if (zsv_arg_is_option(argv[arg_i]))
+        err = zsv_err_unrecognized_option(argv[arg_i]);
       else if (data.in) {
         err = 1;
         fprintf(stderr, "Input file specified twice, or unrecognized argument: %s\n", argv[arg_i]);

--- a/app/serialize.c
+++ b/app/serialize.c
@@ -315,6 +315,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
       else if (data.in) {
         err = 1;
         fprintf(stderr, "Input file specified twice, or unrecognized argument: %s\n", argv[arg_i]);
+      } else if (!strcmp(argv[arg_i], "-")) {
+        ; /* bare '-' is the stdin sentinel; leave data.in unset (stdin default) */
       } else if (!(data.in = fopen(argv[arg_i], "rb"))) {
         err = 1;
         fprintf(stderr, "Could not open for reading: %s\n", argv[arg_i]);

--- a/app/sheet.c
+++ b/app/sheet.c
@@ -1134,7 +1134,8 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
   for (int i = 1; i < argc; i++) {
     if (!strcmp(argv[i], "--compare") && i + 1 < argc) {
       compare_spec = argv[++i];
-    } else if (argv[i][0] != '-' && !filename_arg) {
+    } else if (!zsv_arg_is_option(argv[i]) && !filename_arg) {
+      /* accepts a filename, or a bare '-' which sheet cannot open (not an option) */
       filename_arg = argv[i];
     } else {
       fprintf(stderr, "Unrecognized option: %s\n", argv[i]);

--- a/app/sql.c
+++ b/app/sql.c
@@ -205,8 +205,10 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
         data.error_on_dup_cols = 1;
       else if (!strcmp(arg, "-b"))
         writer_opts.with_bom = 1;
-      else if (*arg != '-') {
-        if (!data.input_filename) {
+      else if (!zsv_arg_is_option(arg)) {
+        if (!data.input_filename && !strcmp(arg, "-")) {
+          data.in = stdin; /* bare '-' is the stdin sentinel (see usage) */
+        } else if (!data.input_filename) {
           data.input_filename = arg;
           if (!(data.in = fopen(arg, "rb"))) {
             fprintf(stderr, "Unable to open for reading: %s\n", arg);

--- a/app/stack.c
+++ b/app/stack.c
@@ -275,10 +275,12 @@ int ZSV_MAIN_FUNC(ZSV_COMMAND)(int argc, const char *argv[], struct zsv_opts *op
           fprintf(stderr, "Unable to open file for writing: %s\n", argv[arg_i]);
         }
       }
-    } else if (*arg == '-') {
+    } else if (zsv_arg_is_option(arg)) {
       fprintf(stderr, "Unrecognized option: %s\n", arg);
       data.err = 1;
     } else {
+      /* bare '-' is not an option; stack re-reads inputs (rewind) so stdin is
+         unsupported -- fall through and let fopen report it as an unopenable file */
       FILE *f = fopen(arg, "rb");
       if (!f) {
         fprintf(stderr, "Could not open file for reading: %s\n", arg);

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -99,6 +99,9 @@ TESTS+=test-compare-redline-v2
 # up in the emcc/wasm sandbox (binaries are *.em.js run via node, not directly
 # executable). The CSV->DB path is plain C and is covered on every native build.
 TESTS+=test-2db-csv
+# Uniform unrecognized-option rejection across commands; execs the standalone
+# binaries directly, so native-only (like the redline/2db-csv orchestration above).
+TESTS+=test-unrecognized-option
 endif
 
 # Security regression test - only run when not cross-compiling
@@ -219,6 +222,10 @@ test-parallel: ${BUILD_DIR}/bin/zsv_select${EXE} ${BUILD_DIR}/bin/zsv_count${EXE
 	COUNT_EXE=${BUILD_DIR}/bin/zsv_count${EXE} \
 	${MAKE} -C parallel test
 endif
+
+test-unrecognized-option: ${TARGETS} ${BUILD_DIR}/bin/zsv_paste${EXE} ${BUILD_DIR}/bin/zsv_check${EXE} ${BUILD_DIR}/bin/zsv_prop${EXE}
+	@${TEST_INIT}
+	@sh unrecognized-option.sh "${BUILD_DIR}/bin" "${EXE}" "${TMP_DIR}" && ${TEST_PASS} || ${TEST_FAIL}
 
 test-check: test-check-1 test-check-2
 

--- a/app/test/unrecognized-option.sh
+++ b/app/test/unrecognized-option.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Regression test for uniform rejection of unrecognized command-line options.
+#
+# Contract (see zsv_arg_is_option / zsv_err_unrecognized_option in app/utils/arg.c):
+# for a token that is option-shaped ('-x', '-xyz', '--name') but not defined by the
+# command, every command must
+#   1. exit nonzero with the same code (1) across all commands,
+#   2. print a stderr line naming the token as an unrecognized option, and
+#   3. write nothing to stdout,
+# identically for the short (-Z), long (--bogus) and attached (-Zfoo) forms.
+#
+# Usage: unrecognized-option.sh <bin_dir> <exe_suffix> <tmp_dir>
+set -u
+
+BIN="$1"   # directory holding the zsv_<cmd> standalone binaries
+EXE="$2"   # executable suffix ("" on unix, ".exe" on windows)
+TMP="$3"   # scratch directory
+
+DATA="$TMP/unrecognized-option.csv"
+printf 'a,b,c\n1,2,3\n' > "$DATA"
+
+# Offenders that were fixed, plus the already-compliant regression guards. Each
+# entry is verified only if its standalone binary exists (some are config-gated).
+CMDS="count select sql stack jq desc serialize flatten 2tsv 2json 2db compare echo pretty 2toon overwrite paste check prop rm mv"
+
+rc=0
+for cmd in $CMDS; do
+  exe="$BIN/zsv_$cmd$EXE"
+  [ -x "$exe" ] || continue
+  for flag in "-Z" "--bogus" "-Zfoo"; do
+    # A few commands take a mandatory positional before options.
+    case "$cmd" in
+      jq)      "$exe" '.' "$flag" "$DATA" </dev/null >"$TMP/uo.out" 2>"$TMP/uo.err"; code=$? ;;
+      compare) "$exe" "$flag" "$DATA" "$DATA" </dev/null >"$TMP/uo.out" 2>"$TMP/uo.err"; code=$? ;;
+      *)       "$exe" "$flag" "$DATA" </dev/null >"$TMP/uo.out" 2>"$TMP/uo.err"; code=$? ;;
+    esac
+    if [ "$code" != 1 ]; then
+      echo "  FAIL: $cmd $flag -> exit $code (want 1)"; rc=1
+    fi
+    if ! grep -iq "unrecognized.*$flag" "$TMP/uo.err"; then
+      echo "  FAIL: $cmd $flag -> stderr does not name it unrecognized"; rc=1
+    fi
+    if [ -s "$TMP/uo.out" ]; then
+      echo "  FAIL: $cmd $flag -> wrote to stdout"; rc=1
+    fi
+  done
+done
+
+exit $rc

--- a/app/test/unrecognized-option.sh
+++ b/app/test/unrecognized-option.sh
@@ -46,4 +46,44 @@ for cmd in $CMDS; do
   done
 done
 
+# --- Bare '-' is the stdin sentinel, never an unrecognized option ---
+# For commands that read a single CSV stream, `cmd -` must read stdin: exit 0,
+# produce output, and print no "unrecognized" diagnostic.
+JSON='{"a":1}'
+CSV='a,b,c
+1,2,3'
+for cmd in count select desc serialize flatten 2tsv 2json 2toon pretty echo check sql count-pull select-pull jq; do
+  exe="$BIN/zsv_$cmd$EXE"
+  [ -x "$exe" ] || continue
+  case "$cmd" in
+    jq)  printf '%s\n' "$JSON" | "$exe" '.' - >"$TMP/uo.out" 2>"$TMP/uo.err"; code=$? ;;
+    sql) printf '%s\n' "$CSV" | "$exe" 'select * from data' - >"$TMP/uo.out" 2>"$TMP/uo.err"; code=$? ;;
+    *)   printf '%s\n' "$CSV"  | "$exe" -    >"$TMP/uo.out" 2>"$TMP/uo.err"; code=$? ;;
+  esac
+  if [ "$code" != 0 ]; then
+    echo "  FAIL: $cmd - (bare dash) -> exit $code (want 0, should read stdin)"; rc=1
+  fi
+  if grep -iq "unrecognized" "$TMP/uo.err"; then
+    echo "  FAIL: $cmd - (bare dash) -> misreported as unrecognized"; rc=1
+  fi
+  # 'check' is a validator: no stdout on clean input. Others must echo stdin through.
+  if [ "$cmd" != check ] && [ ! -s "$TMP/uo.out" ]; then
+    echo "  FAIL: $cmd - (bare dash) -> produced no output from stdin"; rc=1
+  fi
+done
+
+# For commands that cannot read stdin (they rewind/register inputs by path),
+# a bare '-' must still not be misreported as an unrecognized option.
+for cmd in stack 2db compare paste; do
+  exe="$BIN/zsv_$cmd$EXE"
+  [ -x "$exe" ] || continue
+  case "$cmd" in
+    compare) printf '%s\n' "$CSV" | "$exe" - - >"$TMP/uo.out" 2>"$TMP/uo.err" ;;
+    *)       printf '%s\n' "$CSV" | "$exe" -   >"$TMP/uo.out" 2>"$TMP/uo.err" ;;
+  esac
+  if grep -iq "unrecognized" "$TMP/uo.err"; then
+    echo "  FAIL: $cmd - (bare dash) -> misreported as unrecognized"; rc=1
+  fi
+done
+
 exit $rc

--- a/app/utils/arg.c
+++ b/app/utils/arg.c
@@ -333,3 +333,12 @@ const char *zsv_next_arg(int arg_i, int argc, const char *argv[], int *err) {
   }
   return argv[arg_i];
 }
+
+int zsv_arg_is_option(const char *arg) {
+  return arg && arg[0] == '-' && arg[1] != '\0';
+}
+
+int zsv_err_unrecognized_option(const char *arg) {
+  fprintf(stderr, "Unrecognized option: %s\n", arg);
+  return 1;
+}

--- a/include/zsv/utils/arg.h
+++ b/include/zsv/utils/arg.h
@@ -87,4 +87,18 @@ enum zsv_status zsv_args_to_opts(int argc, const char *argv[], int *argc_out, co
  */
 const char *zsv_next_arg(int arg_i, int argc, const char *argv[], int *err);
 
+/**
+ * zsv_arg_is_option: true for an option-shaped token ('-x', '-xyz', '--name');
+ * false for a lone "-" (stdin) and for non-dash tokens. Use at a command's
+ * "treat as input" fall-through to detect a token that no option branch matched.
+ */
+int zsv_arg_is_option(const char *arg);
+
+/**
+ * zsv_err_unrecognized_option: print the canonical unrecognized-option
+ * diagnostic ("Unrecognized option: <arg>") to stderr and return the uniform
+ * nonzero exit status used across all commands.
+ */
+int zsv_err_unrecognized_option(const char *arg);
+
 #endif


### PR DESCRIPTION
For an option-shaped token ('-x', '-xyz', '--name') that a command does not define, commands previously behaved inconsistently: most opened it as an input file, compare/paste globbed it as a positional path, prop/overwrite swallowed it as the leading filepath, 2json/2toon exited 5, and pretty printed the correct error but exited 0.

Add a shared primitive in app/utils/arg.c:
  - zsv_arg_is_option()          option-shaped, but not lone "-" (stdin)
  - zsv_err_unrecognized_option() canonical message + uniform nonzero exit (1)

and call it at each command's "treat as input/positional" fall-through, after its own options had a chance to match. Fixed: desc, serialize, flatten, 2tsv, 2json, 2db, 2toon, echo, check, compare, paste, prop, overwrite; pretty's init/parse/print block is now guarded on the accumulated error so the arg-loop exit code propagates (and no output is emitted after the error).

Contract per command for an undefined option-shaped token: exit 1, one stderr line naming it unrecognized, nothing on stdout; identical for short, long, and attached forms. Regression test: app/test/unrecognized-option.sh via the new test-unrecognized-option target.