### PR TITLE
Return the final row when -L reaches its limit

### DIFF
--- a/app/test/Makefile
+++ b/app/test/Makefile
@@ -84,6 +84,9 @@ ifneq ($(ZSV_NO_PARALLEL),1)
   TESTS+=test-parallel
 endif
 TESTS+=test-check
+ifneq ($(ZSV_EXTRAS),)
+  TESTS+=test-limit-rows-pull
+endif
 TESTS+=test-rename-select
 TESTS+=test-quoted-nonstandard
 TESTS+=test-tab-auto-recognize
@@ -274,6 +277,16 @@ test-vuln-cve-underflow: ${TMP_DIR}/test_vuln_cve_underflow
 ${TMP_DIR}/test_vuln_cve_underflow: test_vuln_cve_underflow.c ${BUILD_DIR}/lib/libzsv.a
 	@mkdir -p ${TMP_DIR}
 	@${CC} ${CFLAGS} -I../../include test_vuln_cve_underflow.c -L${BUILD_DIR}/lib -lzsv -o $@
+
+ifneq ($(ZSV_EXTRAS),)
+  test-limit-rows-pull: ${TMP_DIR}/test_limit_rows_pull
+	@${TEST_INIT}
+	@$< && ${TEST_PASS} || ${TEST_FAIL}
+
+  ${TMP_DIR}/test_limit_rows_pull: test_limit_rows_pull.c ${BUILD_DIR}/lib/libzsv.a
+	@mkdir -p ${TMP_DIR}
+	@${CC} ${CFLAGS} -I../../include test_limit_rows_pull.c -L${BUILD_DIR}/lib -lzsv -o $@
+endif
 
 # -----------------------------------------------------------------------------
 # Sanitizer-driven reproduction of the integer-underflow investigation.

--- a/app/test/test_limit_rows_pull.c
+++ b/app/test/test_limit_rows_pull.c
@@ -1,0 +1,58 @@
+/*
+ * Regression test for `zsv_next_row()` with `max_rows`.
+ *
+ * The bug dropped the final permitted row in pull mode, so the parser could
+ * return `zsv_status_max_rows_read` before handing back the row it had just
+ * parsed. This test checks the exact row count returned by the pull API.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zsv.h>
+
+static int run_case(const char *label, size_t max_rows, size_t want_rows) {
+  FILE *f = tmpfile();
+  if (!f) {
+    perror("tmpfile");
+    return 1;
+  }
+
+  fputs("h1,h2\n1,2\n3,4\n", f);
+  rewind(f);
+
+  struct zsv_opts opts;
+  memset(&opts, 0, sizeof(opts));
+  opts.stream = f;
+  opts.max_rows = max_rows;
+
+  zsv_parser parser = zsv_new(&opts);
+  if (!parser) {
+    fclose(f);
+    fprintf(stderr, "FAIL [%s]: zsv_new failed\n", label);
+    return 1;
+  }
+
+  size_t got_rows = 0;
+  enum zsv_status st;
+  while ((st = zsv_next_row(parser)) == zsv_status_row)
+    got_rows++;
+
+  zsv_delete(parser);
+  fclose(f);
+
+  if (got_rows != want_rows || st != zsv_status_done) {
+    fprintf(stderr, "FAIL [%s]: rows=%zu status=%d, want rows=%zu status=%d\n", label, got_rows, st, want_rows,
+            zsv_status_done);
+    return 1;
+  }
+  return 0;
+}
+
+int main(void) {
+  int failures = 0;
+  failures += run_case("limit-1", 1, 1);
+  failures += run_case("limit-2", 2, 2);
+  return failures ? 1 : 0;
+}

--- a/src/zsv.c
+++ b/src/zsv.c
@@ -227,6 +227,14 @@ enum zsv_status zsv_next_row(zsv_parser parser) {
       return zsv_status_row;
     }
   }
+#ifdef ZSV_EXTRAS
+  if (VERY_UNLIKELY(parser->pull.stat == zsv_status_max_rows_read)) {
+    parser->pull.now = 0;
+    parser->row.used = parser->pull.row_used;
+    parser->pull.stat = zsv_status_done;
+    return zsv_status_row;
+  }
+#endif
   return parser->pull.stat;
 }
 


### PR DESCRIPTION
Fixes #591

`-L/--limit-rows` is documented as inclusive of header rows. In pull parsing, the row that reaches `max_rows` was reported as terminal before `zsv_next_row()` exposed it, so `-L 1` appeared empty and larger limits returned one fewer row.

This change restores the saved row count before transitioning the pull parser to `zsv_status_done`. It keeps the inclusive limit semantics and covers the normal and fast scanner paths.

Tests:
- `make -C app/test test-limit-rows-pull`
- Built and ran `zsv_sheet -L 1` and `-L 2` on a three-row CSV