### PR TITLE
pkg(debian): remove non-free license notices (1141785)

### DIFF
--- a/app/mv.c
+++ b/app/mv.c
@@ -1,9 +1,3 @@
-/* Copyright (C) 2022 Guarnerix Inc dba Liquidaty - All Rights Reserved
- * Unauthorized copying of this file, via any medium is strictly prohibited
- * Proprietary and confidential
- * Written by Matt Wong <matt@guarnerix.com>
- */
-
 /*
  * Move a given file and its cache as follows:
  * 1. check that the destination file doesn't exist. if it does, exit with an error

--- a/app/prop.c
+++ b/app/prop.c
@@ -1,9 +1,3 @@
-/* Copyright (C) 2022 Guarnerix Inc dba Liquidaty - All Rights Reserved
- * Unauthorized copying of this file, via any medium is strictly prohibited
- * Proprietary and confidential
- * Written by Matt Wong <matt@guarnerix.com>
- */
-
 /*
   for a given file, edits properties saved in ZSV_CACHE_DIR/<filepath>/props.json
 */

--- a/app/rm.c
+++ b/app/rm.c
@@ -1,9 +1,3 @@
-/* Copyright (C) 2022 Guarnerix Inc dba Liquidaty - All Rights Reserved
- * Unauthorized copying of this file, via any medium is strictly prohibited
- * Proprietary and confidential
- * Written by Matt Wong <matt@guarnerix.com>
- */
-
 /*
  * remove a given file and its cache
  */

--- a/app/test/overwrite/Makefile
+++ b/app/test/overwrite/Makefile
@@ -1,8 +1,3 @@
-## Copyright (C) 2022 Guarnerix Inc dba Liquidaty - All Rights Reserved
-## Unauthorized copying of this file, via any medium is strictly prohibited
-## Proprietary and confidential
-##
-
 THIS_MAKEFILE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 

--- a/app/test/parallel/Makefile
+++ b/app/test/parallel/Makefile
@@ -1,8 +1,3 @@
-## Copyright (C) 2022 Guarnerix Inc dba Liquidaty - All Rights Reserved
-## Unauthorized copying of this file, via any medium is strictly prohibited
-## Proprietary and confidential
-##
-
 THIS_MAKEFILE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 

--- a/app/test/prop/Makefile
+++ b/app/test/prop/Makefile
@@ -1,8 +1,3 @@
-## Copyright (C) 2022 Guarnerix Inc dba Liquidaty - All Rights Reserved
-## Unauthorized copying of this file, via any medium is strictly prohibited
-## Proprietary and confidential
-##
-
 THIS_MAKEFILE_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 


### PR DESCRIPTION
Related: #438

Bug Report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1141785

> app/test/prop/Makefile, app/test/parallel/Makefile,
app/test/overwrite/Makefile, app/mv.c, app/rm.c, app/prop.c
all contain proprietary license notices.

Removed non-free license notices from above files.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>