### PR TITLE
fix(ci/test-asan): skip checking `config.mk` for `help` and `test-asan` targets

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -18,11 +18,11 @@ on:
         description: 'Compiler(s) to run ASan tests with'
         required: false
         type: choice
-        default: both
+        default: '[gcc, clang]'
         options:
-        - gcc
-        - clang
-        - both
+        - '[gcc]'
+        - '[clang]'
+        - '[gcc, clang]'
 
 permissions:
   contents: read
@@ -32,43 +32,18 @@ defaults:
     shell: bash
 
 jobs:
-  select-compilers:
-    runs-on: ubuntu-latest
-
-    outputs:
-      include: ${{ steps.set.outputs.include }}
-
-    steps:
-    - name: Compute compiler matrix
-      id: set
-      env:
-        COMPILER: ${{ inputs.compiler }}
-      run: |
-        case "$COMPILER" in
-          gcc)   include='[{"cc":"gcc"}]' ;;
-          clang) include='[{"cc":"clang"}]' ;;
-          *)     include='[{"cc":"gcc"},{"cc":"clang"}]' ;;
-        esac
-        echo "include=$include" >> "$GITHUB_OUTPUT"
-
   asan:
-    needs: select-compilers
-
-    # linux amd64 only: gcc and clang are preinstalled on this runner (each
-    # ships its own ASan runtime). No cross-compiling and no other platforms.
     runs-on: ubuntu-22.04
     timeout-minutes: 25
 
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.select-compilers.outputs.include) }}
+        cc: ${{ fromJSON(inputs.compiler) }}
 
     name: asan (${{ matrix.cc }})
 
     steps:
-    # tmux is required by the interactive `zsv view` tests exercised by
-    # `make test-asan` (via app/test).
     - name: Install apt dependencies
       uses: awalsh128/cache-apt-pkgs-action@v1
       with:

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -18,11 +18,11 @@ on:
         description: 'Compiler(s) to run ASan tests with'
         required: false
         type: choice
-        default: '[gcc, clang]'
+        default: '["gcc", "clang"]'
         options:
-        - '[gcc]'
-        - '[clang]'
-        - '[gcc, clang]'
+        - '["gcc"]'
+        - '["clang"]'
+        - '["gcc", "clang"]'
 
 permissions:
   contents: read

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,16 @@ THIS_MAKEFILE:=$(lastword $(MAKEFILE_LIST))
 THIS_MAKE=`basename ${MAKE}`
 
 CONFIGFILE ?= config.mk
-include ${CONFIGFILE}
 
-CONFIGFILEPATH=$(shell ls ${CONFIGFILE} >/dev/null 2>/dev/null && realpath ${CONFIGFILE})
-ifeq (${CONFIGFILEPATH},)
-  $(error Config file ${CONFIGFILE} not found)
+ifneq (,$(filter help test-asan,$(MAKECMDGOALS)))
+  CONFIGFILEPATH :=
+else
+  include ${CONFIGFILE}
+
+  CONFIGFILEPATH=$(shell ls ${CONFIGFILE} >/dev/null 2>/dev/null && realpath ${CONFIGFILE})
+  ifeq (${CONFIGFILEPATH},)
+    $(error Config file ${CONFIGFILE} not found)
+  endif
 endif
 
 help:


### PR DESCRIPTION
Related: #605

- Update ASAN CI workflow
- Skipped checking for `config.mk` for `help` and `test-asan` targets

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>