### PR TITLE
fix(ci): alpine:3.23/latest (musl) pin to GCC 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,7 @@ jobs:
   ci-musl:
     needs: [tag, clang-format, cppcheck, shellcheck]
     runs-on: ubuntu-latest
-    container: alpine:3.22
+    container: alpine:latest
     timeout-minutes: 15
 
     outputs:
@@ -607,7 +607,10 @@ jobs:
     steps:
     - name: Set up dependencies
       shell: sh
-      run: apk add bash gcc make musl-dev ncurses-dev ncurses-static tmux file sqlite curl zip wget tar git
+      run: |
+        apk update
+        apk add bash make musl-dev ncurses-dev ncurses-static tmux file sqlite curl zip wget tar git
+        apk add gcc=14.2.0-r6 --repository=https://dl-cdn.alpinelinux.org/alpine/v3.22/main
 
     - name: Checkout
       uses: actions/checkout@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,19 @@ LABEL maintainer="Liquidaty"
 LABEL url="https://github.com/liquidaty/zsv"
 LABEL org.opencontainers.image.description="zsv: tabular data swiss-army knife CLI + world's fastest (simd) CSV parser"
 
-RUN apk add bash gcc make musl-dev ncurses-dev ncurses-static tmux file sqlite curl zip
+RUN apk update && apk add bash make musl-dev ncurses-dev ncurses-static tmux file sqlite curl zip git
+
+# GCC 15 onwards causes failure due to the default strict aliasing rules in the compiler.
+# GCC 14 is the last version that works with zsv, so we need to install it from the v3.22 repository. 
+RUN apk add gcc=14.2.0-r6 --repository=https://dl-cdn.alpinelinux.org/alpine/v3.22/main
 
 WORKDIR /zsv
 COPY . .
+
+# For some reason, the diff file is not being applied correctly in the docker build context.
+# git apply on local docker build fails to resolve the full path for parallel tests.
+# So, we need to remove the prefix to make paths relative in the diff file before applying it.
+RUN sed "s|app/test/parallel/||" -i app/test/parallel/chunk_break.diff
 
 RUN mkdir /usr/local/etc
 


### PR DESCRIPTION
Fixes #525.

- Pinned GCC 14 with alpine:latest
- Updated Dockerfile for local dev accordingly

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>