### PR TITLE
Auto-select tab delimiter for .tsv/.tab input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ and/or use multi-row header span -- see documentation for further detail.
 * Cell delimiter can be a character other than comma
 * Row delimiter can be specfied as CRLF only, in which case a standalone CR
   or LF is simply part of the cell value, even without quoting
+* When the input is a file whose name ends in `.tsv` or `.tab`, the cell
+  delimiter defaults to tab (equivalent to passing `-t`), unless a delimiter
+  is set explicitly. Recognition of `.tab` can be turned off at build time via
+  `./configure --disable-tab-auto-recognize` (`.tsv` is always recognized)
 
 ## Built-in and extensible features
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -71,6 +71,12 @@ ifeq ($(ZSV_NO_TOON),1)
   CFLAGS+= -DZSV_NO_TOON
 endif
 
+# ZSV_NO_TAB_AUTO_RECOGNIZE: do not default to a tab delimiter for .tab input
+# files (.tsv is always recognized). Guard in app/utils/prop.c keys off this.
+ifeq ($(ZSV_NO_TAB_AUTO_RECOGNIZE),1)
+  CFLAGS+= -DZSV_NO_TAB_AUTO_RECOGNIZE
+endif
+
 DEBUG=0
 WIN=
 ifeq ($(WIN),)

--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -86,6 +86,7 @@ endif
 TESTS+=test-check
 TESTS+=test-rename-select
 TESTS+=test-quoted-nonstandard
+TESTS+=test-tab-auto-recognize
 # The redline tests pin output determinism via SOURCE_DATE_EPOCH and exercise the unified
 # `cli` / `--help-topic` routing. emscripten's getenv does not see host env vars (only a
 # minimal built-in ENV), and that multi-binary orchestration is not set up in the emcc/wasm
@@ -770,6 +771,23 @@ test-pretty-escape-chars: ${BUILD_DIR}/bin/zsv_pretty${EXE}
 	@${TEST_INIT}
 	@(${PREFIX} $< ${ARGS-$*} < ${TEST_DATA_DIR}/test/pretty-escape.csv -M ${REDIRECT1} ${TMP_DIR}/$@.out && \
 	${CMP} ${TMP_DIR}/$@.out expected/$@.out && ${TEST_PASS} || ${TEST_FAIL})
+
+# .tsv/.tab input files default to a tab delimiter (== -t); other extensions and
+# an explicit delimiter are unaffected. Exercises the app/utils/prop.c seam that
+# every delimited-input command routes through. Fails before the seam was added.
+test-tab-auto-recognize: ${BUILD_DIR}/bin/zsv_select${EXE}
+	@${TEST_INIT}
+	@cp ${TEST_DATA_DIR}/Excel.tsv ${TMP_DIR}/$@.tsv && \
+	cp ${TEST_DATA_DIR}/Excel.tsv ${TMP_DIR}/$@.tab && \
+	cp ${TEST_DATA_DIR}/Excel.tsv ${TMP_DIR}/$@.csv && \
+	${PREFIX} $< -t ${TMP_DIR}/$@.tsv > ${TMP_DIR}/$@-t.out && \
+	${PREFIX} $< ${TMP_DIR}/$@.tsv > ${TMP_DIR}/$@-tsv.out && \
+	${PREFIX} $< ${TMP_DIR}/$@.tab > ${TMP_DIR}/$@-tab.out && \
+	${PREFIX} $< ${TMP_DIR}/$@.csv > ${TMP_DIR}/$@-csv.out && \
+	cmp ${TMP_DIR}/$@-tsv.out ${TMP_DIR}/$@-t.out && \
+	cmp ${TMP_DIR}/$@-tab.out ${TMP_DIR}/$@-t.out && \
+	! cmp -s ${TMP_DIR}/$@-csv.out ${TMP_DIR}/$@-t.out && \
+	${TEST_PASS} || ${TEST_FAIL}
 
 test-2tsv: test-2tsv-1 test-2tsv-2 test-2tsv-3
 

--- a/app/utils/prop.c
+++ b/app/utils/prop.c
@@ -7,6 +7,7 @@
 #include <zsv/utils/cache.h>
 #include <zsv/utils/file.h>
 #include <zsv/utils/overwrite.h>
+#include <zsv/utils/string.h>
 #include <yajl_helper/yajl_helper.h>
 
 #ifndef ZSVTLS
@@ -241,6 +242,26 @@ static int zsv_properties_parse_process_value(yajl_helper_t yh, struct json_valu
 }
 
 /**
+ * zsv_tab_ext_delim(): return '\t' if `path` ends (case-insensitive) with a
+ * standard tab-delimited extension, else 0. `.tsv` is always recognized; `.tab`
+ * unless compiled out via ZSV_NO_TAB_AUTO_RECOGNIZE (configure
+ * --disable-tab-auto-recognize).
+ */
+static char zsv_tab_ext_delim(const char *path) {
+  size_t n = path ? strlen(path) : 0;
+  if (n >= 4) {
+    const unsigned char *ext = (const unsigned char *)path + (n - 4);
+    if (!zsv_stricmp(ext, (const unsigned char *)".tsv"))
+      return '\t';
+#ifndef ZSV_NO_TAB_AUTO_RECOGNIZE
+    if (!zsv_stricmp(ext, (const unsigned char *)".tab"))
+      return '\t';
+#endif
+  }
+  return 0;
+}
+
+/**
  * zsv_new_with_properties(): use in lieu of zsv_new() to also merge zsv options
  * with any saved properties (such as rows_to_ignore or header_span) for the
  * specified input file. In the event that saved properties conflict with a
@@ -261,6 +282,10 @@ enum zsv_status zsv_new_with_properties(struct zsv_opts *opts, struct zsv_prop_h
   if (opts->overwrite_auto)
     zsv_overwrite_auto(opts, input_path);
 #endif
+  // Default to a tab delimiter for .tsv/.tab input unless one was set explicitly
+  // (via -t/-O) or by a saved property (either leaves delimiter non-zero here)
+  if (input_path && opts->delimiter == 0)
+    opts->delimiter = zsv_tab_ext_delim(input_path);
   if ((*handle_out = zsv_new(opts)))
     return zsv_status_ok;
   return zsv_status_memory;

--- a/configure
+++ b/configure
@@ -56,6 +56,9 @@ Optional features:
   --disable-only-crlf     disable the --only-crlf parsing option
   --disable-toon          build without any TOON features (no 2toon command,
                           no compare --toon, no 2json --from-toon / 2toon --from-json)
+  --disable-tab-auto-recognize
+                          do not auto-select tab delimiter for .tab input files
+                          (.tsv is always recognized) [enabled]
   --default-parser=fast|compat
                           set the default parsing engine when --parser is
                           not specified on the command line [compat]
@@ -356,6 +359,7 @@ usetermcap=auto
 ZSV_NO_PARALLEL=
 ZSV_PARALLEL_TEMPFILE=
 ZSV_NO_TOON=
+ZSV_NO_TAB_AUTO_RECOGNIZE=
 NCURSES_DYNAMIC=
 for arg ; do
     case "$arg" in
@@ -418,6 +422,9 @@ for arg ; do
 
         --enable-toon|--enable-toon=yes) ZSV_NO_TOON=0;;
         --disable-toon|--enable-toon=no) ZSV_NO_TOON=1;;
+
+        --enable-tab-auto-recognize|--enable-tab-auto-recognize=yes) ZSV_NO_TAB_AUTO_RECOGNIZE=0;;
+        --disable-tab-auto-recognize|--enable-tab-auto-recognize=no) ZSV_NO_TAB_AUTO_RECOGNIZE=1;;
 
         --enable-shared|--enable-shared=yes) BUILD_SHAREDLIB=1;;
         --disable-shared|--enable-shared=no) BUILD_SHAREDLIB=0;;
@@ -1054,6 +1061,8 @@ ZSV_NO_ONLY_CRLF = $ZSV_NO_ONLY_CRLF
 
 ZSV_NO_TOON = $ZSV_NO_TOON
 
+ZSV_NO_TAB_AUTO_RECOGNIZE = $ZSV_NO_TAB_AUTO_RECOGNIZE
+
 $NO_HAVE
 $USE_LIBS
 
@@ -1139,6 +1148,12 @@ if [ "$ZSV_NO_TOON" = "1" ]; then
     printf '%-64s*\n' "*  - TOON features: DISABLED"
 else
     printf '%-64s*\n' "*  - TOON features: enabled"
+fi
+
+if [ "$ZSV_NO_TAB_AUTO_RECOGNIZE" = "1" ]; then
+    printf '%-64s*\n' "*  - .tab auto-recognize: DISABLED (.tsv still recognized)"
+else
+    printf '%-64s*\n' "*  - .tab/.tsv auto-recognize: enabled"
 fi
 
 echo "*****************************************************************"


### PR DESCRIPTION
#620

Commands reading a file whose name ends in .tsv or .tab now default to a tab delimiter (equivalent to -t) unless a delimiter was set explicitly (-t/-O) or by a saved file property. Recognition is centralized in zsv_new_with_properties(), the single seam every delimited-input command routes through, so it applies uniformly without per-command changes.

.tsv is always recognized; .tab recognition can be compiled out via configure --disable-tab-auto-recognize (ZSV_NO_TAB_AUTO_RECOGNIZE), following the existing --disable-only-crlf / --disable-toon pattern.

Adds test-tab-auto-recognize asserting .tsv/.tab == -t while other extensions and explicit delimiters are unaffected.